### PR TITLE
fix: 修复docker-compose文件脚本，确保项目能够启动

### DIFF
--- a/data-agent-management/src/main/resources/application.yml
+++ b/data-agent-management/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
     type: com.alibaba.druid.pool.DruidDataSource
   sql:
     init:
-      mode: never
+      mode: ${DATA_AGENT_DATASOURCE_SQL_INIT:never}
       schema-locations: classpath:sql/schema.sql
       data-locations: classpath:sql/data.sql
       continue-on-error: true

--- a/docker-file/Dockerfile-backend
+++ b/docker-file/Dockerfile-backend
@@ -12,7 +12,7 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
-FROM openjdk:17-jdk-slim as build
+FROM eclipse-temurin:17-jdk-jammy as build
 
 WORKDIR /app
 
@@ -42,12 +42,15 @@ RUN apt update && apt install -y maven git
 #  </profiles>\
 #</settings>' > aliyun-settings.xml
 
-RUN git clone https://github.com/spring-ai-alibaba/DataAgent.git \
-    && cd DataAgent &&  \
-    mvn install -DskipTests
+# 复制本地代码到构建容器
+COPY . /app/DataAgent
+
+# 进入项目目录并构建
+WORKDIR /app/DataAgent
+RUN mvn install -DskipTests
 #    mvn install -DskipTests -s ../aliyun-settings.xml
 
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk-jammy
 
 WORKDIR /app
 

--- a/docker-file/docker-compose-datasource.yml
+++ b/docker-file/docker-compose-datasource.yml
@@ -43,7 +43,6 @@ services:
       POSTGRES_PASSWORD: postgres
     volumes:
       - ./config/postgres:/docker-entrypoint-initdb.d
-    command: postgres -c config_file=/etc/postgresql/postgresql.conf
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 30s

--- a/docker-file/docker-compose.yml
+++ b/docker-file/docker-compose.yml
@@ -40,9 +40,10 @@ services:
         - saa-data-agent-backend:1.0.0-SNAPSHOT
     container_name: data-agent-backend
     environment:
-      - NL2SQL_DATASOURCE_URL=jdbc:mysql://mysql:3306/nl2sql_db?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
-      - NL2SQL_DATASOURCE_USERNAME=root
-      - NL2SQL_DATASOURCE_PASSWORD=root
+      - DATA_AGENT_DATASOURCE_URL=jdbc:mysql://mysql:3306/nl2sql_db?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
+      - DATA_AGENT_DATASOURCE_USERNAME=root
+      - DATA_AGENT_DATASOURCE_PASSWORD=root
+      - DATA_AGENT_DATASOURCE_SQL_INIT=always
       - AI_DASHSCOPE_API_KEY=${AI_DASHSCOPE_API_KEY}
     ports:
       - "8065:8065"


### PR DESCRIPTION
### Describe what this PR does / why we need it
使用docker能够让初学者快速部署，让代码开发成功后能更快部署到对应环境。但目前看到好几个人提到跑docker起环境有问题，因此想要进行修复。
主要原因：
1、部分环境变量没有正确传递。
      例如老版的NL2SQL_XX_XX变量没有写成DATA_AGENT_XX_XX
2、镜像使用过时。
      openjdk:17-jdk-slim 这个镜像我看的确是废弃了的，在公开库里的确搜不到，我找了个相近替代的。
3、代码构建的来源我个人更认为用当前文件更合适，而不是从线上拉取。“所见即所得”

### Does this pull request fix one issue?
fix #349
fix #366

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
