### PR TITLE
fix: 变量SqlServer错误导致无法加载到表

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/impl/DatasourceServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/impl/DatasourceServiceImpl.java
@@ -267,7 +267,7 @@ public class DatasourceServiceImpl implements DatasourceService {
 		}
 		else if ("sqlserver".equalsIgnoreCase(datasource.getType())) {
 			dbConfig.setConnectionType("jdbc");
-			dbConfig.setDialectType("SqlServer");
+			dbConfig.setDialectType("sqlserver");
 		}
 		else {
 			throw new RuntimeException("不支持的数据库类型: " + datasource.getType());


### PR DESCRIPTION
### Describe what this PR does / why we need it
修复了 SQL Server 查询中变量使用错误，导致无法加载表信息的问题。修改后表数据可以正常获取，保证报表和数据分析功能正常工作。  

### Does this pull request fix one issue?
#230 

### Describe how you did it
调整了 `SqlServer` 为`sqlserver`

### Describe how to verify it
1. 连接 SQL Server 并运行相关查询  
2. 验证能正确列出指定 schema 下的表  
3. 验证表注释和字段信息正确加载  
4. 确认报表或数据分析模块可以正常使用表数据  

### Special notes for reviews
本次修改仅涉及 SQL 查询逻辑，影响 SQL Server 数据源，不影响其他数据库或业务逻辑。  
