### PR TITLE
fix: 测试模型改为流式调用，防止出现enable_thinking配置的报错

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigOpsService.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigOpsService.java
@@ -29,6 +29,7 @@ import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+import reactor.core.publisher.Flux;
 
 @Slf4j
 @Service
@@ -142,7 +143,10 @@ public class ModelConfigOpsService {
 		String promptText = "Hello";
 
 		// 3. 调用
-		String response = tempModel.call(promptText);
+		Flux<String> responseFlux = tempModel.stream(promptText);
+		String response = responseFlux.collect(StringBuilder::new, StringBuilder::append)
+			.map(StringBuilder::toString)
+			.block();
 
 		// 4. 校验结果
 		if (!StringUtils.hasText(response)) {


### PR DESCRIPTION
### Describe what this PR does / why we need it

测试模型的地方改为流式调用

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #334 

使用qwen3-xx模型连接测试提示异常

### Describe how you did it
testChatModel方法中调用改为如下方式
```java
// 3. 调用
		Flux<String> responseFlux = tempModel.stream(promptText);
		String response = responseFlux.collect(StringBuilder::new, StringBuilder::append)
			.map(StringBuilder::toString)
			.block();
```

### Describe how to verify it


### Special notes for reviews
