### PR TITLE
fix: update DatasourceController.java 数据源测试失败时，前端依旧返回success的bug

### DIFF
--- a/spring-ai-alibaba-data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/controller/DatasourceController.java
+++ b/spring-ai-alibaba-data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/controller/DatasourceController.java
@@ -132,7 +132,8 @@ public class DatasourceController {
 	public ResponseEntity<ApiResponse> testConnection(@PathVariable(value = "id") Integer id) {
 		try {
 			boolean success = datasourceService.testConnection(id);
-			return ResponseEntity.ok(ApiResponse.success(success ? "连接测试成功" : "连接测试失败"));
+			ApiResponse response = success ? ApiResponse.success("连接测试成功") : ApiResponse.error("连接测试失败");
+			return ResponseEntity.ok(response);
 		}
 		catch (Exception e) {
 			return ResponseEntity.badRequest().body(ApiResponse.error("测试失败：" + e.getMessage()));


### PR DESCRIPTION
### Describe what this PR does / why we need it
数据源[测试连接]失败时，前端依旧返回success的bug

### Does this pull request fix one issue?

无

### Describe how you did it
添加 三元运算，判断返回结果

ApiResponse response = success ? ApiResponse.success("连接测试成功") : ApiResponse.error("连接测试失败");

### Describe how to verify it


### Special notes for reviews
