### PR TITLE
fix(security): prevent data exposure and path traversal; fix Mockito JDK 21 tests

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/controller/FileUploadController.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/controller/FileUploadController.java
@@ -22,7 +22,6 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -91,9 +90,20 @@ public class FileUploadController {
 			String requestMapPath = this.getClass().getAnnotation(RequestMapping.class).value()[0];
 			String requestPath = request.getPath().value();
 			String urlPrefix = fileStorageProperties.getUrlPrefix();
-			String filePath = requestPath.substring(requestMapPath.length() + urlPrefix.length());
+			String requestPrefix = requestMapPath + urlPrefix + "/";
+			if (!requestPath.startsWith(requestPrefix)) {
+				return ResponseEntity.badRequest().build();
+			}
+			String filePath = requestPath.substring(requestPrefix.length());
+			if (filePath.isBlank()) {
+				return ResponseEntity.badRequest().build();
+			}
 
-			Path fullPath = Paths.get(fileStorageProperties.getPath(), filePath);
+			Path basePath = fileStorageProperties.getLocalBasePath().toAbsolutePath().normalize();
+			Path fullPath = basePath.resolve(filePath).normalize();
+			if (!fullPath.startsWith(basePath)) {
+				return ResponseEntity.status(403).build();
+			}
 
 			if (!Files.exists(fullPath) || Files.isDirectory(fullPath)) {
 				return ResponseEntity.notFound().build();

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/entity/Agent.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/entity/Agent.java
@@ -16,6 +16,7 @@
 package com.alibaba.cloud.ai.dataagent.entity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -44,6 +45,7 @@ public class Agent {
 	private String status; // Status: draft-pending publication, published-published,
 							// offline-offline
 
+	@JsonIgnore
 	private String apiKey; // API Key for external access, format sk-xxx
 
 	@Builder.Default

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/entity/Datasource.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/entity/Datasource.java
@@ -16,6 +16,7 @@
 package com.alibaba.cloud.ai.dataagent.entity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -44,8 +45,10 @@ public class Datasource {
 
 	private String username;
 
+	@JsonIgnore
 	private String password;
 
+	@JsonIgnore
 	private String connectionUrl;
 
 	private String status;

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/controller/FileAndSerializationSecurityTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/controller/FileAndSerializationSecurityTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.controller;
+
+import com.alibaba.cloud.ai.dataagent.entity.Agent;
+import com.alibaba.cloud.ai.dataagent.entity.Datasource;
+import com.alibaba.cloud.ai.dataagent.properties.FileStorageProperties;
+import com.alibaba.cloud.ai.dataagent.service.file.FileStorageService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.multipart.FilePart;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.web.multipart.MultipartFile;
+import reactor.core.publisher.Mono;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FileAndSerializationSecurityTest {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@TempDir
+	Path tempDir;
+
+	@Test
+	void agentSerializationShouldHideApiKey() throws Exception {
+		Agent agent = Agent.builder().id(1L).name("demo").apiKey("sk-test-secret").apiKeyEnabled(1).build();
+
+		String json = objectMapper.writeValueAsString(agent);
+
+		assertFalse(json.contains("\"apiKey\":"));
+		assertFalse(json.contains("sk-test-secret"));
+		assertTrue(json.contains("apiKeyEnabled"));
+	}
+
+	@Test
+	void datasourceSerializationShouldHideCredentials() throws Exception {
+		Datasource datasource = Datasource.builder()
+			.id(1)
+			.name("mysql")
+			.username("root")
+			.password("secret")
+			.connectionUrl("jdbc:mysql://127.0.0.1:3306/test")
+			.build();
+
+		String json = objectMapper.writeValueAsString(datasource);
+
+		assertTrue(json.contains("username"));
+		assertFalse(json.contains("\"password\":"));
+		assertFalse(json.contains("\"connectionUrl\":"));
+		assertFalse(json.contains("jdbc:mysql://127.0.0.1:3306/test"));
+	}
+
+	@Test
+	void getFileShouldReturnFileWithinBasePath() throws Exception {
+		Path file = tempDir.resolve("avatars").resolve("ok.txt");
+		Files.createDirectories(file.getParent());
+		byte[] expected = "safe-content".getBytes(StandardCharsets.UTF_8);
+		Files.write(file, expected);
+
+		FileUploadController controller = new FileUploadController(buildFileStorageProperties(),
+				new NoopFileStorageService());
+		MockServerHttpRequest request = MockServerHttpRequest.get("/api/upload/uploads/avatars/ok.txt").build();
+
+		ResponseEntity<byte[]> response = controller.getFile(request);
+
+		assertEquals(200, response.getStatusCode().value());
+		assertArrayEquals(expected, response.getBody());
+	}
+
+	@Test
+	void getFileShouldBlockPathTraversal() throws Exception {
+		Path parentSecret = tempDir.getParent().resolve("secret.txt");
+		Files.write(parentSecret, "top-secret".getBytes(StandardCharsets.UTF_8));
+
+		FileUploadController controller = new FileUploadController(buildFileStorageProperties(),
+				new NoopFileStorageService());
+		MockServerHttpRequest request = MockServerHttpRequest.get("/api/upload/uploads/../secret.txt").build();
+
+		ResponseEntity<byte[]> response = controller.getFile(request);
+
+		assertEquals(403, response.getStatusCode().value());
+	}
+
+	private FileStorageProperties buildFileStorageProperties() {
+		FileStorageProperties properties = new FileStorageProperties();
+		properties.setPath(tempDir.toString());
+		properties.setUrlPrefix("/uploads");
+		return properties;
+	}
+
+	private static final class NoopFileStorageService implements FileStorageService {
+
+		@Override
+		public Mono<String> storeFile(FilePart filePart, String subPath) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public String storeFile(MultipartFile file, String subPath) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean deleteFile(String filePath) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public String getFileUrl(String filePath) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Resource getFileResource(String filePath) {
+			throw new UnsupportedOperationException();
+		}
+
+	}
+
+}

--- a/data-agent-management/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-agent-management/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-subclass


### PR DESCRIPTION
### Describe what this PR does / why we need it

增强安全性并修复测试环境兼容问题：  
1. 隐藏敏感字段（`apiKey`、`password`、`connectionUrl`）  
2. 修复上传文件读取接口路径穿越  
3. 解决 JDK21 下 Mockito `MockMaker` 初始化失败

### Does this pull request fix one issue?

### Describe how you did it

- 给敏感字段加 `@JsonIgnore`  
- `getFile` 增加前缀校验、`resolve + normalize`、`basePath` 越界拦截（403）  
- 新增回归测试 `FileAndSerializationSecurityTest`  
- 增加 `mockito-extensions/org.mockito.plugins.MockMaker=mock-maker-subclass`

### Describe how to verify it

已执行全量构建与测试：  
`mvn clean package`  

结果：通过。

### Special notes for reviews
