### PR TITLE
fix: 解决数据源新增和修改时密码无法保存的问题 #493

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/entity/Datasource.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/entity/Datasource.java
@@ -16,7 +16,7 @@
 package com.alibaba.cloud.ai.dataagent.entity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -45,10 +45,10 @@ public class Datasource {
 
 	private String username;
 
-	@JsonIgnore
+	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 	private String password;
 
-	@JsonIgnore
+	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 	private String connectionUrl;
 
 	private String status;

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/impl/DatasourceServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/impl/DatasourceServiceImpl.java
@@ -115,6 +115,11 @@ public class DatasourceServiceImpl implements DatasourceService {
 
 	@Override
 	public Datasource updateDatasource(Integer id, Datasource datasource) {
+		Datasource existingDatasource = datasourceMapper.selectById(id);
+		if (existingDatasource == null) {
+			throw new RuntimeException("Datasource not found with id: " + id);
+		}
+
 		// Regenerate connection URL
 		DatasourceTypeHandler handler = datasourceTypeHandlerRegistry.getRequired(datasource.getType());
 		String connectionUrl = handler.resolveConnectionUrl(datasource);
@@ -124,11 +129,11 @@ public class DatasourceServiceImpl implements DatasourceService {
 		datasource.setId(id);
 
 		if (datasource.getPassword() == null) {
-			datasource.setPassword("");
+			datasource.setPassword(existingDatasource.getPassword());
 		}
 
 		if (datasource.getUsername() == null) {
-			datasource.setUsername("");
+			datasource.setUsername(existingDatasource.getUsername());
 		}
 
 		datasourceMapper.updateById(datasource);


### PR DESCRIPTION

### Describe what this PR does / why we need it
修复在新增或修改数据源时，前端传入的密码由于序列化配置问题未被持久化到数据库，导致后续数据源连接失败的问题。

### Does this pull request fix one issue?
Fixes #493

### Describe how you did it
1.  **权限调整**：将 `Datasource` 实体类中 `password` 字段的注解由 `@JsonIgnore` 改为 `WRITE_ONLY` 访问级别，确保后端能接收前端参数且不在返回时泄露。
2.  **逻辑优化**：在 `DatasourceServiceImpl` 更新逻辑中，增加对密码和用户名的非空判断。若更新请求未传密，则自动保留数据库原有的凭据，防止更新操作导致密码被置空。

### Describe how to verify it
1.  通过界面新增数据源并填写密码，确认数据库中密码字段不为空。
2.  通过界面修改数据源其他信息（不填密码），确认保存后数据源连接依然正常，密码未丢失。

### Special notes for reviews
无