### PR TITLE
fix: handle empty string input for embedding models and some hard coding

### DIFF
--- a/spring-ai-alibaba-data-agent-chat/src/test/java/com/alibaba/cloud/ai/service/code/AgentVectorStoreServiceImplTest.java
+++ b/spring-ai-alibaba-data-agent-chat/src/test/java/com/alibaba/cloud/ai/service/code/AgentVectorStoreServiceImplTest.java
@@ -150,16 +150,19 @@ public class AgentVectorStoreServiceImplTest {
 				new Document("Test content 1", Map.of(Constant.AGENT_ID, TEST_AGENT_ID)),
 				new Document("Test content 2", Map.of(Constant.AGENT_ID, TEST_AGENT_ID)));
 		// Mock the vectorStore.similaritySearch to return documents on first call and
-		// empty list on subsequent calls
-		when(vectorStore.similaritySearch(any(SearchRequest.class))).thenReturn(mockDocuments)
-			.thenReturn(Collections.emptyList());
+		// empty list on subsequent calls using doReturn style for better mocking
+		doReturn(mockDocuments).doReturn(Collections.emptyList())
+			.when(vectorStore)
+			.similaritySearch(any(SearchRequest.class));
 
 		// Act
 		int result = agentVectorStoreService.estimateDocuments(TEST_AGENT_ID);
 
 		// Assert
 		assertEquals(2, result);
-		verify(vectorStore, times(1)).similaritySearch(any(SearchRequest.class));
+		// Since the estimated Documents method is called multiple times until there are
+		// no new documents, we should verify that it has been called at least once
+		verify(vectorStore, atLeastOnce()).similaritySearch(any(SearchRequest.class));
 	}
 
 	@Test


### PR DESCRIPTION
### Describe what this PR does / why we need it
修复第三方模型如硅基模型不能向量化空字符串导致查询失败问题
把AgentVectorStoreServiceImpl的一些硬编码数值如查询的topK做成可配置项，防止后期因为不同向量库的差异导致查询失败。

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
