### PR TITLE
feat(AgentRun): 报告格式切换、全屏查看、输入选项折叠及会话侧边栏抽屉

### DIFF
--- a/data-agent-frontend/src/components/run/ChatSessionSidebar.vue
+++ b/data-agent-frontend/src/components/run/ChatSessionSidebar.vue
@@ -23,17 +23,11 @@
     <!-- 收起时只显示展开按钮 -->
     <div v-if="collapsed" class="sidebar-collapsed">
       <el-tooltip content="展开会话列表" placement="right">
-        <el-button
-          type="primary"
-          circle
-          class="expand-btn"
-          @click="collapsed = false"
-        >
+        <el-button type="primary" circle class="expand-btn" @click="collapsed = false">
           <el-icon><DArrowRight /></el-icon>
         </el-button>
       </el-tooltip>
-      <el-tooltip content="返回" placement="right">
-      </el-tooltip>
+      <el-tooltip content="返回" placement="right"></el-tooltip>
     </div>
 
     <!-- 展开时显示完整内容 -->
@@ -45,28 +39,29 @@
             <el-icon><ArrowLeft /></el-icon>
           </el-button> -->
           <!-- 头像居中 -->
-          <el-avatar :src="agent.avatar" size="large" style="margin: 0 auto">{{ agent.name }}</el-avatar>
-         
+          <el-avatar :src="agent.avatar" size="large" style="margin: 0 auto">
+            {{ agent.name }}
+          </el-avatar>
+
           <div class="header-right">
             <el-tooltip content="收起会话列表" placement="bottom">
               <el-button type="default" circle size="large" @click="collapsed = true">
                 <el-icon><DArrowLeft /></el-icon>
               </el-button>
             </el-tooltip>
-          
-          </div>          
+          </div>
         </div>
         <!-- 在一行并且左80%右20%排列 gap8px -->
         <div class="new-session-section d-flex justify-content-between gap-8px">
           <div style="width: 80%">
-            <el-button type="primary" @click="createNewSession" style="width:100%">
+            <el-button type="primary" @click="createNewSession" style="width: 100%">
               <el-icon><Plus /></el-icon>
               新建会话
             </el-button>
           </div>
           <div>
             <el-button type="danger" @click="clearAllSessions">
-               <el-icon><Delete /></el-icon>
+              <el-icon><Delete /></el-icon>
             </el-button>
           </div>
         </div>
@@ -76,52 +71,52 @@
 
       <!-- 会话列表 -->
       <div class="session-list" style="margin-top: 20px">
