### PR TITLE
fix: Fix the issue of compilation errors caused by the absence of code generation based on Lombok annotations in a pure Maven environment.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -344,6 +344,13 @@
           <compilerArgs>
             <arg>-parameters</arg>
           </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>1.18.38</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Fix the issue of compilation errors caused by the absence of code generation based on Lombok annotations in a pure Maven environment.

### Describe what this PR does / why we need it
Fix the issue of compilation errors caused by the absence of code generation based on Lombok annotations in a pure Maven environment.

### Does this pull request fix one issue?
NONE
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Add annotationProcessorPaths configuration for the maven-compiler-plugin to attach Lombok annotation processing capabilities to the Maven compilation phase.

### Describe how to verify it
mvn clean package

### Special notes for reviews
NONE