### PR TITLE
fix: 表或字段注释为空字符串时，不会使用表名作为默认值， 导致text嵌入时报错。

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/common/util/DocumentConverterUtil.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/common/util/DocumentConverterUtil.java
@@ -22,6 +22,7 @@ import com.alibaba.cloud.ai.dataagent.common.constant.DocumentMetadataConstant;
 import com.alibaba.cloud.ai.dataagent.entity.AgentKnowledge;
 import com.alibaba.cloud.ai.dataagent.entity.BusinessKnowledge;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.ai.document.Document;
 
 import java.util.*;
@@ -56,7 +57,8 @@ public class DocumentConverterUtil {
 	 */
 	public static Document convertColumnToDocumentForAgent(String agentId, TableInfoBO tableInfoBO,
 			ColumnInfoBO columnInfoBO) {
-		String text = Optional.ofNullable(columnInfoBO.getDescription()).orElse(columnInfoBO.getName());
+		String text = StringUtils.isBlank(columnInfoBO.getDescription()) ? columnInfoBO.getName()
+				: columnInfoBO.getDescription();
 		Map<String, Object> metadata = new HashMap<>();
 		metadata.put("name", columnInfoBO.getName());
 		metadata.put("tableName", tableInfoBO.getName());
@@ -80,7 +82,8 @@ public class DocumentConverterUtil {
 	 * @return Document object with table metadata
 	 */
 	public static Document convertTableToDocumentForAgent(String agentId, TableInfoBO tableInfoBO) {
-		String text = Optional.ofNullable(tableInfoBO.getDescription()).orElse(tableInfoBO.getName());
+		String text = StringUtils.isBlank(tableInfoBO.getDescription()) ? tableInfoBO.getName()
+				: tableInfoBO.getDescription();
 		Map<String, Object> metadata = new HashMap<>();
 		metadata.put("schema", Optional.ofNullable(tableInfoBO.getSchema()).orElse(""));
 		metadata.put("name", tableInfoBO.getName());


### PR DESCRIPTION
### Describe what this PR does / why we need it
  表或字段注释为空字符串时，不会使用表名作为默认值， 导致text嵌入时报错, 导致初始化失败

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
 text 改为判空。

### Describe how to verify it


### Special notes for reviews