-      <div
-        v-for="session in sessions"
-        :key="session.id"
-        :class="[
-          'session-item',
-          { active: handleGetCurrentSession()?.id === session.id, pinned: session.isPinned },
-        ]"
-        @click="handleSelectSession(session)"
-      >
-        <div class="session-header">
-          <span
-            class="session-title"
-            @dblclick="startEditSessionTitle(session)"
-            v-if="!session.editing"
-          >
-            {{ session.title || '新会话' }}
-          </span>
-          <el-input
-            v-else
-            v-model="session.editingTitle"
-            size="small"
-            @blur="saveSessionTitle(session)"
-            @keyup.enter="saveSessionTitle(session)"
-            @keyup.esc="cancelEditSessionTitle(session)"
-            ref="sessionTitleInputRef"
-          />
-          <div class="session-actions">
-            <el-button type="text" size="small" @click.stop="startEditSessionTitle(session)">
-              <el-icon><Edit /></el-icon>
-            </el-button>
-            <el-button type="text" size="small" @click.stop="togglePinSession(session)">
-              <el-icon>
-                <StarFilled v-if="session.isPinned" />
-                <Star v-else />
-              </el-icon>
-            </el-button>
-            <el-button type="text" size="small" @click.stop="deleteSession(session)">
-              <el-icon><Delete /></el-icon>
-            </el-button>
+        <div
+          v-for="session in sessions"
+          :key="session.id"
+          :class="[
+            'session-item',
+            { active: handleGetCurrentSession()?.id === session.id, pinned: session.isPinned },
+          ]"
+          @click="handleSelectSession(session)"
+        >
+          <div class="session-header">
+            <span
+              class="session-title"
+              @dblclick="startEditSessionTitle(session)"
+              v-if="!session.editing"
+            >
+              {{ session.title || '新会话' }}
+            </span>
+            <el-input
+              v-else
+              v-model="session.editingTitle"
+              size="small"
+              @blur="saveSessionTitle(session)"
+              @keyup.enter="saveSessionTitle(session)"
+              @keyup.esc="cancelEditSessionTitle(session)"
+              ref="sessionTitleInputRef"
+            />
+            <div class="session-actions">
+              <el-button type="text" size="small" @click.stop="startEditSessionTitle(session)">
+                <el-icon><Edit /></el-icon>
+              </el-button>
+              <el-button type="text" size="small" @click.stop="togglePinSession(session)">
+                <el-icon>
+                  <StarFilled v-if="session.isPinned" />
+                  <Star v-else />
+                </el-icon>
+              </el-button>
+              <el-button type="text" size="small" @click.stop="deleteSession(session)">
+                <el-icon><Delete /></el-icon>
+              </el-button>
+            </div>
+          </div>
+          <div class="session-time">
+            {{ formatTime(session.updateTime || session.createTime) }}
           </div>
         </div>
-        <div class="session-time">
-          {{ formatTime(session.updateTime || session.createTime) }}
-        </div>
       </div>
-    </div>
     </template>
   </el-aside>
 </template>
@@ -132,7 +127,15 @@
   import { useRouter, useRoute } from 'vue-router';
   import { ElMessage, ElMessageBox } from 'element-plus';
   import ChatService from '../../services/chat';
-  import { ArrowLeft, Plus, Delete, Star, StarFilled, Edit, DArrowLeft, DArrowRight } from '@element-plus/icons-vue';
+  import {
+    Plus,
+    Delete,
+    Star,
+    StarFilled,
+    Edit,
+    DArrowLeft,
+    DArrowRight,
+  } from '@element-plus/icons-vue';
   import { type Agent } from '../../services/agent';
   import { type ChatSession } from '../../services/chat';
 
