### PR TITLE
fix: bugs in QueryRewriteNode

### DIFF
--- a/spring-ai-alibaba-data-agent-chat/src/main/java/com/alibaba/cloud/ai/node/QueryRewriteNode.java
+++ b/spring-ai-alibaba-data-agent-chat/src/main/java/com/alibaba/cloud/ai/node/QueryRewriteNode.java
@@ -59,11 +59,13 @@ public class QueryRewriteNode implements NodeAction {
 		String agentId = StateUtil.getStringValue(state, AGENT_ID); // Get agent ID
 		log.info("[{}] Processing user input: {} for agentId: {}", this.getClass().getSimpleName(), input, agentId);
 
+		final StringBuilder queryResultCollector = new StringBuilder();
 		// Use streaming utility class for content collection and result mapping
 		Flux<GraphResponse<StreamingOutput>> generator = FluxUtil.createStreamingGeneratorWithMessages(this.getClass(),
-				state, "开始进行问题重写...", "\n\n问题重写完成！",
-				finalResult -> Map.of(QUERY_REWRITE_NODE_OUTPUT, finalResult, RESULT, finalResult),
-				queryProcessingService.rewriteStream(input, agentId));
+				state, "开始进行问题重写...", "\n\n问题重写完成！", finalResult -> {
+					finalResult = queryResultCollector.toString();
+					return Map.of(QUERY_REWRITE_NODE_OUTPUT, finalResult, RESULT, finalResult);
+				}, queryProcessingService.rewriteStream(input, agentId, queryResultCollector));
 
 		return Map.of(QUERY_REWRITE_NODE_OUTPUT, generator);
 	}

--- a/spring-ai-alibaba-data-agent-chat/src/main/java/com/alibaba/cloud/ai/service/processing/QueryProcessingService.java
+++ b/spring-ai-alibaba-data-agent-chat/src/main/java/com/alibaba/cloud/ai/service/processing/QueryProcessingService.java
@@ -39,6 +39,6 @@ public interface QueryProcessingService {
 	 */
 	Flux<ChatResponse> expandQuestion(String query, Consumer<List<String>> resultConsumer);
 
-	Flux<ChatResponse> rewriteStream(String query, String agentId) throws Exception;
+	Flux<ChatResponse> rewriteStream(String query, String agentId, StringBuilder queryResultCollector) throws Exception;
 
 }


### PR DESCRIPTION
`QUERY_REWRITE_NODE_OUTPUT`存储的是整个节点的流式运行结果，实际上只需要存储最后一次LLM请求的重写结果就可以了
