### PR TITLE
fix(schema): 使用 query 进行表向量召回 

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/schema/SchemaServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/schema/SchemaServiceImpl.java
@@ -306,7 +306,7 @@ public class SchemaServiceImpl implements SchemaService {
 			.filterExpression(filterExpression)
 			.build();
 
-		return agentVectorStoreService.getDocumentsOnlyByFilter(filterExpression, tableTopK);
+		return agentVectorStoreService.similaritySearch(searchRequest);
 	}
 
 	private List<String> getMissingTableNamesWithForeignKeySet(List<Document> tableDocuments,

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/AgentVectorStoreService.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/AgentVectorStoreService.java
@@ -17,6 +17,7 @@ package com.alibaba.cloud.ai.dataagent.service.vectorstore;
 
 import com.alibaba.cloud.ai.dataagent.dto.search.AgentSearchRequest;
 import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.filter.Filter;
 
 import java.util.List;
@@ -41,6 +42,8 @@ public interface AgentVectorStoreService {
 	List<Document> getDocumentsForAgent(String agentId, String query, String vectorType);
 
 	List<Document> getDocumentsForAgent(String agentId, String query, String vectorType, int topK, double threshold);
+
+	List<Document> similaritySearch(SearchRequest searchRequest);
 
 	// 通过元数据过滤精确查找
 	List<Document> getDocumentsOnlyByFilter(Filter.Expression filterExpression, Integer topK);

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/AgentVectorStoreServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/AgentVectorStoreServiceImpl.java
@@ -228,6 +228,12 @@ public class AgentVectorStoreServiceImpl implements AgentVectorStoreService {
 	}
 
 	@Override
+	public List<Document> similaritySearch(SearchRequest searchRequest) {
+		Assert.notNull(searchRequest, "searchRequest cannot be null.");
+		return vectorStore.similaritySearch(searchRequest);
+	}
+
+	@Override
 	public List<Document> getDocumentsOnlyByFilter(Filter.Expression filterExpression, Integer topK) {
 		Assert.notNull(filterExpression, "filterExpression cannot be null.");
 		if (topK == null)

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/schema/SchemaServiceImplTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/schema/SchemaServiceImplTest.java
@@ -34,97 +34,97 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class SchemaServiceImplTest {
 
-    private SchemaServiceImpl schemaService;
+	private SchemaServiceImpl schemaService;
 
-    private RecordingAgentVectorStoreService agentVectorStoreService;
+	private RecordingAgentVectorStoreService agentVectorStoreService;
 
-    @BeforeEach
-    void setUp() {
-        DataAgentProperties dataAgentProperties = new DataAgentProperties();
-        dataAgentProperties.getVectorStore().setTableTopkLimit(6);
-        dataAgentProperties.getVectorStore().setTableSimilarityThreshold(0.35);
-        agentVectorStoreService = new RecordingAgentVectorStoreService();
+	@BeforeEach
+	void setUp() {
+		DataAgentProperties dataAgentProperties = new DataAgentProperties();
+		dataAgentProperties.getVectorStore().setTableTopkLimit(6);
+		dataAgentProperties.getVectorStore().setTableSimilarityThreshold(0.35);
+		agentVectorStoreService = new RecordingAgentVectorStoreService();
 
-        schemaService = new SchemaServiceImpl(null, null, null, null, null, dataAgentProperties,
-                agentVectorStoreService);
-    }
+		schemaService = new SchemaServiceImpl(null, null, null, null, null, dataAgentProperties,
+				agentVectorStoreService);
+	}
 
-    @Test
-    void getTableDocumentsByDatasource_ShouldUseQueryInSimilaritySearch() {
-        Integer datasourceId = 42;
-        String query = "查询用户订单";
-        List<Document> expectedDocuments = List.of(new Document("orders table",
-                Map.of(DocumentMetadataConstant.NAME, "orders", Constant.DATASOURCE_ID, datasourceId.toString())));
-        agentVectorStoreService.documentsToReturn = expectedDocuments;
+	@Test
+	void getTableDocumentsByDatasource_ShouldUseQueryInSimilaritySearch() {
+		Integer datasourceId = 42;
+		String query = "查询用户订单";
+		List<Document> expectedDocuments = List.of(new Document("orders table",
+				Map.of(DocumentMetadataConstant.NAME, "orders", Constant.DATASOURCE_ID, datasourceId.toString())));
+		agentVectorStoreService.documentsToReturn = expectedDocuments;
 
-        List<Document> actualDocuments = schemaService.getTableDocumentsByDatasource(datasourceId, query);
+		List<Document> actualDocuments = schemaService.getTableDocumentsByDatasource(datasourceId, query);
 
-        assertEquals(expectedDocuments, actualDocuments);
-        assertNotNull(agentVectorStoreService.lastSearchRequest);
-        assertEquals(query, agentVectorStoreService.lastSearchRequest.getQuery());
-        assertEquals(6, agentVectorStoreService.lastSearchRequest.getTopK());
-        assertEquals(0.35, agentVectorStoreService.lastSearchRequest.getSimilarityThreshold());
-        assertNotNull(agentVectorStoreService.lastSearchRequest.getFilterExpression());
-    }
+		assertEquals(expectedDocuments, actualDocuments);
+		assertNotNull(agentVectorStoreService.lastSearchRequest);
+		assertEquals(query, agentVectorStoreService.lastSearchRequest.getQuery());
+		assertEquals(6, agentVectorStoreService.lastSearchRequest.getTopK());
+		assertEquals(0.35, agentVectorStoreService.lastSearchRequest.getSimilarityThreshold());
+		assertNotNull(agentVectorStoreService.lastSearchRequest.getFilterExpression());
+	}
 
-    private static final class RecordingAgentVectorStoreService implements AgentVectorStoreService {
+	private static final class RecordingAgentVectorStoreService implements AgentVectorStoreService {
 
-        private SearchRequest lastSearchRequest;
+		private SearchRequest lastSearchRequest;
 
-        private List<Document> documentsToReturn = List.of();
+		private List<Document> documentsToReturn = List.of();
 
-        @Override
-        public List<Document> search(AgentSearchRequest searchRequest) {
-            throw new UnsupportedOperationException();
-        }
+		@Override
+		public List<Document> search(AgentSearchRequest searchRequest) {
+			throw new UnsupportedOperationException();
+		}
 
-        @Override
-        public Boolean deleteDocumentsByVectorType(String agentId, String vectorType) {
-            throw new UnsupportedOperationException();
-        }
+		@Override
+		public Boolean deleteDocumentsByVectorType(String agentId, String vectorType) {
+			throw new UnsupportedOperationException();
+		}
 
-        @Override
-        public Boolean deleteDocumentsByMetedata(String agentId, Map<String, Object> metadata) {
-            throw new UnsupportedOperationException();
-        }
+		@Override
+		public Boolean deleteDocumentsByMetedata(String agentId, Map<String, Object> metadata) {
+			throw new UnsupportedOperationException();
+		}
 
-        @Override
-        public Boolean deleteDocumentsByMetadata(Map<String, Object> metadata) {
-            throw new UnsupportedOperationException();
-        }
+		@Override
+		public Boolean deleteDocumentsByMetadata(Map<String, Object> metadata) {
+			throw new UnsupportedOperationException();
+		}
 
-        @Override
-        public List<Document> getDocumentsForAgent(String agentId, String query, String vectorType) {
-            throw new UnsupportedOperationException();
-        }
+		@Override
+		public List<Document> getDocumentsForAgent(String agentId, String query, String vectorType) {
+			throw new UnsupportedOperationException();
+		}
 
-        @Override
-        public List<Document> getDocumentsForAgent(String agentId, String query, String vectorType, int topK,
-                double threshold) {
-            throw new UnsupportedOperationException();
-        }
+		@Override
+		public List<Document> getDocumentsForAgent(String agentId, String query, String vectorType, int topK,
+				double threshold) {
+			throw new UnsupportedOperationException();
+		}
 
-        @Override
-        public List<Document> similaritySearch(SearchRequest searchRequest) {
-            this.lastSearchRequest = searchRequest;
-            return documentsToReturn;
-        }
+		@Override
+		public List<Document> similaritySearch(SearchRequest searchRequest) {
+			this.lastSearchRequest = searchRequest;
+			return documentsToReturn;
+		}
 
-        @Override
-        public List<Document> getDocumentsOnlyByFilter(Filter.Expression filterExpression, Integer topK) {
-            throw new UnsupportedOperationException();
-        }
+		@Override
+		public List<Document> getDocumentsOnlyByFilter(Filter.Expression filterExpression, Integer topK) {
+			throw new UnsupportedOperationException();
+		}
 
-        @Override
-        public boolean hasDocuments(String agentId) {
-            throw new UnsupportedOperationException();
-        }
+		@Override
+		public boolean hasDocuments(String agentId) {
+			throw new UnsupportedOperationException();
+		}
 
-        @Override
-        public void addDocuments(String agentId, List<Document> documents) {
-            throw new UnsupportedOperationException();
-        }
+		@Override
+		public void addDocuments(String agentId, List<Document> documents) {
+			throw new UnsupportedOperationException();
+		}
 
-    }
+	}
 
 }

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/schema/SchemaServiceImplTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/schema/SchemaServiceImplTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.service.schema;
+
+import com.alibaba.cloud.ai.dataagent.constant.Constant;
+import com.alibaba.cloud.ai.dataagent.constant.DocumentMetadataConstant;
+import com.alibaba.cloud.ai.dataagent.dto.search.AgentSearchRequest;
+import com.alibaba.cloud.ai.dataagent.properties.DataAgentProperties;
+import com.alibaba.cloud.ai.dataagent.service.vectorstore.AgentVectorStoreService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.filter.Filter;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class SchemaServiceImplTest {
+
+    private SchemaServiceImpl schemaService;
+
+    private RecordingAgentVectorStoreService agentVectorStoreService;
+
+    @BeforeEach
+    void setUp() {
+        DataAgentProperties dataAgentProperties = new DataAgentProperties();
+        dataAgentProperties.getVectorStore().setTableTopkLimit(6);
+        dataAgentProperties.getVectorStore().setTableSimilarityThreshold(0.35);
+        agentVectorStoreService = new RecordingAgentVectorStoreService();
+
+        schemaService = new SchemaServiceImpl(null, null, null, null, null, dataAgentProperties,
+                agentVectorStoreService);
+    }
+
+    @Test
+    void getTableDocumentsByDatasource_ShouldUseQueryInSimilaritySearch() {
+        Integer datasourceId = 42;
+        String query = "查询用户订单";
+        List<Document> expectedDocuments = List.of(new Document("orders table",
+                Map.of(DocumentMetadataConstant.NAME, "orders", Constant.DATASOURCE_ID, datasourceId.toString())));
+        agentVectorStoreService.documentsToReturn = expectedDocuments;
+
+        List<Document> actualDocuments = schemaService.getTableDocumentsByDatasource(datasourceId, query);
+
+        assertEquals(expectedDocuments, actualDocuments);
+        assertNotNull(agentVectorStoreService.lastSearchRequest);
+        assertEquals(query, agentVectorStoreService.lastSearchRequest.getQuery());
+        assertEquals(6, agentVectorStoreService.lastSearchRequest.getTopK());
+        assertEquals(0.35, agentVectorStoreService.lastSearchRequest.getSimilarityThreshold());
+        assertNotNull(agentVectorStoreService.lastSearchRequest.getFilterExpression());
+    }
+
+    private static final class RecordingAgentVectorStoreService implements AgentVectorStoreService {
+
+        private SearchRequest lastSearchRequest;
+
+        private List<Document> documentsToReturn = List.of();
+
+        @Override
+        public List<Document> search(AgentSearchRequest searchRequest) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Boolean deleteDocumentsByVectorType(String agentId, String vectorType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Boolean deleteDocumentsByMetedata(String agentId, Map<String, Object> metadata) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Boolean deleteDocumentsByMetadata(Map<String, Object> metadata) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<Document> getDocumentsForAgent(String agentId, String query, String vectorType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<Document> getDocumentsForAgent(String agentId, String query, String vectorType, int topK,
+                double threshold) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<Document> similaritySearch(SearchRequest searchRequest) {
+            this.lastSearchRequest = searchRequest;
+            return documentsToReturn;
+        }
+
+        @Override
+        public List<Document> getDocumentsOnlyByFilter(Filter.Expression filterExpression, Integer topK) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean hasDocuments(String agentId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addDocuments(String agentId, List<Document> documents) {
+            throw new UnsupportedOperationException();
+        }
+
+    }
+
+}


### PR DESCRIPTION
  ### Describe what this PR does / why we need it                                                                                                                                                        
                                                                                                                                                                                                         
  修复表 Schema 召回时未实际使用用户 `query` 的问题。                                                                                                                                                    
                                                                                                                                                                                                         
  此前虽然构建了包含 `query` 的 `SearchRequest`，但实际执行的是仅按 metadata 过滤的查询路径，导致会召回当前数据源下的全部表，而不是与用户问题相关的表。                                                  
                                                                                                                                                                                                         
  ### Does this pull request fix one issue?                                                                                                                                                              
                                                                                                                                                                                                         
  Yes. Closes #478                                                                                                                                                                                       
                                                                                                                                                                                                         
  ### Describe how you did it                                                                                                                                                                            
                                                                                                                                                                                                         
  1. 修复 `SchemaServiceImpl#getTableDocumentsByDatasource(...)` 的调用逻辑，使表召回实际执行带 `query` 的向量相似度检索。                                                                               
  2. 新增 `AgentVectorStoreService#similaritySearch(SearchRequest)` 接口。                                                                                                                               
  3. 在 `AgentVectorStoreServiceImpl` 中补充对应实现。                                                                                                                                                   
  4. 新增回归测试 `SchemaServiceImplTest`，验证表召回会正确使用用户 `query`。                                                                                                                            
                                                                                                                                                                                                         
  ### Describe how to verify it                                                                                                                                                                          
                                                                                                                                                                                                         
  运行以下命令：                                                                                                                                                                                         
                                                                                                                                                                                                         
  ```bash                                                                                                                                                                                                
  cmd /c mvnw.cmd -pl data-agent-management -Dtest=SchemaServiceImplTest test                                                                                                                            
                                                                                                                                                                                                         
  验证点：                                                                                                                                                                                               
                                                                                                                                                                                                         
  - 测试通过。                                                                                                                                                                                           
  - 表 Schema 召回会使用用户 query，不再返回当前数据源下的全部表。                                                                                                                                       
                                                                                                                                                                                                         
  ### Special notes for reviews                                                                                                                                                                          
                                                                                                                                                                                                         
  本次修改仅影响表 Schema 的初步召回逻辑，不涉及列召回、知识库召回或多数据源管理逻辑。   