### PR TITLE
refactor: update default similarityThreshold

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/config/DataAgentProperties.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/config/DataAgentProperties.java
@@ -139,7 +139,7 @@ public class DataAgentProperties {
 		/**
 		 * 相似度阈值配置，用于过滤相似度分数大于等于此阈值的文档
 		 */
-		private double similarityThreshold = 0.2;
+		private double similarityThreshold = 0.4;
 
 		/**
 		 * 一次删除操作中，最多删除的文档数量

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/dto/search/AgentSearchRequest.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/dto/search/AgentSearchRequest.java
@@ -31,7 +31,7 @@ public class AgentSearchRequest implements java.io.Serializable {
 	private String docVectorType;
 
 	@Builder.Default
-	private Double similarityThreshold = 0.2;
+	private Double similarityThreshold = 0.4;
 
 	private String query;
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
以前进行那个数据表的列的召回的时候效果很差（列的描述信息非常少），所以就把向量召回的阈值调的很低为0.2， 现在不需要进行列的独立召回了，只需要召回表，而表的描述信息是足够的，所以这个阈值可以提高一点。

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
