### PR TITLE
feat(datasource): 支持单实例多 Schema 管理，及使用 schema.table 实现跨域查询与向量外键存储

### DIFF
--- a/data-agent-frontend/src/components/agent/DataSourceConfig.vue
+++ b/data-agent-frontend/src/components/agent/DataSourceConfig.vue
@@ -699,7 +699,7 @@
               clearable
               filterable
             >
-              <el-option v-for="table in tableList" :key="table" :label="table" :value="table" />
+              <el-option v-for="table in targetTableList" :key="table" :label="table" :value="table" />
             </el-select>
           </el-col>
 
@@ -859,6 +859,7 @@
         description: '',
       } as LogicalRelation);
       const tableList: Ref<string[]> = ref([]);
+      const targetTableList: Ref<string[]> = ref([]);
       const sourceColumnList: Ref<string[]> = ref([]);
       const targetColumnList: Ref<string[]> = ref([]);
       const savingForeignKeys: Ref<boolean> = ref(false);
@@ -1348,7 +1349,11 @@
 
         // 加载表列表
         try {
+          // 左侧主表：仅显示当前点击进入配置环境的当前数据源及子 Schema 列表
           tableList.value = await datasourceService.getDatasourceTables(datasourceRow.id);
+          
+          // 右侧关联表：获取平台上所有 Active 状态数据源下的合法受管表（跨业务库）
+          targetTableList.value = await logicalRelationService.getAllDatasourceTables(datasourceRow.id);
         } catch (error) {
           ElMessage.error('加载表列表失败');
           console.error('Failed to load table list:', error);
@@ -1627,6 +1632,7 @@
         foreignKeyList,
         newForeignKey,
         tableList,
+        targetTableList,
         sourceColumnList,
         targetColumnList,
         savingForeignKeys,

--- a/data-agent-frontend/src/services/logicalRelation.ts
+++ b/data-agent-frontend/src/services/logicalRelation.ts
@@ -107,6 +107,19 @@ class LogicalRelationService {
     return response.data;
   }
 
+  // 获取数据源所属数据库的全量表（包含所有有效的 schema）
+  async getAllDatasourceTables(datasourceId: number): Promise<string[]> {
+    try {
+      const response = await axios.get<string[]>(
+        `${API_BASE_URL}/${datasourceId}/all-tables`,
+      );
+      return response.data || [];
+    } catch (error) {
+      console.error('Failed to get all datasource tables:', error);
+      return [];
+    }
+  }
+
   // 获取数据源表的字段列表
   async getTableColumns(datasourceId: number, tableName: string): Promise<string[]> {
     try {

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/bo/DbConfigBO.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/bo/DbConfigBO.java
@@ -20,6 +20,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -38,4 +40,5 @@ public class DbConfigBO {
 
 	private String dialectType;
 
+	private List<String> schemas;
 }

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/connector/impls/mysql/MysqlJdbcDdl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/connector/impls/mysql/MysqlJdbcDdl.java
@@ -81,8 +81,9 @@ public class MysqlJdbcDdl extends AbstractJdbcDdl {
 		sql += "limit 2000;";
 		List<TableInfoBO> tableInfoList = Lists.newArrayList();
 		try {
+			String actualSchema = StringUtils.isNotBlank(schema) ? schema : connection.getCatalog();
 			String[][] resultArr = SqlExecutor.executeSqlAndReturnArr(connection,
-					String.format(sql, connection.getCatalog(), tablePattern));
+					String.format(sql,actualSchema, tablePattern));
 			if (resultArr.length <= 1) {
 				return Lists.newArrayList();
 			}
@@ -110,8 +111,9 @@ public class MysqlJdbcDdl extends AbstractJdbcDdl {
 		List<TableInfoBO> tableInfoList = Lists.newArrayList();
 		String tableListStr = String.join(", ", tables.stream().map(x -> "'" + x + "'").collect(Collectors.toList()));
 		try {
+			String actualSchema = StringUtils.isNotBlank(schema) ? schema : connection.getCatalog();
 			String[][] resultArr = SqlExecutor.executeSqlAndReturnArr(connection,
-					String.format(sql, connection.getCatalog(), tableListStr));
+					String.format(sql,actualSchema, tableListStr));
 			if (resultArr.length <= 1) {
 				return Lists.newArrayList();
 			}
@@ -139,8 +141,9 @@ public class MysqlJdbcDdl extends AbstractJdbcDdl {
 				+ "FROM information_schema.COLUMNS " + "WHERE table_schema='%s' " + "and table_name='%s';";
 		List<ColumnInfoBO> columnInfoList = Lists.newArrayList();
 		try {
+			String actualSchema = StringUtils.isNotBlank(schema) ? schema : connection.getCatalog();
 			String[][] resultArr = SqlExecutor.executeSqlAndReturnArr(connection, "INFORMATION_SCHEMA",
-					String.format(sql, connection.getCatalog(), table));
+					String.format(sql,actualSchema, table));
 			if (resultArr.length <= 1) {
 				return Lists.newArrayList();
 			}
@@ -176,7 +179,8 @@ public class MysqlJdbcDdl extends AbstractJdbcDdl {
 		String tableListStr = String.join(", ", tables.stream().map(x -> "'" + x + "'").collect(Collectors.toList()));
 
 		try {
-			sql = String.format(sql, connection.getCatalog(), tableListStr, tableListStr);
+			String actualSchema = StringUtils.isNotBlank(schema) ? schema : connection.getCatalog();
+			sql = String.format(sql,actualSchema, tableListStr, tableListStr);
 			String[][] resultArr = SqlExecutor.executeSqlAndReturnArr(connection, "INFORMATION_SCHEMA", sql);
 			if (resultArr.length <= 1) {
 				return Lists.newArrayList();
@@ -203,10 +207,11 @@ public class MysqlJdbcDdl extends AbstractJdbcDdl {
 
 	@Override
 	public List<String> sampleColumn(Connection connection, String schema, String table, String column) {
-		String sql = "SELECT \n" + "    `%s`\n" + "FROM \n" + "    `%s`\n" + "LIMIT 99;";
+		String qualifiedTable = StringUtils.isNotBlank(schema) ? String.format("`%s`.`%s`", schema, table) :
+				String.format("`%s`",table);
+		String sql = String.format("SELECT `%s` FROM %s LIMIT 99", column, qualifiedTable);
 		List<String> sampleInfo = Lists.newArrayList();
 		try {
-			sql = String.format(sql, column, table);
 			String[][] resultArr = SqlExecutor.executeSqlAndReturnArr(connection, null, sql);
 			if (resultArr.length <= 1) {
 				return Lists.newArrayList();
@@ -231,9 +236,11 @@ public class MysqlJdbcDdl extends AbstractJdbcDdl {
 	@Override
 	public ResultSetBO scanTable(Connection connection, String schema, String table) {
 		String sql = "SELECT *\n" + "FROM \n" + "    `%s`\n" + "LIMIT 20;";
+		String qualifiedTable = StringUtils.isNotBlank(schema) ? String.format("`%s`.`%s`", schema, table) :
+				String.format("`%s`",table);
 		ResultSetBO resultSet = ResultSetBO.builder().build();
 		try {
-			resultSet = SqlExecutor.executeSqlAndReturnObject(connection, schema, String.format(sql, table));
+			resultSet = SqlExecutor.executeSqlAndReturnObject(connection, schema, String.format(sql, qualifiedTable));
 		}
 		catch (SQLException e) {
 			throw new RuntimeException(e);

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/connector/impls/postgre/PostgreJdbcDdl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/connector/impls/postgre/PostgreJdbcDdl.java
@@ -112,8 +112,9 @@ public class PostgreJdbcDdl extends AbstractJdbcDdl {
 
 		List<TableInfoBO> tableInfoList = Lists.newArrayList();
 		try {
+			String actualSchema = StringUtils.isNotBlank(schema) ? schema : "public";
 			String[][] resultArr = SqlExecutor.executeSqlAndReturnArr(connection,
-					String.format(sql, schema, tablePattern));
+					String.format(sql,actualSchema, tablePattern));
 			if (resultArr.length <= 1) {
 				return Lists.newArrayList();
 			}
@@ -216,13 +217,14 @@ public class PostgreJdbcDdl extends AbstractJdbcDdl {
 				+ "    ON tc.constraint_name = kcu.constraint_name\n" + "    AND tc.table_schema = kcu.table_schema\n"
 				+ "JOIN\n" + "    information_schema.constraint_column_usage AS ccu\n"
 				+ "    ON ccu.constraint_name = tc.constraint_name\n" + "    AND ccu.table_schema = tc.table_schema\n"
-				+ "WHERE\n" + "    tc.constraint_type = 'FOREIGN KEY'\n" + "    AND tc.table_schema='public'\n"
+				+ "WHERE\n" + "    tc.constraint_type = 'FOREIGN KEY'\n" + "    AND tc.table_schema='%s'\n"
 				+ "    AND tc.table_name in (%s)";
 		List<ForeignKeyInfoBO> foreignKeyInfoList = Lists.newArrayList();
 		String tableListStr = String.join(", ", tables.stream().map(x -> "'" + x + "'").collect(Collectors.toList()));
 
 		try {
-			sql = String.format(sql, tableListStr);
+			String actualSchema = StringUtils.isNotBlank(schema) ? schema : "public";
+			sql = String.format(sql,actualSchema, tableListStr);
 			String[][] resultArr = SqlExecutor.executeSqlAndReturnArr(connection, null, sql);
 			if (resultArr.length <= 1) {
 				return Lists.newArrayList();
@@ -249,10 +251,11 @@ public class PostgreJdbcDdl extends AbstractJdbcDdl {
 
 	@Override
 	public List<String> sampleColumn(Connection connection, String schema, String table, String column) {
-		String sql = "SELECT \n" + "    \"%s\"\n" + "FROM \n" + "    \"%s\"\n" + "LIMIT 99;";
+		String actualSchema = StringUtils.isNotBlank(schema) ? schema : "public";
+		String qualifiedTable = String.format("\"%s\".\"%s\"", actualSchema, table);
+		String sql = String.format("SELECT \"%s\" FROM %s LIMIT 99", column, qualifiedTable);
 		List<String> sampleInfo = Lists.newArrayList();
 		try {
-			sql = String.format(sql, column, table);
 			String[][] resultArr = SqlExecutor.executeSqlAndReturnArr(connection, schema, sql);
 			if (resultArr.length <= 1) {
 				return Lists.newArrayList();
@@ -278,10 +281,12 @@ public class PostgreJdbcDdl extends AbstractJdbcDdl {
 
 	@Override
 	public ResultSetBO scanTable(Connection connection, String schema, String table) {
-		String sql = "SELECT *\n" + "FROM \n" + "    %s\n" + "LIMIT 20;";
+		String actualSchema = StringUtils.isNotBlank(schema) ? schema : "public";
+		String qualifiedTable = String.format("\"%s\".\"%s\"", actualSchema, table);
+		String sql = String.format("SELECT * FROM %s LIMIT 20", qualifiedTable);
 		ResultSetBO resultSet = ResultSetBO.builder().build();
 		try {
-			resultSet = SqlExecutor.executeSqlAndReturnObject(connection, schema, String.format(sql, table));
+			resultSet = SqlExecutor.executeSqlAndReturnObject(connection, schema, sql);
 		}
 		catch (SQLException e) {
 			throw new RuntimeException(e);

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/controller/DatasourceController.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/controller/DatasourceController.java
@@ -119,6 +119,17 @@ public class DatasourceController {
 		}
 	}
 
+	@GetMapping("/{id}/all-tables")
+	public List<String> getAllDatasourceTables(@PathVariable Integer id) {
+		checkDatasourceExists(id);
+		try {
+			return datasourceService.getAllSchemasTables(id);
+		}
+		catch (Exception e) {
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+		}
+	}
+
 	/**
 	 * Create data source
 	 */

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/entity/Datasource.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/entity/Datasource.java
@@ -52,6 +52,8 @@ public class Datasource {
 
 	private String testStatus;
 
+	private String schemas;
+
 	private String description;
 
 	private Long creatorId;

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/mapper/AgentDatasourceMapper.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/mapper/AgentDatasourceMapper.java
@@ -38,9 +38,9 @@ public interface AgentDatasourceMapper {
 	@Select("SELECT * FROM agent_datasource WHERE agent_id = #{agentId} ORDER BY create_time DESC")
 	List<AgentDatasource> selectByAgentId(@Param("agentId") Long agentId);
 
-	/** Query active datasource ID by agent ID */
+	/** Query active datasource IDs by agent ID */
 	@Select("SELECT datasource_id FROM agent_datasource WHERE agent_id = #{agentId} AND is_active = 1")
-	Integer selectActiveDatasourceIdByAgentId(@Param("agentId") Long agentId);
+	List<Integer> selectActiveDatasourceIdsByAgentId(@Param("agentId") Long agentId);
 
 	/** Query association by agent ID and data source ID */
 	@Select("SELECT * FROM agent_datasource WHERE agent_id = #{agentId} AND datasource_id = #{datasourceId}")

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/mapper/DatasourceMapper.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/mapper/DatasourceMapper.java
@@ -43,8 +43,8 @@ public interface DatasourceMapper {
 
 	@Insert("""
 			INSERT INTO datasource
-			    (name, type, host, port, database_name, username, password, connection_url, status, test_status, description, creator_id, create_time, update_time)
-			VALUES (#{name}, #{type}, #{host}, #{port}, #{databaseName}, #{username}, #{password}, #{connectionUrl}, #{status}, #{testStatus}, #{description}, #{creatorId}, NOW(), NOW())
+			    (name, type, host, port, database_name, username, password, connection_url, status, test_status,`schemas`,description, creator_id, create_time, update_time)
+			VALUES (#{name}, #{type}, #{host}, #{port}, #{databaseName}, #{username}, #{password}, #{connectionUrl}, #{status}, #{testStatus}, #{schemas}, #{description}, #{creatorId}, NOW(), NOW())
 			""")
 	@Options(useGeneratedKeys = true, keyProperty = "id", keyColumn = "id")
 	int insert(Datasource datasource);
@@ -65,6 +65,7 @@ public interface DatasourceMapper {
 			    <if test="password != null">password = #{password},</if>
 			    <if test="connectionUrl != null">connection_url = #{connectionUrl},</if>
 			    <if test="status != null">status = #{status},</if>
+			    <if test="schemas != null">`schemas` = #{schemas},</if>
 			    <if test="testStatus != null">test_status = #{testStatus},</if>
 			    <if test="description != null">description = #{description},</if>
 			    <if test="creatorId != null">creator_id = #{creatorId},</if>

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/DatasourceService.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/DatasourceService.java
@@ -77,6 +77,8 @@ public interface DatasourceService {
 
 	List<String> getDatasourceTables(Integer datasourceId) throws Exception;
 
+	List<String> getAllSchemasTables(Integer datasourceId) throws Exception;
+
 	/**
 	 * 获取数据源表的字段列表
 	 */

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/handler/DatasourceTypeHandler.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/handler/DatasourceTypeHandler.java
@@ -20,6 +20,8 @@ import com.alibaba.cloud.ai.dataagent.bo.DbConfigBO;
 import com.alibaba.cloud.ai.dataagent.entity.Datasource;
 import org.springframework.util.StringUtils;
 
+import java.util.Arrays;
+
 public interface DatasourceTypeHandler {
 
 	String typeName();
@@ -64,6 +66,15 @@ public interface DatasourceTypeHandler {
 		config.setConnectionType(connectionType());
 		config.setDialectType(dialectType());
 		config.setSchema(extractSchemaName(datasource));
+		if (StringUtils.hasText(datasource.getSchemas())) {
+			config.setSchemas(Arrays.stream(datasource.getSchemas().split(","))
+					.map(String::trim)
+					.filter(s -> !s.isEmpty())
+					.collect(java.util.stream.Collectors.toList()));
+		}
+		else {
+			config.setSchemas(java.util.List.of(datasource.getDatabaseName()));
+		}
 		return config;
 	}
 

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/impl/AgentDatasourceServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/impl/AgentDatasourceServiceImpl.java
@@ -19,6 +19,8 @@ import com.alibaba.cloud.ai.dataagent.bo.DbConfigBO;
 import com.alibaba.cloud.ai.dataagent.dto.datasource.SchemaInitRequest;
 import com.alibaba.cloud.ai.dataagent.entity.AgentDatasource;
 import com.alibaba.cloud.ai.dataagent.entity.Datasource;
+import com.alibaba.cloud.ai.dataagent.exception.InternalServerException;
+import com.alibaba.cloud.ai.dataagent.exception.InvalidInputException;
 import com.alibaba.cloud.ai.dataagent.mapper.AgentDatasourceMapper;
 import com.alibaba.cloud.ai.dataagent.mapper.AgentDatasourceTablesMapper;
 import com.alibaba.cloud.ai.dataagent.service.datasource.AgentDatasourceService;
@@ -141,11 +143,27 @@ public class AgentDatasourceServiceImpl implements AgentDatasourceService {
 
 	@Override
 	public AgentDatasource toggleDatasourceForAgent(Long agentId, Integer datasourceId, Boolean isActive) {
-		// If enabling data source, first check if there are other enabled data sources
+		// 如果要激活数据源，需要检查该数据源是否与当前激活的数据源属于同一物理实例，防止多数据源情况下跨实例调用报错
 		if (isActive) {
-			int activeCount = agentDatasourceMapper.countActiveByAgentIdExcluding(agentId, datasourceId);
-			if (activeCount > 0) {
-				throw new RuntimeException("同一智能体下只能启用一个数据源，请先禁用其他数据源后再启用此数据源");
+			Datasource targetDs = datasourceService.getDatasourceById(datasourceId);
+			if (targetDs != null) {
+				String targetHost = (targetDs.getHost() != null ? targetDs.getHost() : "");
+				Integer targetPort = targetDs.getPort();
+				String targetType = (targetDs.getType() != null ? targetDs.getType() : "");
+
+				List<AgentDatasource> existings = getAgentDatasource(agentId);
+				for (AgentDatasource existing : existings) {
+					if (existing.getIsActive() != 0 && !existing.getDatasourceId().equals(datasourceId) && existing.getDatasource() != null) {
+						Datasource activeDs = existing.getDatasource();
+						String activeHost = (activeDs.getHost() != null ? activeDs.getHost() : "");
+						Integer activePort = activeDs.getPort();
+						String activeType = (activeDs.getType() != null ? activeDs.getType() : "");
+
+						if (!targetHost.equals(activeHost) || !java.util.Objects.equals(targetPort, activePort) || !targetType.equals(activeType)) {
+							throw new InvalidInputException("同一智能体下仅允许激活属于同一数据库实例(主机、端口、引擎一致)的数据源。当前已激活异构源：" + activeHost + ":" + activePort);
+						}
+					}
+				}
 			}
 		}
 

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/impl/DatasourceServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/impl/DatasourceServiceImpl.java
@@ -34,6 +34,7 @@ import com.alibaba.cloud.ai.dataagent.service.datasource.DatasourceService;
 import com.alibaba.cloud.ai.dataagent.service.datasource.handler.DatasourceTypeHandler;
 import com.alibaba.cloud.ai.dataagent.service.datasource.handler.registry.DatasourceTypeHandlerRegistry;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -228,27 +229,62 @@ public class DatasourceServiceImpl implements DatasourceService {
 		// Create database configuration
 		DbConfigBO dbConfig = getDbConfig(datasource);
 
-		// Create query parameters
-		DbQueryParameter queryParam = DbQueryParameter.from(dbConfig);
-
-		// 提取schema名称
-		DatasourceTypeHandler handler = datasourceTypeHandlerRegistry.getRequired(datasource.getType());
-		String schemaName = handler.extractSchemaName(datasource);
-		queryParam.setSchema(schemaName);
-
 		// Query table list
 		Accessor dbAccessor = accessorFactory.getAccessorByDbConfig(dbConfig);
-		List<TableInfoBO> tableInfoList = dbAccessor.showTables(dbConfig, queryParam);
+		List<String> allTableNames = new ArrayList<>();
 
-		// Extract table names
-		List<String> tableNames = tableInfoList.stream()
-			.map(TableInfoBO::getName)
-			.filter(name -> name != null && !name.trim().isEmpty())
-			.sorted()
-			.toList();
+		// 遍历所有 schema，使用 schema.table 格式与向量库保持一致
+		List<String> schemasToProcess = (dbConfig.getSchemas() != null && !dbConfig.getSchemas().isEmpty())
+				? dbConfig.getSchemas()
+				: java.util.List.of(dbConfig.getSchema());
 
-		log.info("Found {} tables for datasource: {}", tableNames.size(), datasourceId);
-		return tableNames;
+		for (String schema : schemasToProcess) {
+			DbQueryParameter queryParam = DbQueryParameter.from(dbConfig).setSchema(schema);
+			List<TableInfoBO> tableInfoList = dbAccessor.showTables(dbConfig, queryParam);
+			List<String> tableNames = tableInfoList.stream()
+				.map(TableInfoBO::getName)
+				.filter(name -> name != null && !name.trim().isEmpty())
+				.map(name -> schema + "." + name)
+				.sorted()
+				.toList();
+			allTableNames.addAll(tableNames);
+		}
+
+		log.info("Found {} tables for datasource: {}", allTableNames.size(), datasourceId);
+		return allTableNames;
+	}
+
+	@Override
+	public List<String> getAllSchemasTables(Integer datasourceId) throws Exception {
+		log.info("Getting aggregated tables from all active datasources to act as cross-schema targets.");
+		
+		List<String> allTableNames = new ArrayList<>();
+		
+		// 1. 查找所有开启了活跃状态的业务配置数据源
+		List<Datasource> activeDatasources = this.getDatasourceByStatus("active");
+		if (activeDatasources == null || activeDatasources.isEmpty()) {
+			return this.getDatasourceTables(datasourceId);
+		}
+		
+		Set<String> uniqueTables = new HashSet<>();
+		// 2. 借用原生针对单数据源的安全拉取功能，遍历拼装出平台级白名单可用的多库大集合
+		for (Datasource ds : activeDatasources) {
+			try {
+				List<String> dsTables = this.getDatasourceTables(ds.getId());
+				if (dsTables != null) {
+					uniqueTables.addAll(dsTables);
+				}
+			} catch (Exception e) {
+				log.warn("Failed to get tables for datasource: {} - {} when aggregating active tables", 
+						ds.getId(), ds.getName(), e);
+			}
+		}
+
+		allTableNames.addAll(uniqueTables);
+		Collections.sort(allTableNames);
+		
+		log.info("Aggregated {} distinct tables across {} active datasources.", allTableNames.size(), activeDatasources.size());
+		return allTableNames;
 	}
 
 	@Override
@@ -274,11 +310,15 @@ public class DatasourceServiceImpl implements DatasourceService {
 		DbQueryParameter queryParam = DbQueryParameter.from(dbConfig);
 
 		// 提取schema名称
-		DatasourceTypeHandler handler = datasourceTypeHandlerRegistry.getRequired(datasource.getType());
-		String schemaName = handler.extractSchemaName(datasource);
-		queryParam.setSchema(schemaName);
-		queryParam.setTable(tableName);
-
+		String actualTableName = tableName;
+		String actualSchema = datasource.getDatabaseName();
+		if (tableName.contains(".")){
+			String[] split = tableName.split("\\.", 2);
+			actualSchema = split[0];
+			actualTableName = split[1];
+		}
+		queryParam.setSchema(actualSchema);
+		queryParam.setTable(actualTableName);
 		// 查询字段列表
 		Accessor dbAccessor = accessorFactory.getAccessorByDbConfig(dbConfig);
 		List<ColumnInfoBO> columnInfoList = dbAccessor.showColumns(dbConfig, queryParam); // 提取字段名称

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/schema/SchemaService.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/schema/SchemaService.java
@@ -31,7 +31,7 @@ public interface SchemaService {
 	void extractDatabaseName(SchemaDTO schemaDTO, DbConfigBO dbConfig);
 
 	void buildSchemaFromDocuments(String agentId, List<Document> columnDocumentList, List<Document> tableDocuments,
-			SchemaDTO schemaDTO);
+			SchemaDTO schemaDTO, List<String> extraForeignKeys);
 
 	List<Document> getTableDocuments(Integer datasourceId, List<String> tableNames);
 

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/schema/SchemaServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/schema/SchemaServiceImpl.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.cloud.ai.dataagent.service.schema;
 
+import com.alibaba.cloud.ai.dataagent.bo.schema.ColumnInfoBO;
 import com.alibaba.cloud.ai.dataagent.connector.DbQueryParameter;
 import com.alibaba.cloud.ai.dataagent.bo.schema.ForeignKeyInfoBO;
 import com.alibaba.cloud.ai.dataagent.bo.schema.TableInfoBO;
@@ -42,6 +43,7 @@ import org.springframework.ai.embedding.BatchingStrategy;
 import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.filter.Filter;
 import org.springframework.ai.vectorstore.filter.FilterExpressionBuilder;
+import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
@@ -83,7 +85,7 @@ public class SchemaServiceImpl implements SchemaService {
 
 	@Override
 	public void buildSchemaFromDocuments(String agentId, List<Document> currentColumnDocuments,
-			List<Document> tableDocuments, SchemaDTO schemaDTO) {
+			List<Document> tableDocuments, SchemaDTO schemaDTO, List<String> extraForeignKeys) {
 
 		// 创建可变列表副本，避免不可变集合异常
 		List<Document> mutableColumnDocuments = new ArrayList<>(currentColumnDocuments);
@@ -102,6 +104,21 @@ public class SchemaServiceImpl implements SchemaService {
 		// 将包含"订单表.订单ID"和"订单详情表.订单ID"
 		Set<String> relatedNamesFromForeignKeys = extractRelatedNamesFromForeignKeys(mutableTableDocuments);
 
+		// 将额外的外键信息（例如逻辑虚拟外键）一并纳入提取
+		if (extraForeignKeys != null) {
+			for (String fk : extraForeignKeys) {
+				if (StringUtils.isNotBlank(fk)) {
+					Arrays.stream(fk.split("、")).forEach(pair -> {
+						String[] parts = pair.split("=");
+						if (parts.length == 2) {
+							relatedNamesFromForeignKeys.add(parts[0].trim());
+							relatedNamesFromForeignKeys.add(parts[1].trim());
+						}
+					});
+				}
+			}
+		}
+
 		// 通过外键加载缺失的表和列
 		List<String> missingTables = getMissingTableNamesWithForeignKeySet(mutableTableDocuments,
 				relatedNamesFromForeignKeys);
@@ -119,7 +136,10 @@ public class SchemaServiceImpl implements SchemaService {
 		schemaDTO.setTable(tableList);
 
 		Set<String> foreignKeys = tableDocuments.stream()
-			.map(doc -> (String) doc.getMetadata().getOrDefault("foreignKey", ""))
+			.map(doc -> {
+				Object fk = doc.getMetadata().getOrDefault("foreignKey", "");
+				return fk != null ? fk.toString() : "";
+			})
 			.flatMap(fk -> Arrays.stream(fk.split("、")))
 			.filter(StringUtils::isNotBlank)
 			.collect(Collectors.toSet());
@@ -130,48 +150,82 @@ public class SchemaServiceImpl implements SchemaService {
 	public Boolean schema(Integer datasourceId, SchemaInitRequest schemaInitRequest) throws Exception {
 		log.info("Starting schema initialization for datasource: {}", datasourceId);
 		DbConfigBO config = schemaInitRequest.getDbConfig();
-		DbQueryParameter dqp = DbQueryParameter.from(config)
-			.setSchema(config.getSchema())
-			.setTables(schemaInitRequest.getTables());
+		// 将前端传入的表按 schema 归类
+		Map<String, List<String>> schemaToTables = new HashMap<>();
+		// 解析 "schema.table" 格式，按 schema 分组
+		for (String rawTable : schemaInitRequest.getTables()) {
+			String schemaName = config.getSchema();
+			String tableName = rawTable;
+			if (rawTable.contains(".")) {
+				String[] split = rawTable.split("\\.", 2);
+				schemaName = split[0];
+				tableName = split[1];
+			}
+			schemaToTables.computeIfAbsent(schemaName, k -> new ArrayList<>()).add(tableName);
+		}
 
 		try {
 			// 根据当前DbConfig获取Accessor
 			Accessor dbAccessor = accessorFactory.getAccessorByDbConfig(config);
-
 			// 清理旧数据
 			log.info("Clearing existing schema data for datasource: {}", datasourceId);
 			clearSchemaDataForDatasource(datasourceId);
 			log.debug("Successfully cleared existing schema data for datasource: {}", datasourceId);
+			List<TableInfoBO> allTables = new ArrayList<>();
+			for (Map.Entry<String, List<String>> entry : schemaToTables.entrySet()) {
+				String schemaName = entry.getKey();
+				List<String> tableNamesForSchema = entry.getValue();
 
-			// 处理外键
-			log.debug("Fetching foreign keys for datasource: {}", datasourceId);
-			List<ForeignKeyInfoBO> foreignKeys = dbAccessor.showForeignKeys(config, dqp);
-			log.info("Found {} foreign keys for datasource: {}", foreignKeys.size(), datasourceId);
+				// 复制一个带有特定 schema 的配置对象
+				DbConfigBO currentSchemaConfig = new DbConfigBO();
+				BeanUtils.copyProperties(config, currentSchemaConfig);
+				currentSchemaConfig.setSchema(schemaName);
+				DbQueryParameter dqp = DbQueryParameter.from(currentSchemaConfig)
+						.setSchema(schemaName)
+						.setTables(tableNamesForSchema);
+				// 处理外键
+				log.debug("Fetching foreign keys for datasource: {}", datasourceId);
+				List<ForeignKeyInfoBO> foreignKeys = dbAccessor.showForeignKeys(currentSchemaConfig, dqp);
+				log.info("Found {} foreign keys for datasource: {}", foreignKeys.size(), datasourceId);
+				// 外键 map 的 key 需要使用 schema.table 格式，与后续表名前缀保持一致
+				Map<String, List<String>> foreignKeyMap = buildForeignKeyMap(foreignKeys, schemaName);
+				log.debug("Built foreign key map with {} entries for datasource: {}", foreignKeyMap.size(), datasourceId);
 
-			Map<String, List<String>> foreignKeyMap = buildForeignKeyMap(foreignKeys);
-			log.debug("Built foreign key map with {} entries for datasource: {}", foreignKeyMap.size(), datasourceId);
+				// 处理表和列
+				log.debug("Fetching tables for datasource: {}", datasourceId);
+				List<TableInfoBO> tables = dbAccessor.fetchTables(currentSchemaConfig, dqp);
+				log.info("Found {} tables for datasource: {}", tables.size(), datasourceId);
 
-			// 处理表和列
-			log.debug("Fetching tables for datasource: {}", datasourceId);
-			List<TableInfoBO> tables = dbAccessor.fetchTables(config, dqp);
-			log.info("Found  tables for datasource: {}", tables.size(), datasourceId);
-
-			if (tables.size() > 5) {
-				// 对于大量表，使用并行处理
-				log.info("Processing {} tables in parallel mode for datasource: {}", tables.size(), datasourceId);
-				processTablesInParallel(tables, config, foreignKeyMap);
-			}
-			else {
-				// 对于少量表，使用批量处理
-				log.info("Processing {} tables in batch mode for datasource: {}", tables.size(), datasourceId);
-				tableMetadataService.batchEnrichTableMetadata(tables, config, foreignKeyMap);
+				if (tables.size() > 5) {
+					// 对于大量表，使用并行处理
+					log.info("Processing {} tables in parallel mode for datasource: {}", tables.size(), datasourceId);
+					processTablesInParallel(tables, currentSchemaConfig, foreignKeyMap);
+				}
+				else {
+					// 对于少量表，使用批量处理
+					log.info("Processing {} tables in batch mode for datasource: {}", tables.size(), datasourceId);
+					tableMetadataService.batchEnrichTableMetadata(tables, currentSchemaConfig, foreignKeyMap);
+				}
+				// 将带有 schema 的表名和相关列的归属表名更新，方便存储到向量库中
+				if (StringUtils.isNotBlank(schemaName)) {
+					for (TableInfoBO table : tables) {
+						String fullName = schemaName + "." + table.getName();
+						table.setName(fullName);
+						if (table.getColumns() != null) {
+							for (ColumnInfoBO column : table.getColumns()) {
+								column.setTableName(fullName);
+							}
+						}
+					}
+				}
+				allTables.addAll(tables);
 			}
 
 			log.info("Successfully processed all tables for datasource: {}", datasourceId);
 
 			// 转换为文档
-			List<Document> columnDocs = convertColumnsToDocuments(datasourceId, tables);
-			List<Document> tableDocs = convertTablesToDocuments(datasourceId, tables);
+			List<Document> columnDocs = convertColumnsToDocuments(datasourceId,allTables);
+			List<Document> tableDocs = convertTablesToDocuments(datasourceId, allTables);
 
 			// 存储文档
 			log.info("Storing  columns and {} tables for datasource: {}", columnDocs.size(), tableDocs.size(),
@@ -260,13 +314,24 @@ public class SchemaServiceImpl implements SchemaService {
 	}
 
 	protected Map<String, List<String>> buildForeignKeyMap(List<ForeignKeyInfoBO> foreignKeys) {
-		Map<String, List<String>> map = new HashMap<>();
-		for (ForeignKeyInfoBO fk : foreignKeys) {
-			String key = fk.getTable() + "." + fk.getColumn() + "=" + fk.getReferencedTable() + "."
-					+ fk.getReferencedColumn();
+		return buildForeignKeyMap(foreignKeys, null);
+	}
 
-			map.computeIfAbsent(fk.getTable(), k -> new ArrayList<>()).add(key);
-			map.computeIfAbsent(fk.getReferencedTable(), k -> new ArrayList<>()).add(key);
+	/**
+	 * 构建外键映射，key 使用 schema.table 格式（与向量库表名保持一致）
+	 * @param foreignKeys 外键列表
+	 * @param schemaName schema 名称（为非空时，table 名前加 schema. 前缀）
+	 */
+	protected Map<String, List<String>> buildForeignKeyMap(List<ForeignKeyInfoBO> foreignKeys, String schemaName) {
+		Map<String, List<String>> map = new HashMap<>();
+		boolean hasSchema = StringUtils.isNotBlank(schemaName);
+		for (ForeignKeyInfoBO fk : foreignKeys) {
+			String table = hasSchema ? schemaName + "." + fk.getTable() : fk.getTable();
+			String refTable = hasSchema ? schemaName + "." + fk.getReferencedTable() : fk.getReferencedTable();
+			String key = table + "." + fk.getColumn() + "=" + refTable + "." + fk.getReferencedColumn();
+
+			map.computeIfAbsent(table, k -> new ArrayList<>()).add(key);
+			map.computeIfAbsent(refTable, k -> new ArrayList<>()).add(key);
 		}
 		return map;
 	}
@@ -317,9 +382,11 @@ public class SchemaServiceImpl implements SchemaService {
 
 		Set<String> missingTables = new HashSet<>();
 		for (String key : foreignKeySet) {
-			String[] parts = key.split("\\.");
-			if (parts.length == 2) {
-				String tableName = parts[0];
+			// key 格式： schema.table.column 或 table.column
+			// 从最后一个点拆分，取左边得到表名（可能是 schema.table 或 table）
+			int lastDot = key.lastIndexOf('.');
+			if (lastDot > 0) {
+				String tableName = key.substring(0, lastDot);
 				if (!uniqueTableNames.contains(tableName)) {
 					missingTables.add(tableName);
 				}
@@ -483,7 +550,11 @@ public class SchemaServiceImpl implements SchemaService {
 			}
 		}
 		else if (BizDataSourceTypeEnum.isPgDialect(dbConfig.getDialectType())) {
-			schemaDTO.setName(dbConfig.getSchema());
+			if (dbConfig.getSchemas() != null && !dbConfig.getSchemas().isEmpty()) {
+				schemaDTO.setName(String.join(",", dbConfig.getSchemas()));
+			}else {
+				schemaDTO.setName(dbConfig.getSchema());
+			}
 		}
 	}
 

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/schema/TableMetadataService.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/schema/TableMetadataService.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -63,7 +64,7 @@ public class TableMetadataService {
 				tableColumnsMap);
 
 		// 3. 处理每个表的元数据
-		enrichTablesWithMetadata(tables, tableColumnsMap, allTablesSampleData, foreignKeyMap);
+		enrichTablesWithMetadata(tables, tableColumnsMap, allTablesSampleData, foreignKeyMap, dbConfig.getSchema());
 	}
 
 	/**
@@ -97,7 +98,8 @@ public class TableMetadataService {
 	 * @param foreignKeyMap 外键映射
 	 */
 	private void enrichTablesWithMetadata(List<TableInfoBO> tables, Map<String, List<ColumnInfoBO>> tableColumnsMap,
-			Map<String, Map<String, List<String>>> allTablesSampleData, Map<String, List<String>> foreignKeyMap) {
+			Map<String, Map<String, List<String>>> allTablesSampleData, Map<String, List<String>> foreignKeyMap,
+			String schemaName) {
 
 		for (TableInfoBO table : tables) {
 			List<ColumnInfoBO> columnInfoBOS = tableColumnsMap.get(table.getName());
@@ -111,7 +113,7 @@ public class TableMetadataService {
 			setTablePrimaryKeys(table, columnInfoBOS);
 
 			// 设置表的外键信息
-			setTableForeignKeys(table, foreignKeyMap);
+			setTableForeignKeys(table, foreignKeyMap, schemaName);
 		}
 	}
 
@@ -177,8 +179,19 @@ public class TableMetadataService {
 	 * @param table 表信息
 	 * @param foreignKeyMap 外键映射
 	 */
-	private void setTableForeignKeys(TableInfoBO table, Map<String, List<String>> foreignKeyMap) {
-		List<String> foreignKeys = foreignKeyMap.getOrDefault(table.getName(), new ArrayList<>());
+	private void setTableForeignKeys(TableInfoBO table, Map<String, List<String>> foreignKeyMap, String schemaName) {
+		// foreignKeyMap 在 SchemaServiceImpl 中通常使用 schema.table 作为 key，这里需要对齐查询口径
+		String rawTableName = table.getName();
+		List<String> foreignKeys = new ArrayList<>();
+		if (foreignKeyMap != null) {
+			if (StringUtils.isNotBlank(schemaName)) {
+				foreignKeys = foreignKeyMap.getOrDefault(schemaName + "." + rawTableName,
+						foreignKeyMap.getOrDefault(rawTableName, new ArrayList<>()));
+			}
+			else {
+				foreignKeys = foreignKeyMap.getOrDefault(rawTableName, new ArrayList<>());
+			}
+		}
 		table.setForeignKey(String.join("、", foreignKeys));
 	}
 

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/SchemaRecallNode.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/SchemaRecallNode.java
@@ -67,10 +67,10 @@ public class SchemaRecallNode implements NodeAction {
 		String input = queryEnhanceOutputDTO.getCanonicalQuery();
 		String agentId = StateUtil.getStringValue(state, AGENT_ID);
 
-		// 查询 Agent 的激活数据源
-		Integer datasourceId = agentDatasourceMapper.selectActiveDatasourceIdByAgentId(Long.valueOf(agentId));
+		// 查询 Agent 的所有激活数据源
+		List<Integer> datasourceIds = agentDatasourceMapper.selectActiveDatasourceIdsByAgentId(Long.valueOf(agentId));
 
-		if (datasourceId == null) {
+		if (datasourceIds == null || datasourceIds.isEmpty()) {
 			log.warn("Agent {} has no active datasource", agentId);
 			// 返回空结果
 			String noDataSourceMessage = """
@@ -98,11 +98,22 @@ public class SchemaRecallNode implements NodeAction {
 		}
 
 		// Execute business logic first - recall schema information immediately
-		List<Document> tableDocuments = new ArrayList<>(
-				schemaService.getTableDocumentsByDatasource(datasourceId, input));
-		// extract table names
-		List<String> recalledTableNames = extractTableName(tableDocuments);
-		List<Document> columnDocuments = schemaService.getColumnDocumentsByTableName(datasourceId, recalledTableNames);
+		List<Document> tableDocuments = new ArrayList<>();
+		List<String> recalledTableNames = new ArrayList<>();
+		List<Document> columnDocuments = new ArrayList<>();
+
+		for (Integer datasourceId : datasourceIds) {
+			List<Document> currentTableDocs = schemaService.getTableDocumentsByDatasource(datasourceId, input);
+			tableDocuments.addAll(currentTableDocs);
+
+			List<String> currentTableNames = extractTableName(currentTableDocs);
+			recalledTableNames.addAll(currentTableNames);
+
+			if (!currentTableNames.isEmpty()) {
+				List<Document> currentColumnDocs = schemaService.getColumnDocumentsByTableName(datasourceId, currentTableNames);
+				columnDocuments.addAll(currentColumnDocs);
+			}
+		}
 
 		String failMessage = """
 				\n 未检索到相关数据表

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/TableRelationNode.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/TableRelationNode.java
@@ -164,7 +164,7 @@ public class TableRelationNode implements NodeAction {
 		SchemaDTO schemaDTO = new SchemaDTO();
 
 		schemaService.extractDatabaseName(schemaDTO, agentDbConfig);
-		schemaService.buildSchemaFromDocuments(agentId, columnDocuments, tableDocuments, schemaDTO);
+		schemaService.buildSchemaFromDocuments(agentId, columnDocuments, tableDocuments, schemaDTO, logicalForeignKeys);
 
 		// 将逻辑外键信息合并到 schemaDTO 的 foreignKeys 字段
 		if (logicalForeignKeys != null && !logicalForeignKeys.isEmpty()) {

--- a/data-agent-management/src/main/resources/sql/schema.sql
+++ b/data-agent-management/src/main/resources/sql/schema.sql
@@ -106,6 +106,7 @@ CREATE TABLE IF NOT EXISTS datasource (
   connection_url VARCHAR(1000) COMMENT '完整连接URL',
   status VARCHAR(50) DEFAULT 'inactive' COMMENT '状态：active-启用，inactive-禁用',
   test_status VARCHAR(50) DEFAULT 'unknown' COMMENT '连接测试状态：success-成功，failed-失败，unknown-未知',
+  schemas VARCHAR(1000) COMMENT '配置的schemas(逗号隔开)'
   description TEXT COMMENT '描述',
   creator_id BIGINT COMMENT '创建者ID',
   create_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',


### PR DESCRIPTION
### Describe what this PR does / why we need it
支持在同一物理实例下为一个智能体激活并配置多个 Schema（或 Database），并实现了跨 Schema 的查询与关联。统一使用 schema.table 作为逻辑外键与向量存储的唯一标识。

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1.后端新增 /{id}/all-tables 接口返回已激活数据源的合规表库；前端外键配置在目标表下拉列表中调用该全集接口，实现跨 Schema 的表选项加载。
2.在 SchemaService 的二次补全流程中增加对跨库虚拟外键实体的提取和解析；全局统一使用 schema.table 作为表和特征向量的主键认知标准。
3.将 AgentDatasourceMapper.selectActiveDatasourceIdByAgentId 接口重构为返回 List<Integer>。将 SchemaRecallNode
 的处理逻辑改为循环遍历并合并（addAll）所有活跃数据源的文档信息。
4. AgentDatasourceServiceImpl.toggleDatasourceForAgent 中校验，若检测到 Host/Port/Type 与已有活跃数据源不一致的连接，则抛出异常阻断，避免 JDBC 本地跨网段报错。
5. datasource表中新增schemas字段，对于mysql来讲database==schema,但pg和oracle中一个database中含有多个schema,我们将多个schema合并成schema1,schema2形式存入数据库中，后续按照,进行分割

### Describe how to verify it


### Special notes for reviews
由于当前单机 JDBC 暂不支持诸如数据湖级别的跨主机异构下推，通过比对 Host/Port 实施前置阻断是防止执行器崩溃的必要规避方案。同时需注意 schema.table 格式在所有历史存量数据访问中的兼容性。