@@ -151,7 +154,6 @@
   export default defineComponent({
     name: 'ChatSessionSidebar',
     components: {
-      ArrowLeft,
       Plus,
       Delete,
       Star,

--- a/data-agent-frontend/src/components/run/ReportHtmlView.vue
+++ b/data-agent-frontend/src/components/run/ReportHtmlView.vue
@@ -2,7 +2,7 @@
  * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this except in compliance with the License.
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *      https://www.apache.org/licenses/LICENSE-2.0
@@ -26,153 +26,71 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, watch, nextTick } from 'vue';
+  import { defineComponent, ref, watch, nextTick } from 'vue';
+  import { buildReportHtml } from './charts/report-html-template';
 
-// 与后端 ReportTemplateUtil 一致的 CDN 地址
-const MARKED_URL = 'https://mirrors.sustech.edu.cn/cdnjs/ajax/libs/marked/12.0.0/marked.min.js';
-const ECHARTS_URL = 'https://mirrors.sustech.edu.cn/cdnjs/ajax/libs/echarts/5.5.0/echarts.min.js';
-
-// 与后端 ReportTemplateUtil 一致的完整 HTML 模板
-// raw-markdown 中的内容需转义，以便 innerText 能正确读取原始 Markdown
-function escapeForHtml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
-}
-
-function buildReportHtml(markdownContent: string): string {
-  const escapedContent = escapeForHtml(markdownContent);
-
-  return `<!DOCTYPE html>
-<html lang="zh-CN">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>分析报告</title>
-<script src="${MARKED_URL}"><\/script>
-<script src="${ECHARTS_URL}"><\/script>
-<style>
-* { box-sizing: border-box; }
-body { margin: 0; padding: 20px; background-color: #f3f4f6; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; color: #374151; line-height: 1.6; }
-.container { max-width: 900px; margin: 0 auto; background-color: #ffffff; padding: 40px; border-radius: 12px; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); }
-h1 { font-size: 2.25rem; font-weight: 800; color: #1e3a8a; margin-top: 0; margin-bottom: 1.5rem; border-bottom: 2px solid #e5e7eb; padding-bottom: 0.5rem; }
-h2 { font-size: 1.5rem; font-weight: 700; color: #2563eb; margin-top: 2.5rem; margin-bottom: 1rem; border-left: 5px solid #2563eb; padding-left: 12px; }
-h3 { font-size: 1.25rem; font-weight: 600; color: #1f2937; margin-top: 1.5rem; margin-bottom: 0.75rem; }
-p { margin-bottom: 1rem; }
-ul, ol { margin-bottom: 1rem; padding-left: 1.5rem; }
-li { margin-bottom: 0.25rem; }
-code { background-color: #f1f5f9; padding: 0.2rem 0.4rem; border-radius: 0.25rem; font-size: 0.875em; color: #d946ef; font-family: monospace; }
-pre { background: #1e293b; color: #f8fafc; padding: 1rem; border-radius: 0.5rem; overflow-x: auto; }
-pre code { background: transparent; color: inherit; padding: 0; }
-.chart-box { width: 100%; height: 450px; margin: 30px 0; border: 1px solid #e2e8f0; border-radius: 8px; background-color: #fff; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
-.chart-error { display: flex; align-items: center; justify-content: center; height: 100%; color: #ef4444; background-color: #fef2f2; border: 1px dashed #ef4444; border-radius: 8px; }
-</style>
-</head>
-<body>
-<div class="container">
-<div id="raw-markdown" style="display:none;">${escapedContent}</div>
-<div id="render-target" class="markdown-body"></div>
-</div>
-<script>
-window.onload = function() {
-  if (typeof marked === 'undefined') {
-    document.getElementById('render-target').innerHTML = '<p style="color:red;">Marked库加载失败，请检查网络</p>';
-    return;
-  }
-  var rawDiv = document.getElementById('raw-markdown');
-  if (!rawDiv) return;
-  var rawText = rawDiv.innerText;
-  var renderer = new marked.Renderer();
-  renderer.code = function(code, language) {
-    if (language === 'echarts' || language === 'json') {
-      var id = 'chart_' + Math.random().toString(36).substr(2, 9);
-      return '<div id="' + id + '" class="chart-box" data-option="' + encodeURIComponent(code) + '"><\/div>';
-    }
-    return '<pre><code class="language-' + language + '">' + code.replace(/</g, '&lt;').replace(/>/g, '&gt;') + '<\/code><\/pre>';
-  };
-  document.getElementById('render-target').innerHTML = marked.parse(rawText, { renderer: renderer });
-  if (typeof echarts !== 'undefined') {
-    document.querySelectorAll('.chart-box').forEach(function(box) {
-      try {
-        var code = decodeURIComponent(box.getAttribute('data-option'));
-        var option = new Function('return ' + code)();
-        var myChart = echarts.init(box);
-        myChart.setOption(option);
-        window.addEventListener('resize', function() { myChart.resize(); });
-      } catch(e) {
-        box.innerHTML = '<div class="chart-error"><b>图表渲染错误<\/b><br/>' + e.message + '<\/div>';
-      }
-    });
-  }
-};
-<\/script>
-</body>
-</html>`;
-}
-
-export default defineComponent({
-  name: 'ReportHtmlView',
-  props: {
-    content: {
-      type: String,
-      default: '',
-    },
-  },
-  setup(props) {
-    const iframeRef = ref<HTMLIFrameElement | null>(null);
-
-    const loadHtml = () => {
-      if (!iframeRef.value) return;
-
-      if (!props.content) {
-        iframeRef.value.srcdoc = '<html><body style="padding:20px;color:#666;">暂无报告内容</body></html>';
-        return;
-      }
-
-      const html = buildReportHtml(props.content);
-      const blob = new Blob([html], { type: 'text/html;charset=utf-8' });
-      const url = URL.createObjectURL(blob);
-
-      const iframe = iframeRef.value;
-      const onLoad = () => {
-        URL.revokeObjectURL(url);
-        iframe.removeEventListener('load', onLoad);
-      };
-      iframe.addEventListener('load', onLoad);
-      iframe.src = url;
-    };
-
-    watch(
-      () => props.content,
-      () => {
-        nextTick(loadHtml);
+  export default defineComponent({
+    name: 'ReportHtmlView',
+    props: {
+      content: {
+        type: String,
+        default: '',
       },
-      { immediate: true },
-    );
+    },
+    setup(props) {
+      const iframeRef = ref<HTMLIFrameElement | null>(null);
 
-    return {
-      iframeRef,
-    };
-  },
-});
+      const loadHtml = () => {
+        if (!iframeRef.value) return;
+
+        if (!props.content) {
+          iframeRef.value.srcdoc =
+            '<html><body style="padding:20px;color:#666;">暂无报告内容</body></html>';
+          return;
+        }
+
+        const html = buildReportHtml(props.content);
+        const blob = new Blob([html], { type: 'text/html;charset=utf-8' });
+        const url = URL.createObjectURL(blob);
+
+        const iframe = iframeRef.value;
+        const onLoad = () => {
+          URL.revokeObjectURL(url);
+          iframe.removeEventListener('load', onLoad);
+        };
+        iframe.addEventListener('load', onLoad);
+        iframe.src = url;
+      };
+
+      watch(
+        () => props.content,
+        () => {
+          nextTick(loadHtml);
+        },
+        { immediate: true },
+      );
+
+      return {
+        iframeRef,
+      };
+    },
+  });
 </script>
 
 <style scoped>
-.report-html-view-wrapper {
-  width: 100%;
-  min-height: 400px;
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
-  overflow: hidden;
-  background: #fff;
-}
+  .report-html-view-wrapper {
+    width: 100%;
+    min-height: 400px;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    overflow: hidden;
+    background: #fff;
+  }
 
-.report-html-iframe {
-  width: 100%;
-  min-height: 600px;
-  border: none;
-  display: block;
-}
+  .report-html-iframe {
+    width: 100%;
+    min-height: 600px;
+    border: none;
+    display: block;
+  }
 </style>

--- a/data-agent-frontend/src/components/run/charts/report-html-template.ts
+++ b/data-agent-frontend/src/components/run/charts/report-html-template.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// 与后端 ReportTemplateUtil 一致的 CDN 地址
+const MARKED_URL = 'https://mirrors.sustech.edu.cn/cdnjs/ajax/libs/marked/12.0.0/marked.min.js';
+const ECHARTS_URL = 'https://mirrors.sustech.edu.cn/cdnjs/ajax/libs/echarts/5.5.0/echarts.min.js';
+
+// raw-markdown 中的内容需转义，以便 innerText 能正确读取原始 Markdown
+function escapeForHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+export function buildReportHtml(markdownContent: string): string {
+  const escapedContent = escapeForHtml(markdownContent);
+
+  return `<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>分析报告</title>
+<script src="${MARKED_URL}"></script>
+<script src="${ECHARTS_URL}"></script>
+<style>
+* { box-sizing: border-box; }
+body { margin: 0; padding: 20px; background-color: #f3f4f6; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; color: #374151; line-height: 1.6; }
+.container { max-width: 900px; margin: 0 auto; background-color: #ffffff; padding: 40px; border-radius: 12px; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); }
+h1 { font-size: 2.25rem; font-weight: 800; color: #1e3a8a; margin-top: 0; margin-bottom: 1.5rem; border-bottom: 2px solid #e5e7eb; padding-bottom: 0.5rem; }
+h2 { font-size: 1.5rem; font-weight: 700; color: #2563eb; margin-top: 2.5rem; margin-bottom: 1rem; border-left: 5px solid #2563eb; padding-left: 12px; }
+h3 { font-size: 1.25rem; font-weight: 600; color: #1f2937; margin-top: 1.5rem; margin-bottom: 0.75rem; }
+p { margin-bottom: 1rem; }
+ul, ol { margin-bottom: 1rem; padding-left: 1.5rem; }
+li { margin-bottom: 0.25rem; }
+code { background-color: #f1f5f9; padding: 0.2rem 0.4rem; border-radius: 0.25rem; font-size: 0.875em; color: #d946ef; font-family: monospace; }
+pre { background: #1e293b; color: #f8fafc; padding: 1rem; border-radius: 0.5rem; overflow-x: auto; }
+pre code { background: transparent; color: inherit; padding: 0; }
+.chart-box { width: 100%; height: 450px; margin: 30px 0; border: 1px solid #e2e8f0; border-radius: 8px; background-color: #fff; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.chart-error { display: flex; align-items: center; justify-content: center; height: 100%; color: #ef4444; background-color: #fef2f2; border: 1px dashed #ef4444; border-radius: 8px; }
+</style>
+</head>
+<body>
+<div class="container">
+<div id="raw-markdown" style="display:none;">${escapedContent}</div>
+<div id="render-target" class="markdown-body"></div>
+</div>
+<script>
+window.onload = function() {
+  if (typeof marked === 'undefined') {
+    document.getElementById('render-target').innerHTML = '<p style="color:red;">Marked库加载失败，请检查网络</p>';
+    return;
+  }
+  var rawDiv = document.getElementById('raw-markdown');
+  if (!rawDiv) return;
+  var rawText = rawDiv.innerText;
+  var renderer = new marked.Renderer();
+  renderer.code = function(code, language) {
+    if (language === 'echarts' || language === 'json') {
+      var id = 'chart_' + Math.random().toString(36).substr(2, 9);
+      return '<div id="' + id + '" class="chart-box" data-option="' + encodeURIComponent(code) + '"></div>';
+    }
+    return '<pre><code class="language-' + language + '">' + code.replace(/</g, '&lt;').replace(/>/g, '&gt;') + '</code></pre>';
+  };
+  document.getElementById('render-target').innerHTML = marked.parse(rawText, { renderer: renderer });
+  if (typeof echarts !== 'undefined') {
+    document.querySelectorAll('.chart-box').forEach(function(box) {
+      try {
+        var code = decodeURIComponent(box.getAttribute('data-option'));
+        var option = new Function('return ' + code)();
+        var myChart = echarts.init(box);
+        myChart.setOption(option);
+        window.addEventListener('resize', function() { myChart.resize(); });
+      } catch(e) {
+        box.innerHTML = '<div class="chart-error"><b>图表渲染错误</b><br/>' + e.message + '</div>';
+      }
+    });
+  }
+};
+</script>
+</body>
+</html>`;
+}

--- a/data-agent-frontend/src/views/AgentRun.vue
+++ b/data-agent-frontend/src/views/AgentRun.vue
@@ -100,10 +100,7 @@
                       下载HTML报告
                     </el-button>
                     <el-tooltip content="全屏查看报告" placement="top">
-                      <el-button
-                        type="info"
-                        @click="openReportFullscreen(message.content)"
-                      >
+                      <el-button type="info" @click="openReportFullscreen(message.content)">
                         <el-icon><FullScreen /></el-icon>
                         全屏
                       </el-button>
@@ -194,8 +191,6 @@
           :handleFeedback="handleHumanFeedback"
         />
 
-     
-
         <!-- 输入区域 -->
         <div class="input-area" v-if="currentSession">
           <div class="input-controls">
@@ -224,58 +219,58 @@
                 :onQuestionClick="handlePresetQuestionClick"
               />
               <div class="switch-group">
-              <div class="switch-item">
-                <span class="switch-label">人工反馈</span>
-                <el-tooltip
-                  :disabled="!requestOptions.nl2sqlOnly"
-                  content="该功能在NL2SQL模式下不能使用"
-                  placement="top"
-                >
+                <div class="switch-item">
+                  <span class="switch-label">人工反馈</span>
+                  <el-tooltip
+                    :disabled="!requestOptions.nl2sqlOnly"
+                    content="该功能在NL2SQL模式下不能使用"
+                    placement="top"
+                  >
+                    <el-switch
+                      v-model="requestOptions.humanFeedback"
+                      :disabled="requestOptions.nl2sqlOnly || isStreaming || showHumanFeedback"
+                    />
+                  </el-tooltip>
+                </div>
+                <div class="switch-item">
+                  <span class="switch-label">仅NL2SQL</span>
                   <el-switch
-                    v-model="requestOptions.humanFeedback"
-                    :disabled="requestOptions.nl2sqlOnly || isStreaming || showHumanFeedback"
-                  />
-                </el-tooltip>
-              </div>
-              <div class="switch-item">
-                <span class="switch-label">仅NL2SQL</span>
-                <el-switch
-                  v-model="requestOptions.nl2sqlOnly"
-                  :disabled="isStreaming || showHumanFeedback"
-                  @change="handleNl2sqlOnlyChange"
-                />
-              </div>
-              <div class="switch-item">
-                <span class="switch-label">自动Scroll</span>
-                <el-switch v-model="autoScroll" />
-              </div>
-              <div class="switch-item">
-                <span class="switch-label">显示SQL结果</span>
-                <el-tooltip
-                  content="启用本功能会将SQL查询结果存储到DataAgent项目的数据库中，如果数据量较大不建议开启本功能"
-                  placement="top"
-                >
-                  <el-switch
-                    v-model="resultSetDisplayConfig.showSqlResults"
+                    v-model="requestOptions.nl2sqlOnly"
                     :disabled="isStreaming || showHumanFeedback"
+                    @change="handleNl2sqlOnlyChange"
                   />
-                </el-tooltip>
-              </div>
-              <div class="switch-item">
-                <span class="switch-label">每页数量</span>
-                <el-select
-                  v-model="resultSetDisplayConfig.pageSize"
-                  :disabled="isStreaming || showHumanFeedback"
-                  style="width: 80px"
-                >
-                  <el-option label="5" :value="5" />
-                  <el-option label="10" :value="10" />
-                  <el-option label="20" :value="20" />
-                  <el-option label="50" :value="50" />
-                  <el-option label="100" :value="100" />
-                </el-select>
-              </div>
-              <!-- <div class="switch-item">
+                </div>
+                <div class="switch-item">
+                  <span class="switch-label">自动Scroll</span>
+                  <el-switch v-model="autoScroll" />
+                </div>
+                <div class="switch-item">
+                  <span class="switch-label">显示SQL结果</span>
+                  <el-tooltip
+                    content="启用本功能会将SQL查询结果存储到DataAgent项目的数据库中，如果数据量较大不建议开启本功能"
+                    placement="top"
+                  >
+                    <el-switch
+                      v-model="resultSetDisplayConfig.showSqlResults"
+                      :disabled="isStreaming || showHumanFeedback"
+                    />
+                  </el-tooltip>
+                </div>
+                <div class="switch-item">
+                  <span class="switch-label">每页数量</span>
+                  <el-select
+                    v-model="resultSetDisplayConfig.pageSize"
+                    :disabled="isStreaming || showHumanFeedback"
+                    style="width: 80px"
+                  >
+                    <el-option label="5" :value="5" />
+                    <el-option label="10" :value="10" />
+                    <el-option label="20" :value="20" />
+                    <el-option label="50" :value="50" />
+                    <el-option label="100" :value="100" />
+                  </el-select>
+                </div>
+                <!-- <div class="switch-item">
                 <span class="switch-label">报告格式</span>
                 <el-radio-group v-model="requestOptions.reportFormat" size="small">
                   <el-radio-button value="markdown">Markdown</el-radio-button>
@@ -320,7 +315,11 @@
 
     <!-- 报告全屏遮罩 -->
     <Teleport to="body">
-      <div v-if="showReportFullscreen" class="report-fullscreen-overlay" @click.self="closeReportFullscreen">
+      <div
+        v-if="showReportFullscreen"
+        class="report-fullscreen-overlay"
+        @click.self="closeReportFullscreen"
+      >
         <div class="report-fullscreen-container">
           <div class="report-fullscreen-header">
             <span class="report-fullscreen-title">
@@ -342,7 +341,11 @@
               :content="fullscreenReportContent"
               :options="options"
             />
-            <ReportHtmlView v-else :content="fullscreenReportContent" class="report-fullscreen-body" />
+            <ReportHtmlView
+              v-else
+              :content="fullscreenReportContent"
+              class="report-fullscreen-body"
+            />
           </div>
         </div>
       </div>
@@ -354,7 +357,16 @@
   import { ref, defineComponent, onMounted, nextTick, computed } from 'vue';
   import { useRoute } from 'vue-router';
   import { ElMessage } from 'element-plus';
-  import { Loading, Promotion, Document, Download, CircleClose, FullScreen, Close, ArrowDown } from '@element-plus/icons-vue';
+  import {
+    Loading,
+    Promotion,
+    Document,
+    Download,
+    CircleClose,
+    FullScreen,
+    Close,
+    ArrowDown,
+  } from '@element-plus/icons-vue';
   import hljs from 'highlight.js';
   import { marked } from 'marked';
   import DOMPurify from 'dompurify';


### PR DESCRIPTION
## 变更概述

本次 PR 对智能体运行页（AgentRun）及会话侧边栏进行了交互与展示优化，提升报告查看体验和页面空间利用。

## 主要变更

### 1. 报告格式切换
- 支持在 Markdown 与 HTML 两种报告格式间切换
- HTML 模式使用 iframe 沙盒渲染，与「下载 HTML 报告」的样式和图表一致
- 切换入口：报告卡片头部、输入区「更多选项」中

### 2. 报告全屏查看
- 在「下载 HTML 报告」右侧新增「全屏」按钮
- 点击后以全屏遮罩展示当前报告（Markdown 或 HTML）
- 支持点击关闭按钮或遮罩背景退出全屏

### 3. 输入区「更多选项」折叠
- 预设问题与各类开关（人工反馈、仅 NL2SQL、自动 Scroll 等）支持折叠
- 新增「更多选项」折叠标题和「展开/收起」按钮
- 默认展开，可收起以节省输入区空间

### 4. 会话侧边栏抽屉
- 会话列表侧边栏支持收起/展开
- 收起时仅显示展开按钮和返回按钮（宽度 48px）
- 展开时显示完整会话列表及收起按钮
- 支持平滑过渡动画

## 新增文件

- `src/components/run/ReportHtmlView.vue`：HTML 报告展示组件（iframe 沙盒，复用后端 ReportTemplateUtil 的样式与图表渲染逻辑）

## 修改文件

- `src/views/AgentRun.vue`：报告格式切换、全屏查看、输入区折叠
- `src/components/run/ChatSessionSidebar.vue`：侧边栏抽屉收起/展开

## 测试建议

1. **报告格式**：生成报告后切换 Markdown/HTML，确认展示与图表正常
2. **全屏**：点击全屏按钮，确认全屏展示与退出正常
3. **输入区折叠**：点击「更多选项」展开/收起，确认预设问题与开关显示正常
4. **侧边栏**：点击收起/展开按钮，确认会话列表与布局正常