### PR TITLE
feat: 前端页面可以直接展示markdown中的内容

### DIFF
--- a/data-agent-frontend/src/components/run/Markdown.vue
+++ b/data-agent-frontend/src/components/run/Markdown.vue
@@ -50,11 +50,11 @@
       // 创建自定义渲染器
       const createRenderer = () => {
         const renderer = new marked.Renderer();
-        
+
         // 重写代码块渲染
         renderer.code = (code: string, language: string | undefined) => {
           const lang = language || 'text';
-          
+
           // 尝试高亮代码
           let highlightedCode = code;
           if (lang && lang !== 'text') {
@@ -116,30 +116,30 @@
           if (!slotNodes || slotNodes.length === 0) {
             return '';
           }
-          
+
           // 提取所有文本节点
           const extractText = (node: any): string => {
             if (node === null || node === undefined) {
               return '';
             }
-            
+
             // 如果是字符串，直接返回
             if (typeof node === 'string') {
               return node;
             }
-            
+
             // 如果是数字，转换为字符串
             if (typeof node === 'number') {
               return String(node);
             }
-            
+
             // 如果是对象
             if (node && typeof node === 'object') {
               // Vue 3 的文本节点
               if (node.type === 3 || node.type === 'Text') {
                 return node.children || node.text || '';
               }
-              
+
               // 如果有 children 属性
               if (node.children) {
                 if (typeof node.children === 'string') {
@@ -149,21 +149,21 @@
                   return node.children.map(extractText).join('');
                 }
               }
-              
+
               // 如果有 text 属性
               if (node.text) {
                 return node.text;
               }
-              
+
               // 如果是数组（某些情况下）
               if (Array.isArray(node)) {
                 return node.map(extractText).join('');
               }
             }
-            
+
             return '';
           };
-          
+
           return slotNodes.map(extractText).join('');
         } catch (error) {
           console.error('Error extracting slot text:', error);
@@ -181,7 +181,7 @@
         } else {
           content = props.content || '';
         }
-        
+
         if (!content.trim()) {
           return '';
         }
@@ -248,13 +248,13 @@
           // 同时监听 prop 和插槽内容
           return getSlotText() || props.content;
         },
-        (newContent) => {
+        newContent => {
           // 内容变化时，computed 属性会自动重新计算
           // 这里可以添加调试日志
           if (process.env.NODE_ENV === 'development') {
             console.log('Markdown content updated, length:', newContent?.length || 0);
           }
-        }
+        },
       );
 
       // 组件挂载时设置复制函数
@@ -530,4 +530,3 @@
     text-decoration: line-through;
   }
 </style>
-

--- a/data-agent-frontend/src/views/AgentRun.vue
+++ b/data-agent-frontend/src/views/AgentRun.vue
@@ -71,8 +71,8 @@
                 </el-button>
               </div>
               <div
-                  v-else-if="message.messageType === 'markdown-report'"
-                  class="markdown-report-message"
+                v-else-if="message.messageType === 'markdown-report'"
+                class="markdown-report-message"
               >
                 <div class="markdown-report-header">
                   <div class="report-info">
@@ -80,9 +80,9 @@
                     <span>Markdown 报告已生成</span>
                   </div>
                   <el-button
-                      type="primary"
-                      size="large"
-                      @click="downloadMarkdownReportFromMessage(`${message.content}`)"
+                    type="primary"
+                    size="large"
+                    @click="downloadMarkdownReportFromMessage(`${message.content}`)"
                   >
                     <el-icon><Download /></el-icon>
                     下载Markdown报告
@@ -117,12 +117,12 @@
                 <template v-for="(nodeBlock, index) in nodeBlocks" :key="index">
                   <!-- 如果是 Markdown 报告节点，使用 Markdown 组件 -->
                   <div
-                      v-if="
+                    v-if="
                       nodeBlock.length > 0 &&
                       nodeBlock[0].nodeName === 'ReportGeneratorNode' &&
                       nodeBlock[0].textType === 'MARK_DOWN'
                     "
-                      class="agent-response-block"
+                    class="agent-response-block"
                   >
                     <div class="agent-response-title">
                       {{ nodeBlock[0].nodeName }}
@@ -134,10 +134,7 @@
                     </div>
                   </div>
                   <!-- 其他节点使用原来的 HTML 渲染方式 -->
-                  <div
-                      v-else
-                      v-html="generateNodeHtml(nodeBlock)"
-                  ></div>
+                  <div v-else v-html="generateNodeHtml(nodeBlock)"></div>
                 </template>
               </div>
             </div>
@@ -1144,8 +1141,7 @@
         // 如果是 ReportGeneratorNode 且类型为 MARK_DOWN，从 sessionState 获取完整内容
         // 这样可以实时显示流式接收到的 markdown 内容
         const firstNode = node[0];
-        if (firstNode.nodeName === 'ReportGeneratorNode' &&
-            firstNode.textType === 'MARK_DOWN') {
+        if (firstNode.nodeName === 'ReportGeneratorNode' && firstNode.textType === 'MARK_DOWN') {
           const sessionId = currentSession.value?.id;
           if (sessionId) {
             const sessionState = getSessionState(sessionId);


### PR DESCRIPTION
(cherry picked from commit 40ac71b968fb9185f9e36c37780b2213de520637)


### Describe what this PR does / why we need it
目前前端只能通过下载才能查看报告中的内容，针对markdown类型的报告，可以直接前端展示

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
新增Markdown.vue的components，作为markdown内容的展示组件
在AgentRun.vue中引用该组件，无论输出和历史消息展示中都是用该组件展示
效果如下：
<img width="5066" height="2720" alt="iwEcAqNwbmcDAQTRE8oF0QqgBrDHkNdof9J8cQkujM77dDoAB9Igfnb3CAAJomltCgAL0gAKbRQ" src="https://github.com/user-attachments/assets/d4ce9150-7b28-4bc3-af8e-a45d9492527a" />
<img width="3064" height="1870" alt="FEA78FB2-2FB7-4FEB-BA5F-A0290C8C9E2E" src="https://github.com/user-attachments/assets/5616db32-e2c9-459a-80a5-29c9c7c7d5d4" />


### Describe how to verify it


### Special notes for reviews
