### PR TITLE
fix: use user message for python analyze prompt

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/PythonAnalyzeNode.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/PythonAnalyzeNode.java
@@ -84,7 +84,7 @@ public class PythonAnalyzeNode implements NodeAction {
 		String systemPrompt = PromptConstant.getPythonAnalyzePromptTemplate()
 			.render(Map.of("python_output", pythonOutput, "user_query", userQuery));
 
-		Flux<ChatResponse> pythonAnalyzeFlux = llmService.callSystem(systemPrompt);
+		Flux<ChatResponse> pythonAnalyzeFlux = llmService.callUser(systemPrompt);
 
 		Flux<GraphResponse<StreamingOutput>> generator = FluxUtil.createStreamingGeneratorWithMessages(this.getClass(),
 				state, "正在分析代码运行结果...\n", "\n结果分析完成。", aiResponse -> {

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/workflow/node/python/PythonAnalyzeNodeTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/workflow/node/python/PythonAnalyzeNodeTest.java
@@ -102,7 +102,7 @@ class PythonAnalyzeNodeTest {
 		OverAllState state = createTestState();
 		setupBasicState(state);
 
-		when(llmService.callSystem(anyString()))
+		when(llmService.callUser(anyString()))
 			.thenReturn(Flux.just(ChatResponseUtil.createPureResponse("销售总额为15000元，平均销售额3000元")));
 
 		Map<String, Object> result = pythonAnalyzeNode.apply(state);
@@ -116,7 +116,7 @@ class PythonAnalyzeNodeTest {
 		OverAllState state = createTestState();
 		setupBasicState(state);
 
-		when(llmService.callSystem(anyString())).thenThrow(new RuntimeException("LLM service unavailable"));
+		when(llmService.callUser(anyString())).thenThrow(new RuntimeException("LLM service unavailable"));
 
 		assertThrows(RuntimeException.class, () -> pythonAnalyzeNode.apply(state));
 	}
@@ -139,7 +139,7 @@ class PythonAnalyzeNodeTest {
 		state.updateState(Map.of(PYTHON_EXECUTE_NODE_OUTPUT, "", PLAN_CURRENT_STEP, 1, QUERY_ENHANCE_NODE_OUTPUT,
 				TEST_QUERY_ENHANCE, PLANNER_NODE_OUTPUT, TEST_PLAN_JSON));
 
-		when(llmService.callSystem(anyString()))
+		when(llmService.callUser(anyString()))
 			.thenReturn(Flux.just(ChatResponseUtil.createPureResponse("Python输出为空，无法进行深入分析")));
 
 		Map<String, Object> result = pythonAnalyzeNode.apply(state);
@@ -156,7 +156,7 @@ class PythonAnalyzeNodeTest {
 		existingResults.put("step_1", "{\"data\": []}");
 		state.updateState(Map.of(SQL_EXECUTE_NODE_OUTPUT, existingResults));
 
-		when(llmService.callSystem(anyString()))
+		when(llmService.callUser(anyString()))
 			.thenReturn(Flux.just(ChatResponseUtil.createPureResponse("分析完成：数据为空")));
 
 		Map<String, Object> result = pythonAnalyzeNode.apply(state);
@@ -171,7 +171,7 @@ class PythonAnalyzeNodeTest {
 		state.updateState(Map.of(PYTHON_EXECUTE_NODE_OUTPUT, "{{{{invalid json garbage}}}}", PLAN_CURRENT_STEP, 1,
 				QUERY_ENHANCE_NODE_OUTPUT, TEST_QUERY_ENHANCE, PLANNER_NODE_OUTPUT, TEST_PLAN_JSON));
 
-		when(llmService.callSystem(anyString()))
+		when(llmService.callUser(anyString()))
 			.thenReturn(Flux.just(ChatResponseUtil.createPureResponse("无法解析Python输出")));
 
 		Map<String, Object> result = pythonAnalyzeNode.apply(state);
@@ -184,7 +184,7 @@ class PythonAnalyzeNodeTest {
 		OverAllState state = createTestState();
 		setupBasicState(state);
 
-		when(llmService.callSystem(anyString())).thenReturn(Flux.error(new RuntimeException("LLM analysis timeout")));
+		when(llmService.callUser(anyString())).thenReturn(Flux.error(new RuntimeException("LLM analysis timeout")));
 
 		Map<String, Object> result = pythonAnalyzeNode.apply(state);
 		assertNotNull(result);


### PR DESCRIPTION
### Describe what this PR does / why we need it

修复PythonAnalyzeNode只发送system message时，部分OpenAI兼容模型报at least one message is required的问题。

### Does this pull request fix one issue?

Fixes #461

### Describe how you did it

将llmService.callSystem(systemPrompt)改为llmService.callUser(systemPrompt)，并同步更新对应单测mock。

### Describe how to verify it

执行命令：./mvnw.cmd -pl data-agent-management test -Dtest=PythonAnalyzeNodeTest

结果：Tests run: 7, Failures: 0, Errors: 0, Skipped: 0，BUILD SUCCESS

### Special notes for reviews

NONE
