### PR TITLE
fix(entity): 修复数据源保存时密码无法入库问题

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/entity/Datasource.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/entity/Datasource.java
@@ -16,7 +16,7 @@
 package com.alibaba.cloud.ai.dataagent.entity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -45,10 +45,10 @@ public class Datasource {
 
 	private String username;
 
-	@JsonIgnore
+	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 	private String password;
 
-	@JsonIgnore
+	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 	private String connectionUrl;
 
 	private String status;


### PR DESCRIPTION
### Describe what this PR does / why we need it

这个问题造成新增数据源后密码无法落库，会出现新增的数据源一直连接失败。

### Does this pull request fix one issue?

 Fixes #493 

### Describe how you did it

经过排查发现是 Datasource 中的 @JsonIgnore 造成的，改为 @JsonProperty(access = JsonProperty.Access.WRITE_ONLY) 解决问题

### Describe how to verify it

可以通过接口 /api/datasource 验证

### Special notes for reviews
