### PR TITLE
fix: 知识库上传知识库文件报错

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <druid.version>1.2.22</druid.version>
         <postgresql.version>42.4.1</postgresql.version>
         <commons-collections.version>3.2.1</commons-collections.version>
+        <commons-io.version>2.18.0</commons-io.version>
         <commonmark.version>0.17.0</commonmark.version>
         <httpclient5.version>5.4.1</httpclient5.version>
         <commons-compress.version>1.27.1</commons-compress.version>
@@ -131,6 +132,11 @@
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
                 <version>${commons-collections.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${commons-io.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.atlassian.commonmark</groupId>
@@ -229,7 +235,7 @@
     <dependencies>
         <!-- 在这里可以替换vector-store -->
         <!-- 如果不使用默认依赖的话，需要手动配置application.yml -->
-        <!--        统一openai接入以支持多厂商-->
+        <!-- 统一openai接入以支持多厂商-->
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-openai</artifactId>


### PR DESCRIPTION
### Describe what this PR does / why we need it

修复知识库上传知识库文件时报错的问题。  
经排查发现问题来源于 commons-io 版本过低，在处理文件流时存在兼容性缺陷，因此需要进行版本升级以保证上传流程稳定运行。

### Does this pull request fix one issue?
#253 

### Describe how you did it

将项目中 commons-io.version 升级至 2.18.0 以上版本。  
升级后重新验证文件上传相关逻辑，确认不再触发原有异常，且未影响现有功能。

### Describe how to verify it

1. 启动服务  
2. 进入知识库管理页面  
3. 上传知识库文件  
4. 确认文件上传成功，服务端无异常日志

### Special notes for reviews

本次修改仅涉及依赖版本升级，未改动业务代码逻辑。  
如果你在担心“升级依赖会不会引发蝴蝶效应”，那只蝴蝶这次应该是加班失败了。
