### PR TITLE
优化执行步骤获取逻辑和SQL生成流程, 解决重新生成死循环问题

### DIFF
--- a/spring-ai-alibaba-data-agent-chat/src/main/java/com/alibaba/cloud/ai/dataagent/node/SqlGenerateNode.java
+++ b/spring-ai-alibaba-data-agent-chat/src/main/java/com/alibaba/cloud/ai/dataagent/node/SqlGenerateNode.java
@@ -76,7 +76,7 @@ public class SqlGenerateNode implements NodeAction {
 
 		// Get necessary input parameters
 		Plan plan = PlanProcessUtil.getPlan(state);
-		ExecutionStep executionStep = PlanProcessUtil.getCurrentExecutionStep(state);
+		ExecutionStep executionStep = PlanProcessUtil.getCurrentExecutionStep(plan, PlanProcessUtil.getCurrentStepNumber(state));
 		ExecutionStep.ToolParameters toolParameters = executionStep.getToolParameters();
 
 		// Execute business logic first - determine what needs to be regenerated
@@ -223,7 +223,7 @@ public class SqlGenerateNode implements NodeAction {
 						if (checkSqlFunc.apply(newSql) || roundRef.getAndIncrement() > MAX_OPTIMIZATION_ROUNDS) {
 							String bestSql = bestSqlRef.get();
 							bestSqlConsumer.accept(bestSql);
-							return Flux.just(bestSql);
+							return Flux.empty();
 						}
 						else {
 							return this.get();
@@ -243,7 +243,7 @@ public class SqlGenerateNode implements NodeAction {
 				if (checkSqlFunc.apply(newSql) || roundRef.getAndIncrement() > MAX_OPTIMIZATION_ROUNDS) {
 					String bestSql = bestSqlRef.get();
 					bestSqlConsumer.accept(bestSql);
-					return Flux.just(bestSql);
+					return Flux.empty();
 				}
 				else {
 					return reGenerateSupplier.get();

--- a/spring-ai-alibaba-data-agent-chat/src/main/java/com/alibaba/cloud/ai/dataagent/util/PlanProcessUtil.java
+++ b/spring-ai-alibaba-data-agent-chat/src/main/java/com/alibaba/cloud/ai/dataagent/util/PlanProcessUtil.java
@@ -60,7 +60,18 @@ public final class PlanProcessUtil {
 	public static ExecutionStep getCurrentExecutionStep(OverAllState state) {
 		Plan plan = getPlan(state);
 		int currentStep = getCurrentStepNumber(state);
+		return getCurrentExecutionStep(plan, currentStep);
+	}
 
+	/**
+	 * Get the current execution step from the plan
+	 * @param plan the plan object
+	 * @param currentStep current step
+	 * @return the current execution step
+	 * @throws IllegalStateException if plan output is empty, plan parsing fails, or step
+	 * index is out of range
+	 */
+	public static ExecutionStep getCurrentExecutionStep(Plan plan, Integer currentStep) {
 		List<ExecutionStep> executionPlan = plan.getExecutionPlan();
 		if (executionPlan == null || executionPlan.isEmpty()) {
 			throw new IllegalStateException("执行计划为空");


### PR DESCRIPTION

### Describe what this PR does / why we need it
<img width="1065" height="490" alt="1eecd6f2-0cc9-4cb6-891b-d59fd310de93" src="https://github.com/user-attachments/assets/02a6735f-fba7-4d06-b452-9ce14ea06889" />
解决重新生成sql 死循环，及生成sql 不生效问题

### Does this pull request fix one issue?
修复bug #130 

### Describe how you did it

- 重构 `PlanProcessUtil.java` 中的 getCurrentExecutionStep 方法，新增重载版本以支持传入 plan 参数， 解决重新生成的sql 未生效。
- 优化 SQL 生成完成后的返回逻辑，将返回最佳 SQL 改为返回空 Flux 避免死循环

### Describe how to verify it


### Special notes for reviews
