### PR TITLE
fix(connector): fix Oracle database connection URL build and password…

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/entity/Datasource.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/entity/Datasource.java
@@ -17,6 +17,7 @@ package com.alibaba.cloud.ai.dataagent.entity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -45,7 +46,12 @@ public class Datasource {
 
 	private String username;
 
-	@JsonIgnore
+	/**
+	 * Password field is only writable (input only).
+	 * It will not be returned in API responses for security reasons,
+	 * but can be received from API requests.
+	 */
+	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 	private String password;
 
 	@JsonIgnore

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/handler/impl/OracleDatasourceTypeHandler.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/handler/impl/OracleDatasourceTypeHandler.java
@@ -34,8 +34,14 @@ public class OracleDatasourceTypeHandler implements DatasourceTypeHandler {
 			return datasource.getConnectionUrl();
 		}
 		// Oracle JDBC URL format: jdbc:oracle:thin:@host:port/serviceName
+		// databaseName may contain "serviceName|schemaName" format, extract serviceName part
+		String databaseName = datasource.getDatabaseName();
+		String serviceName = databaseName;
+		if (databaseName != null && databaseName.contains("|")) {
+			serviceName = databaseName.split("\\|")[0];
+		}
 		return String.format("jdbc:oracle:thin:@%s:%d/%s", datasource.getHost(), datasource.getPort(),
-				datasource.getDatabaseName());
+				serviceName);
 	}
 
 	@Override

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/impl/DatasourceServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/impl/DatasourceServiceImpl.java
@@ -176,6 +176,12 @@ public class DatasourceServiceImpl implements DatasourceService {
 	 * Actual connection test method
 	 */
 	private boolean realConnectionTest(Datasource datasource) {
+		// Validate password is not empty
+		if (datasource.getPassword() == null || datasource.getPassword().trim().isEmpty()) {
+			log.error("Password is empty for datasource: {}", datasource.getName());
+			return false;
+		}
+
 		// Convert Datasource to DbConfig
 		DbConfigBO config = new DbConfigBO();
 		DatasourceTypeHandler handler = datasourceTypeHandlerRegistry.getRequired(datasource.getType());


### PR DESCRIPTION
# Fix Oracle Database Connection Issues

## 📖 Summary

Fixed two critical bugs preventing Oracle database connections from working:

1. **Invalid JDBC URL construction** - Schema name incorrectly included in connection URL
2. **Password field serialization** - Password could not be saved due to `@JsonIgnore` annotation

---

## 🐛 Problems Fixed

### Issue 1: Oracle JDBC URL Build Error

**Symptom:**
```
Failed to get database connection after 3 attempts, 
URL: jdbc:oracle:thin:@localhost:3306/BOSNDS3|BOSNDS3_ADMIN
```

**Root Cause:**
- The `databaseName` field stores format: `serviceName|schemaName` (e.g., `BOSNDS3|BOSNDS3_ADMIN`)
- `OracleDatasourceTypeHandler.buildConnectionUrl()` directly used the entire field
- Generated invalid JDBC URL with schema name included

**Solution:**
Extract only the `serviceName` part (before `|`) when building the JDBC URL, while preserving the full field for schema extraction later.

---

### Issue 2: Password Field Cannot Be Saved

**Symptom:**
```
ORA-01005: null password given; logon denied
```

**Root Cause:**
- `Datasource.password` field used `@JsonIgnore` annotation
- This causes **bidirectional ignore**: 
  - ❌ Password not returned to frontend (correct - security)
  - ❌ Password not received from frontend (bug - prevents saving)
- Users couldn't save passwords when creating/editing datasources

**Solution:**
Changed from `@JsonIgnore` to `@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)`:
- ✅ Accepts password from frontend requests (input)
- ✅ Does not expose password in API responses (security)

---

## 🔧 Changes Made

### 1. OracleDatasourceTypeHandler.java
**File:** `data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/handler/impl/OracleDatasourceTypeHandler.java`

```java
// Before:
return String.format("jdbc:oracle:thin:@%s:%d/%s", 
    datasource.getHost(), datasource.getPort(),
    datasource.getDatabaseName()); // ❌ Includes "serviceName|schemaName"

// After:
String databaseName = datasource.getDatabaseName();
String serviceName = databaseName;
if (databaseName != null && databaseName.contains("|")) {
    serviceName = databaseName.split("\\|")[0]; // ✅ Extract only serviceName
}
return String.format("jdbc:oracle:thin:@%s:%d/%s", 
    datasource.getHost(), datasource.getPort(), serviceName);
```

### 2. Datasource.java
**File:** `data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/entity/Datasource.java`

```java
// Before:
@JsonIgnore
private String password; // ❌ Bidirectional ignore

// After:
/**
 * Password field is only writable (input only).
 * It will not be returned in API responses for security reasons,
 * but can be received from API requests.
 */
@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
private String password; // ✅ Write-only: accepts input, hides output
```

### 3. DatasourceServiceImpl.java
**File:** `data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/impl/DatasourceServiceImpl.java`

Added password validation before connection test:
```java
// Validate password is not empty
if (datasource.getPassword() == null || datasource.getPassword().trim().isEmpty()) {
    log.error("Password is empty for datasource: {}", datasource.getName());
    return false;
}
```

---

## ✅ How to Test

### Test Oracle Connection
1. Create or edit an Oracle datasource
2. Fill in connection details:
   - Host: `localhost` (or your Oracle host)
   - Port: `1521` (Oracle default port)
   - Database Name: `serviceName|schemaName` (e.g., `BOSNDS3|BOSNDS3_ADMIN`)
   - Username: Your Oracle username
   - Password: Your Oracle password
3. Click "Test Connection"
4. Should return success ✅

### Verify Password Security
1. Create/edit datasource with password
2. Save the datasource
3. Fetch the datasource list via API
4. Verify password field is **not** present in response ✅
5. Edit the datasource again
6. Re-enter password and save
7. Password should be updated successfully ✅

---

## 📝 Special Notes

### For Reviewers

1. **Security Consideration**: The `@JsonProperty(WRITE_ONLY)` approach is the standard Jackson pattern for password fields. It ensures:
   - Passwords can be submitted via API
   - Passwords are never exposed in API responses
   - Better than `@JsonIgnore` which prevents both operations

2. **Backward Compatibility**: 
   - Existing datasources will need to have their passwords re-entered (since they weren't saved before)
   - No database schema changes required

3. **Oracle URL Format**:
   - Standard format: `jdbc:oracle:thin:@host:port/serviceName`
   - Schema is used separately in queries, not in connection URL
   - This aligns with how PostgreSQL handles schema

### Testing Checklist
- [x] Oracle datasource creation works
- [x] Oracle datasource edit works  
- [x] Oracle connection test succeeds
- [x] Password not exposed in API responses
- [x] Password can be saved and updated
- [x] Other datasource types (MySQL, PostgreSQL) still work correctly

---

## 🔗 Related Issues

Fixes connection errors:
- `ORA-01005: null password given; logon denied`
- `GetConnectionTimeoutException` with invalid Oracle URL format

---

## 📚 Documentation References

- [Jackson @JsonProperty Documentation](https://fasterxml.github.io/jackson-annotations/javadoc/2.14/com/fasterxml/jackson/annotation/JsonProperty.html)
- [Oracle JDBC URL Format](https://docs.oracle.com/en/database/oracle/oracle-database/21/jjdbc/data-sources-and-URLs.html)
