### PR TITLE
fix(parser): strip think tags before extracting code blocks

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/util/MarkdownParserUtil.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/util/MarkdownParserUtil.java
@@ -25,16 +25,23 @@ public class MarkdownParserUtil {
 	}
 
 	public static String extractRawText(String markdownCode) {
+		// Strip think tags: keep only content after the last </think>
+		String text = markdownCode;
+		int lastThinkEnd = text.lastIndexOf("</think>");
+		if (lastThinkEnd != -1) {
+			text = text.substring(lastThinkEnd + "</think>".length()).trim();
+		}
+
 		// Find the start of a code block (3 or more backticks)
 		int startIndex = -1;
 		int delimiterLength = 0;
 
-		for (int i = 0; i <= markdownCode.length() - 3; i++) {
-			if (markdownCode.substring(i, i + 3).equals("```")) {
+		for (int i = 0; i <= text.length() - 3; i++) {
+			if (text.substring(i, i + 3).equals("```")) {
 				startIndex = i;
 				delimiterLength = 3;
 				// Count additional backticks
-				while (i + delimiterLength < markdownCode.length() && markdownCode.charAt(i + delimiterLength) == '`') {
+				while (i + delimiterLength < text.length() && text.charAt(i + delimiterLength) == '`') {
 					delimiterLength++;
 				}
 				break;
@@ -42,29 +49,29 @@ public class MarkdownParserUtil {
 		}
 
 		if (startIndex == -1) {
-			return markdownCode; // No code block found
+			return text; // No code block found
 		}
 
 		// Skip the opening delimiter and optional language specification
 		int contentStart = startIndex + delimiterLength;
-		while (contentStart < markdownCode.length() && markdownCode.charAt(contentStart) != '\n') {
+		while (contentStart < text.length() && text.charAt(contentStart) != '\n') {
 			contentStart++;
 		}
-		if (contentStart < markdownCode.length() && markdownCode.charAt(contentStart) == '\n') {
+		if (contentStart < text.length() && text.charAt(contentStart) == '\n') {
 			contentStart++; // Skip the newline after language spec
 		}
 
 		// Find the closing delimiter
 		String closingDelimiter = "`".repeat(delimiterLength);
-		int endIndex = markdownCode.indexOf(closingDelimiter, contentStart);
+		int endIndex = text.indexOf(closingDelimiter, contentStart);
 
 		if (endIndex == -1) {
 			// No closing delimiter found, return from content start to end
-			return markdownCode.substring(contentStart);
+			return text.substring(contentStart);
 		}
 
 		// Extract just the content between delimiters
-		return markdownCode.substring(contentStart, endIndex);
+		return text.substring(contentStart, endIndex);
 	}
 
 }

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/util/MarkdownParserUtilTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/util/MarkdownParserUtilTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MarkdownParserUtilTest {
+
+	@Test
+	void noCodeBlock_returnsOriginal() {
+		String input = "SELECT * FROM users";
+		assertEquals(input, MarkdownParserUtil.extractRawText(input));
+	}
+
+	@Test
+	void singleCodeBlock_returnsContent() {
+		String input = "```sql\nSELECT * FROM users\n```";
+		assertEquals("SELECT * FROM users\n", MarkdownParserUtil.extractRawText(input));
+	}
+
+	@Test
+	void multipleCodeBlocks_returnsLastBlock() {
+		String input = "<think>\n```sql\nSELECT 1\n```\n</think>\n```sql\nSELECT * FROM users\n```";
+		assertEquals("SELECT * FROM users\n", MarkdownParserUtil.extractRawText(input));
+	}
+
+	@Test
+	void thinkTagWithMultipleSql_returnsLastSql() {
+		String input = "<think>\n```sql\nSELECT id FROM t\n```\nLet me refine.\n```sql\nSELECT name FROM t\n```\n</think>\n```sql\nSELECT * FROM orders WHERE id = 1\n```";
+		assertEquals("SELECT * FROM orders WHERE id = 1\n", MarkdownParserUtil.extractRawText(input));
+	}
+
+	@Test
+	void multipleThinkTags_returnsCodeBlockAfterLastThink() {
+		String input = "<think>\n```sql\nSELECT 1\n```\n</think>\n<think>\n```sql\nSELECT 2\n```\n</think>\n```sql\nSELECT * FROM orders\n```";
+		assertEquals("SELECT * FROM orders\n", MarkdownParserUtil.extractRawText(input));
+	}
+
+	@Test
+	void thinkTagNoCodeBlockAfter_returnsPlainTextAfterThink() {
+		String input = "<think>\n```sql\nSELECT 1\n```\n</think>\nSELECT * FROM users";
+		assertEquals("SELECT * FROM users", MarkdownParserUtil.extractRawText(input));
+	}
+
+	@Test
+	void extractText_normalizesNewlines() {
+		String input = "```sql\nSELECT *\nFROM users\n```";
+		String result = MarkdownParserUtil.extractText(input);
+		assertFalse(result.contains("\n"));
+		assertTrue(result.contains("SELECT *"));
+	}
+
+}


### PR DESCRIPTION
Fixes #486

The markdown parser wasn't filtering out think tags, so they were ending up in the extracted SQL. Updated it to strip everything before the closing think tag first, then parse the code block normally.

Added tests for this.