### PR TITLE
支持达梦数据库连接与操作

### DIFF
--- a/spring-ai-alibaba-data-agent-common/pom.xml
+++ b/spring-ai-alibaba-data-agent-common/pom.xml
@@ -67,6 +67,11 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.dameng</groupId>
+            <artifactId>DmJdbcDriver18</artifactId>
+            <version>8.1.3.140</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/spring-ai-alibaba-data-agent-common/src/main/java/com/alibaba/cloud/ai/dataagent/common/connector/impls/dameng/DamengDBAccessor.java
+++ b/spring-ai-alibaba-data-agent-common/src/main/java/com/alibaba/cloud/ai/dataagent/common/connector/impls/dameng/DamengDBAccessor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.common.connector.impls.dameng;
+
+import com.alibaba.cloud.ai.dataagent.common.connector.ddl.DdlFactory;
+import com.alibaba.cloud.ai.dataagent.common.connector.accessor.AbstractAccessor;
+import com.alibaba.cloud.ai.dataagent.common.connector.pool.DBConnectionPoolFactory;
+import com.alibaba.cloud.ai.dataagent.common.enums.BizDataSourceTypeEnum;
+import org.springframework.stereotype.Service;
+
+@Service("damengAccessor")
+public class DamengDBAccessor extends AbstractAccessor {
+
+    private static final String ACCESSOR_TYPE = "Dameng_Accessor";
+
+    protected DamengDBAccessor(DdlFactory ddlFactory, DBConnectionPoolFactory poolFactory) {
+        super(ddlFactory, poolFactory.getPoolByDbType(BizDataSourceTypeEnum.DAMENG.getTypeName()));
+    }
+
+    @Override
+    public String getAccessorType() {
+        return ACCESSOR_TYPE;
+    }
+
+    @Override
+    public boolean supportedDataSourceType(String type) {
+        return BizDataSourceTypeEnum.DAMENG.getTypeName().equalsIgnoreCase(type);
+    }
+}

--- a/spring-ai-alibaba-data-agent-common/src/main/java/com/alibaba/cloud/ai/dataagent/common/connector/impls/dameng/DamengJdbcConnectionPool.java
+++ b/spring-ai-alibaba-data-agent-common/src/main/java/com/alibaba/cloud/ai/dataagent/common/connector/impls/dameng/DamengJdbcConnectionPool.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.common.connector.impls.dameng;
+
+import com.alibaba.cloud.ai.dataagent.common.connector.pool.AbstractDBConnectionPool;
+import com.alibaba.cloud.ai.dataagent.common.enums.BizDataSourceTypeEnum;
+import com.alibaba.cloud.ai.dataagent.common.enums.ErrorCodeEnum;
+import org.springframework.stereotype.Service;
+
+import static com.alibaba.cloud.ai.dataagent.common.enums.ErrorCodeEnum.OTHERS;
+
+@Service("damengJdbcConnectionPool")
+public class DamengJdbcConnectionPool extends AbstractDBConnectionPool {
+
+    private static final String DRIVER = "dm.jdbc.driver.DmDriver";
+
+    @Override
+    public String getDriver() {
+        return DRIVER;
+    }
+
+    @Override
+    public ErrorCodeEnum errorMapping(String sqlState) {
+        ErrorCodeEnum ret = ErrorCodeEnum.fromCode(sqlState);
+        if (ret != null && ret != OTHERS) {
+            return ret;
+        }
+        return OTHERS;
+    }
+
+    @Override
+    public boolean supportedDataSourceType(String type) {
+        return BizDataSourceTypeEnum.DAMENG.getTypeName().equals(type);
+    }
+
+    @Override
+    public String getConnectionPoolType() {
+        return BizDataSourceTypeEnum.DAMENG.getTypeName();
+    }
+}

