### PR TITLE
fix(prompt): correct typo in planner prompt and add regression guard

### DIFF
--- a/data-agent-management/src/main/resources/prompts/planner.txt
+++ b/data-agent-management/src/main/resources/prompts/planner.txt
@@ -76,7 +76,7 @@
     3.1、需要按渠道看转化率？ -> Step 1: SQL_GENERATE_NODE (描述：按渠道分组查询各阶段人数)。
     3.2、需要按地区看转化率？ -> Step 2: SQL_GENERATE_NODE (描述：按地区分组查询各阶段人数)。
     3.3、需要计算复杂的比率或排名？ -> Step 3: PYTHON_GENERATE_NODE (指令：读取前两步数据，计算转化率并排名)。
-    3.4 需要总结？ -> Step 4: REPORT_GENERATE_NODE。
+    3.4 需要总结？ -> Step 4: REPORT_GENERATOR_NODE。
 4、撰写指令：确保 SQL_GENERATE_NODE 的 instruction 足够详细，让写 SQL 的同事（下游节点）一看就懂，不需要再问用户。
 5、构建 JSON：组装最终结果。
 

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/prompt/PlannerPromptTemplateTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/prompt/PlannerPromptTemplateTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.prompt;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PlannerPromptTemplateTest {
+
+	@Test
+	void plannerPrompt_shouldUseCorrectReportGeneratorNodeName() throws IOException {
+		var inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("prompts/planner.txt");
+		assertNotNull(inputStream, "planner prompt template should exist");
+
+		String content;
+		try (inputStream) {
+			content = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+		}
+
+		assertTrue(content.contains("REPORT_GENERATOR_NODE"),
+				"planner prompt should guide model to use REPORT_GENERATOR_NODE");
+		assertFalse(content.contains("REPORT_GENERATE_NODE"),
+				"planner prompt should not contain legacy typo REPORT_GENERATE_NODE");
+	}
+
+}


### PR DESCRIPTION
This PR is part of an ordered contribution batch (#6/20).\n\nScope:\n- fix planner prompt typo: REPORT_GENERATE_NODE -> REPORT_GENERATOR_NODE\n- add a small regression test to guard against reintroducing the typo\n\nRationale:\nThe typo can mislead planner output tool names and cause downstream execution mismatch.