### PR TITLE
fix: chunk空导致系统崩溃

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphServiceImpl.java
@@ -261,6 +261,11 @@ public class GraphServiceImpl implements GraphService {
 		String node = output.node();
 		String chunk = output.chunk();
 		log.debug("Received Stream output: {}", chunk);
+
+		if (chunk == null || chunk.isEmpty()) {
+			return;
+		}
+
 		// 如果是文本标记符号，则更新文本类型
 		TextType originType = context.getTextType();
 		TextType textType;


### PR DESCRIPTION
### Describe what this PR does / why we need it
修复了在流式输出场景下，个别模型返回的 chunk 为空时，
系统在后续文本类型判断过程中发生异常的问题。
该问题会导致请求中断，影响正常使用。

### Does this pull request fix one issue?
#223 

### Describe how you did it
在处理模型流式输出时，增加了对 chunk 为空的判空处理，
在无有效文本内容的情况下跳过后续文本类型解析逻辑，
避免因空值导致的异常。

### Describe how to verify it
1. 调用存在流式输出的模型接口
2. 模拟模型返回 chunk 为空的场景
3. 确认系统不再抛出异常，请求能够正常完成
4. 对正常返回 chunk 的场景进行回归验证，确保原有逻辑不受影响

### Special notes for reviews