--- a/spring-ai-alibaba-data-agent-common/src/main/java/com/alibaba/cloud/ai/dataagent/common/connector/impls/dameng/DamengJdbcDdl.java
+++ b/spring-ai-alibaba-data-agent-common/src/main/java/com/alibaba/cloud/ai/dataagent/common/connector/impls/dameng/DamengJdbcDdl.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.common.connector.impls.dameng;
+
+import com.alibaba.cloud.ai.dataagent.common.connector.ddl.AbstractJdbcDdl;
+import com.alibaba.cloud.ai.dataagent.common.enums.BizDataSourceTypeEnum;
+import com.alibaba.cloud.ai.dataagent.common.connector.SqlExecutor;
+import com.alibaba.cloud.ai.dataagent.common.connector.bo.*;
+import org.apache.commons.compress.utils.Lists;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.alibaba.cloud.ai.dataagent.common.util.ColumnTypeUtil.wrapType;
+
+@Service
+public class DamengJdbcDdl extends AbstractJdbcDdl {
+
+    @Override
+    public List<DatabaseInfoBO> showDatabases(Connection connection) {
+        // 达梦通常以实例+用户作为schema，数据库枚举意义不大，这里返回空集
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<SchemaInfoBO> showSchemas(Connection connection) {
+        String sql = "SELECT USERNAME FROM SYS.ALL_USERS";
+        List<SchemaInfoBO> schemaInfoList = Lists.newArrayList();
+        try {
+            String[][] resultArr = SqlExecutor.executeSqlAndReturnArr(connection, sql);
+            if (resultArr.length <= 1) {
+                return Lists.newArrayList();
+            }
+            for (int i = 1; i < resultArr.length; i++) {
+                if (resultArr[i].length == 0) {
+                    continue;
+                }
+                String schema = resultArr[i][0];
+                schemaInfoList.add(SchemaInfoBO.builder().name(schema).build());
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return schemaInfoList;
+    }
+
+    @Override
+    public List<TableInfoBO> showTables(Connection connection, String schema, String tablePattern) {
+        String sql = "SELECT TABLE_NAME FROM USER_TABLES";
+        if (StringUtils.isNotBlank(tablePattern)) {
+            sql = "SELECT TABLE_NAME FROM USER_TABLES WHERE TABLE_NAME LIKE '%' || '" + tablePattern + "' || '%'";
+        }
+        List<TableInfoBO> tableInfoList = Lists.newArrayList();
+        try {
+            String[][] resultArr = SqlExecutor.executeSqlAndReturnArr(connection, sql);
+            if (resultArr.length <= 1) {
+                return Lists.newArrayList();
+            }
+            for (int i = 1; i < resultArr.length; i++) {
+                if (resultArr[i].length == 0) {
+                    continue;
+                }
+                String tableName = resultArr[i][0];
+                tableInfoList.add(TableInfoBO.builder().name(tableName).description("").build());
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return tableInfoList;
+    }
+
+    @Override
+    public List<TableInfoBO> fetchTables(Connection connection, String schema, List<String> tables) {
+        if (tables == null || tables.isEmpty()) {
+            return Lists.newArrayList();
+        }
+        String tableListStr = String.join(", ", tables.stream().map(x -> "'" + x + "'").collect(Collectors.toList()));
+        String sql = "SELECT TABLE_NAME FROM USER_TABLES WHERE TABLE_NAME in(" + tableListStr + ")";
+        List<TableInfoBO> tableInfoList = Lists.newArrayList();
+        try {
+            String[][] resultArr = SqlExecutor.executeSqlAndReturnArr(connection, sql);
+            if (resultArr.length <= 1) {
+                return Lists.newArrayList();
+            }
+            for (int i = 1; i < resultArr.length; i++) {
+                if (resultArr[i].length == 0) {
+                    continue;
+                }
+                String tableName = resultArr[i][0];
+                tableInfoList.add(TableInfoBO.builder().name(tableName).description("").build());
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return tableInfoList;
+    }
+
+    @Override
+    public List<ColumnInfoBO> showColumns(Connection connection, String schema, String table) {
+        String sql = "SELECT COLUMN_NAME, DATA_TYPE, DATA_LENGTH, NULLABLE FROM USER_TAB_COLUMNS WHERE TABLE_NAME='" + table + "'";
+        List<ColumnInfoBO> columnInfoList = Lists.newArrayList();
+        try {
+            String[][] resultArr = SqlExecutor.executeSqlAndReturnArr(connection, null, sql);
+            if (resultArr.length <= 1) {
+                return Lists.newArrayList();
+            }
+            for (int i = 1; i < resultArr.length; i++) {
+                if (resultArr[i].length == 0) {
+                    continue;
+                }
+                columnInfoList.add(ColumnInfoBO.builder()
+                    .name(resultArr[i][0])
+                    .description("")
+                    .type(wrapType(resultArr[i][1]))
+                    .primary(false)
+                    .notnull(BooleanUtils.toBoolean("N".equalsIgnoreCase(resultArr[i][3]) ? "true" : "false"))
+                    .build());
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return columnInfoList;
+    }
+
+    @Override
+    public List<ForeignKeyInfoBO> showForeignKeys(Connection connection, String schema, List<String> tables) {
+        if (tables == null || tables.isEmpty()) {
+            return Lists.newArrayList();
+        }
+        String tableListStr = String.join(", ", tables.stream().map(x -> "'" + x + "'").collect(Collectors.toList()));
+        String sql = "SELECT uc.TABLE_NAME, ucc.COLUMN_NAME, uc.CONSTRAINT_NAME, uc.R_OWNER, uc.R_CONSTRAINT_NAME " +
+                "FROM USER_CONSTRAINTS uc JOIN USER_CONS_COLUMNS ucc ON uc.CONSTRAINT_NAME = ucc.CONSTRAINT_NAME " +
+                "WHERE uc.CONSTRAINT_TYPE='R' AND uc.TABLE_NAME IN (" + tableListStr + ")";
+        List<ForeignKeyInfoBO> foreignKeyInfoList = Lists.newArrayList();
+        try {
+            String[][] resultArr = SqlExecutor.executeSqlAndReturnArr(connection, null, sql);
+            if (resultArr.length <= 1) {
+                return Lists.newArrayList();
+            }
+            for (int i = 1; i < resultArr.length; i++) {
+                if (resultArr[i].length == 0) {
+                    continue;
+                }
+                foreignKeyInfoList.add(ForeignKeyInfoBO.builder()
+                    .table(resultArr[i][0])
+                    .column(resultArr[i][1])
+                    .referencedTable("")
+                    .referencedColumn("")
+                    .build());
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return foreignKeyInfoList;
+    }
+
+    @Override
+    public List<String> sampleColumn(Connection connection, String schema, String table, String column) {
+        String sql = "SELECT " + column + " FROM " + table + " FETCH FIRST 99 ROWS ONLY";
+        List<String> sampleInfo = Lists.newArrayList();
+        try {
+            String[][] resultArr = SqlExecutor.executeSqlAndReturnArr(connection, null, sql);
+            if (resultArr.length <= 1) {
+                return Lists.newArrayList();
+            }
+            for (int i = 1; i < resultArr.length; i++) {
+                if (resultArr[i].length == 0 || column.equalsIgnoreCase(resultArr[i][0])) {
+                    continue;
+                }
+                sampleInfo.add(resultArr[i][0]);
+            }
+        } catch (SQLException e) {
+            // ignore
+        }
+        Set<String> siSet = sampleInfo.stream().collect(Collectors.toSet());
+        sampleInfo = siSet.stream().collect(Collectors.toList());
+        return sampleInfo;
+    }
+
+    @Override
+    public ResultSetBO scanTable(Connection connection, String schema, String table) {
+        String sql = "SELECT * FROM " + table + " FETCH FIRST 20 ROWS ONLY";
+        ResultSetBO resultSet = ResultSetBO.builder().build();
+        try {
+            resultSet = SqlExecutor.executeSqlAndReturnObject(connection, schema, sql);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return resultSet;
+    }
+
+    @Override
+    public BizDataSourceTypeEnum getDataSourceType() {
+        return BizDataSourceTypeEnum.DAMENG;
+    }
+}

--- a/spring-ai-alibaba-data-agent-common/src/main/java/com/alibaba/cloud/ai/dataagent/common/connector/pool/AbstractDBConnectionPool.java
+++ b/spring-ai-alibaba-data-agent-common/src/main/java/com/alibaba/cloud/ai/dataagent/common/connector/pool/AbstractDBConnectionPool.java
@@ -163,15 +163,28 @@ public abstract class AbstractDBConnectionPool implements DBConnectionPool {
 	 * useful for resource cleanup in special scenarios.
 	 */
 
-	public DataSource createdDataSource(String url, String username, String password) throws Exception {
+    public DataSource createdDataSource(String url, String username, String password) throws Exception {
 
-		DruidDataSource dataSource = (DruidDataSource) DruidDataSourceFactory.createDataSource(
-				Map.of(DruidDataSourceFactory.PROP_DRIVERCLASSNAME, getDriver(), DruidDataSourceFactory.PROP_URL, url,
-						DruidDataSourceFactory.PROP_USERNAME, username, DruidDataSourceFactory.PROP_PASSWORD, password,
-						DruidDataSourceFactory.PROP_INITIALSIZE, "5", DruidDataSourceFactory.PROP_MINIDLE, "5",
-						DruidDataSourceFactory.PROP_MAXACTIVE, "20", DruidDataSourceFactory.PROP_MAXWAIT, "10000",
-						DruidDataSourceFactory.PROP_TIMEBETWEENEVICTIONRUNSMILLIS, "60000",
-						DruidDataSourceFactory.PROP_FILTERS, "wall,stat"));
+        String driver = getDriver();
+
+        String filters = "wall,stat";
+        if (driver != null && driver.toLowerCase().contains("dm.jdbc.driver.dmdriver")) {
+            filters = "stat";
+        }
+
+        java.util.Map<String, String> props = new java.util.HashMap<>();
+        props.put(DruidDataSourceFactory.PROP_DRIVERCLASSNAME, driver);
+        props.put(DruidDataSourceFactory.PROP_URL, url);
+        props.put(DruidDataSourceFactory.PROP_USERNAME, username);
+        props.put(DruidDataSourceFactory.PROP_PASSWORD, password);
+        props.put(DruidDataSourceFactory.PROP_INITIALSIZE, "5");
+        props.put(DruidDataSourceFactory.PROP_MINIDLE, "5");
+        props.put(DruidDataSourceFactory.PROP_MAXACTIVE, "20");
+        props.put(DruidDataSourceFactory.PROP_MAXWAIT, "10000");
+        props.put(DruidDataSourceFactory.PROP_TIMEBETWEENEVICTIONRUNSMILLIS, "60000");
+        props.put(DruidDataSourceFactory.PROP_FILTERS, filters);
+
+        DruidDataSource dataSource = (DruidDataSource) DruidDataSourceFactory.createDataSource(props);
 		dataSource.setBreakAfterAcquireFailure(Boolean.TRUE);
 		dataSource.setConnectionErrorRetryAttempts(2);
 

--- a/spring-ai-alibaba-data-agent-common/src/main/java/com/alibaba/cloud/ai/dataagent/common/enums/BizDataSourceTypeEnum.java
+++ b/spring-ai-alibaba-data-agent-common/src/main/java/com/alibaba/cloud/ai/dataagent/common/enums/BizDataSourceTypeEnum.java
@@ -25,6 +25,11 @@ public enum BizDataSourceTypeEnum {
 
 	H2(4, "h2", DatabaseDialectEnum.H2.getCode(), DbAccessTypeEnum.JDBC.getCode()),
 
+	/**
+	 * Dameng database (达梦)
+	 */
+	DAMENG(5, "dameng", DatabaseDialectEnum.DAMENG.getCode(), DbAccessTypeEnum.JDBC.getCode()),
+
 	HOLOGRESS(10, "hologress", DatabaseDialectEnum.POSTGRESQL.getCode(), DbAccessTypeEnum.JDBC.getCode()),
 
 	MYSQL_VPC(11, "mysql-vpc", DatabaseDialectEnum.MYSQL.getCode(), DbAccessTypeEnum.JDBC.getCode()),
@@ -41,6 +46,8 @@ public enum BizDataSourceTypeEnum {
 
 	POSTGRESQL_VIRTUAL(52, "postgresql-virtual", DatabaseDialectEnum.POSTGRESQL.getCode(),
 			DbAccessTypeEnum.MEMORY.getCode());
+
+
 
 	public final Integer code;
 

--- a/spring-ai-alibaba-data-agent-common/src/main/java/com/alibaba/cloud/ai/dataagent/common/enums/DatabaseDialectEnum.java
+++ b/spring-ai-alibaba-data-agent-common/src/main/java/com/alibaba/cloud/ai/dataagent/common/enums/DatabaseDialectEnum.java
@@ -25,7 +25,9 @@ public enum DatabaseDialectEnum {
 
 	POSTGRESQL("PostgreSQL"),
 
-	H2("H2");
+	H2("H2"),
+
+	DAMENG("Dameng");
 
 	public final String code;
 


### PR DESCRIPTION
- 新增达梦数据库枚举类型 DAMENG
- 添加达梦 JDBC 驱动依赖及连接池配置
- 实现达梦数据库访问器 DamengDBAccessor
- 创建达梦 JDBC 连接池 DamengJdbcConnectionPool
- 开发达梦 DDL 操作类 DamengJdbcDdl，支持表、列、外键等元数据查询
- 优化数据源创建逻辑，针对达梦数据库禁用 wall 过滤器
- 实现达梦特有 SQL 查询语法支持（如 FETCH FIRST）