### PR TITLE
fix: 修复生成echart图空指针异常，增加配置

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/properties/DataAgentProperties.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/properties/DataAgentProperties.java
@@ -71,6 +71,16 @@ public class DataAgentProperties {
 	// 每张表的最大预估列数
 	private int maxColumnsPerTable = 50;
 
+	/**
+	 * 是否启用SQL执行结果图表判断，默认启用
+	 */
+	private boolean enableSqlResultChart = true;
+
+	/**
+	 * 执行SQL结果图表化超时时间，默认3000ms
+	 */
+	private Long enrichSqlResultTimeout = 3000L;
+
 	@Getter
 	@Setter
 	public static class ReportTemplate {

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/SqlExecuteNode.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/SqlExecuteNode.java
@@ -16,38 +16,47 @@
 
 package com.alibaba.cloud.ai.dataagent.workflow.node;
 
+import static com.alibaba.cloud.ai.dataagent.constant.Constant.PLAN_CURRENT_STEP;
+import static com.alibaba.cloud.ai.dataagent.constant.Constant.SQL_EXECUTE_NODE_OUTPUT;
+import static com.alibaba.cloud.ai.dataagent.constant.Constant.SQL_GENERATE_COUNT;
+import static com.alibaba.cloud.ai.dataagent.constant.Constant.SQL_GENERATE_OUTPUT;
+import static com.alibaba.cloud.ai.dataagent.constant.Constant.SQL_REGENERATE_REASON;
+import static com.alibaba.cloud.ai.dataagent.constant.Constant.SQL_RESULT_LIST_MEMORY;
+
+import com.alibaba.cloud.ai.dataagent.bo.DbConfigBO;
 import com.alibaba.cloud.ai.dataagent.bo.schema.DisplayStyleBO;
 import com.alibaba.cloud.ai.dataagent.bo.schema.ResultBO;
-import com.alibaba.cloud.ai.dataagent.connector.accessor.Accessor;
-import com.alibaba.cloud.ai.dataagent.connector.DbQueryParameter;
 import com.alibaba.cloud.ai.dataagent.bo.schema.ResultSetBO;
-import com.alibaba.cloud.ai.dataagent.bo.DbConfigBO;
+import com.alibaba.cloud.ai.dataagent.connector.DbQueryParameter;
+import com.alibaba.cloud.ai.dataagent.connector.accessor.Accessor;
 import com.alibaba.cloud.ai.dataagent.constant.Constant;
-import com.alibaba.cloud.ai.dataagent.enums.TextType;
 import com.alibaba.cloud.ai.dataagent.dto.datasource.SqlRetryDto;
-
+import com.alibaba.cloud.ai.dataagent.dto.planner.ExecutionStep;
+import com.alibaba.cloud.ai.dataagent.enums.TextType;
 import com.alibaba.cloud.ai.dataagent.prompt.PromptLoader;
+import com.alibaba.cloud.ai.dataagent.properties.DataAgentProperties;
 import com.alibaba.cloud.ai.dataagent.service.llm.LlmService;
 import com.alibaba.cloud.ai.dataagent.service.nl2sql.Nl2SqlService;
-
-import com.alibaba.cloud.ai.dataagent.dto.planner.ExecutionStep;
-import com.alibaba.cloud.ai.dataagent.util.*;
+import com.alibaba.cloud.ai.dataagent.util.ChatResponseUtil;
+import com.alibaba.cloud.ai.dataagent.util.DatabaseUtil;
+import com.alibaba.cloud.ai.dataagent.util.FluxUtil;
+import com.alibaba.cloud.ai.dataagent.util.JsonUtil;
+import com.alibaba.cloud.ai.dataagent.util.MarkdownParserUtil;
+import com.alibaba.cloud.ai.dataagent.util.PlanProcessUtil;
+import com.alibaba.cloud.ai.dataagent.util.StateUtil;
 import com.alibaba.cloud.ai.graph.GraphResponse;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.action.NodeAction;
 import com.alibaba.cloud.ai.graph.streaming.StreamingOutput;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import static com.alibaba.cloud.ai.dataagent.constant.Constant.*;
 
 /**
  * SQL execution node that executes SQL queries against the database.
@@ -69,12 +78,9 @@ public class SqlExecuteNode implements NodeAction {
 
 	private final LlmService llmService;
 
-	private static final int SAMPLE_DATA_NUMBER = 20;
+	private final DataAgentProperties properties;
 
-	/**
-	 * 调用大模型生成图表配置的默认超时时间，单位毫秒
-	 */
-	private static final long DEFAULT_GENERATE_CHART_TIMEOUT_MILLIS = 2000L;
+	private static final int SAMPLE_DATA_NUMBER = 20;
 
 	@Override
 	public Map<String, Object> apply(OverAllState state) throws Exception {
@@ -197,6 +203,14 @@ public class SqlExecuteNode implements NodeAction {
 	 * @param resultSetBO SQL执行结果
 	 */
 	private DisplayStyleBO enrichResultSetWithChartConfig(OverAllState state, ResultSetBO resultSetBO) {
+		// 创建ResultDisplayStyleBO对象
+		DisplayStyleBO displayStyle = new DisplayStyleBO();
+		if (!this.properties.isEnableSqlResultChart()) {
+			log.debug("Sql result chart is disabled, set display style as table default");
+			displayStyle.setType("table");
+			return displayStyle;
+		}
+
 		try {
 			// 获取用户查询
 			String userQuery = StateUtil.getCanonicalQuery(state);
@@ -227,20 +241,15 @@ public class SqlExecuteNode implements NodeAction {
 			log.debug("Built chart config generation user prompt as follows \n {} \n", userPrompt);
 
 			// 调用LLM生成图表配置（使用系统提示词和用户提示词）
-			// 由于需要同步获取结果，这里使用block方式调用
-			String chartConfigJson = llmService.call(systemPrompt, userPrompt)
-				.map(chatResponse -> chatResponse.getResult().getOutput().getText())
-				.collectList()
-				.map(textList -> String.join("", textList))
-				.block(Duration.ofMillis(DEFAULT_GENERATE_CHART_TIMEOUT_MILLIS));
+			String chartConfigJson = llmService.toStringFlux(llmService.call(systemPrompt, userPrompt))
+				.collect(StringBuilder::new, StringBuilder::append)
+				.map(StringBuilder::toString)
+				.block(Duration.ofMillis(properties.getEnrichSqlResultTimeout()));
 
 			if (chartConfigJson != null && !chartConfigJson.trim().isEmpty()) {
 				String content = MarkdownParserUtil.extractText(chartConfigJson.trim());
 				// 解析JSON并填充到ResultSetBO中
 				Map<String, Object> chartConfig = JsonUtil.getObjectMapper().readValue(content, Map.class);
-
-				// 创建ResultDisplayStyleBO对象
-				DisplayStyleBO displayStyle = new DisplayStyleBO();
 
 				// 提取图表配置信息并设置到ResultDisplayStyleBO
 				if (chartConfig.containsKey("type")) {

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -143,16 +143,18 @@ public class AgentVectorStoreService {
 
 ### 1. 通用配置
 
-| 配置项 | 说明 | 默认值 |
-|--------|------|--------|
-| `spring.ai.alibaba.data-agent.llm-service-type` | LLM服务类型 (STREAM/BLOCK) | STREAM |
-| `spring.ai.alibaba.data-agent.max-sql-retry-count` | SQL执行失败重试次数 | 10 |
-| `spring.ai.alibaba.data-agent.max-sql-optimize-count` | SQL优化最多次数 | 10 |
-| `spring.ai.alibaba.data-agent.sql-score-threshold` | SQL优化分数阈值 | 0.95 |
-| `spring.ai.alibaba.data-agent.maxturnhistory` | 最多保留的对话轮数 | 5 |
-| `spring.ai.alibaba.data-agent.maxplanlength` | 单次规划最大长度限制 | 2000 |
-| `spring.ai.alibaba.data-agent.max-columns-per-table` | 每张表的最大预估列数 | 50 |
-| `spring.ai.alibaba.data-agent.fusion-strategy` | 多路召回结果融合策略 | rrf |
+| 配置项                                                    | 说明 | 默认值    |
+|--------------------------------------------------------|------|--------|
+| `spring.ai.alibaba.data-agent.llm-service-type`        | LLM服务类型 (STREAM/BLOCK) | STREAM |
+| `spring.ai.alibaba.data-agent.max-sql-retry-count`     | SQL执行失败重试次数 | 10     |
+| `spring.ai.alibaba.data-agent.max-sql-optimize-count`  | SQL优化最多次数 | 10     |
+| `spring.ai.alibaba.data-agent.sql-score-threshold`     | SQL优化分数阈值 | 0.95   |
+| `spring.ai.alibaba.data-agent.maxturnhistory`          | 最多保留的对话轮数 | 5      |
+| `spring.ai.alibaba.data-agent.maxplanlength`           | 单次规划最大长度限制 | 2000   |
+| `spring.ai.alibaba.data-agent.max-columns-per-table`   | 每张表的最大预估列数 | 50     |
+| `spring.ai.alibaba.data-agent.fusion-strategy`         | 多路召回结果融合策略 | rrf    |
+| `spring.ai.alibaba.data-agent.enable-sql-result-chart` | 是否启用SQL执行结果图表判断 | true   |
+| `spring.ai.alibaba.data-agent.enrich-sql-result-timeout` | 执行SQL结果图表化超时时间，单位毫秒 | 3000   |
 
 ### 2. 嵌入模型批处理策略 (Embedding Batch)
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

1、修复判别图表类型的时候部分模型出现的空指针问题
2、增加2项配置：是否生成图形、生成图形的耗时时间

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1、空指针问题改用：llmService.toStringFlux将流信息转换为字符串
2、增加的2项配置如下

| 配置项                                                    | 说明 | 默认值    |
|--------------------------------------------------------|------|--------|
| `spring.ai.alibaba.data-agent.enable-sql-result-chart` | 是否启用SQL执行结果图表判断 | true   |
| `spring.ai.alibaba.data-agent.enrich-sql-result-timeout` | 执行SQL结果图表化超时时间，单位毫秒 | 3000   |

### Describe how to verify it


### Special notes for reviews
