### PR TITLE
fix(nl2sql): extract last SQL block from model output

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/nl2sql/Nl2SqlService.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/nl2sql/Nl2SqlService.java
@@ -35,7 +35,7 @@ public interface Nl2SqlService {
 			String sqlGenerateSchemaMissingAdvice, DbConfigBO specificDbConfig, Consumer<SchemaDTO> dtoConsumer);
 
 	default String sqlTrim(String sql) {
-		return MarkdownParserUtil.extractRawText(sql).trim();
+		return MarkdownParserUtil.extractLastRawText(sql).trim();
 	}
 
 }

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/util/MarkdownParserUtil.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/util/MarkdownParserUtil.java
@@ -25,15 +25,34 @@ public class MarkdownParserUtil {
 	}
 
 	public static String extractRawText(String markdownCode) {
-		// Find the start of a code block (3 or more backticks)
+		CodeBlock codeBlock = findNextCodeBlock(markdownCode, 0);
+		return codeBlock == null ? markdownCode : codeBlock.rawText;
+	}
+
+	public static String extractLastRawText(String markdownCode) {
+		CodeBlock lastCodeBlock = null;
+		int searchIndex = 0;
+
+		while (searchIndex <= markdownCode.length() - 3) {
+			CodeBlock codeBlock = findNextCodeBlock(markdownCode, searchIndex);
+			if (codeBlock == null) {
+				break;
+			}
+			lastCodeBlock = codeBlock;
+			searchIndex = codeBlock.nextSearchIndex;
+		}
+
+		return lastCodeBlock == null ? markdownCode : lastCodeBlock.rawText;
+	}
+
+	private static CodeBlock findNextCodeBlock(String markdownCode, int searchIndex) {
 		int startIndex = -1;
 		int delimiterLength = 0;
 
-		for (int i = 0; i <= markdownCode.length() - 3; i++) {
+		for (int i = searchIndex; i <= markdownCode.length() - 3; i++) {
 			if (markdownCode.substring(i, i + 3).equals("```")) {
 				startIndex = i;
 				delimiterLength = 3;
-				// Count additional backticks
 				while (i + delimiterLength < markdownCode.length() && markdownCode.charAt(i + delimiterLength) == '`') {
 					delimiterLength++;
 				}
@@ -42,29 +61,38 @@ public class MarkdownParserUtil {
 		}
 
 		if (startIndex == -1) {
-			return markdownCode; // No code block found
+			return null;
 		}
 
-		// Skip the opening delimiter and optional language specification
 		int contentStart = startIndex + delimiterLength;
 		while (contentStart < markdownCode.length() && markdownCode.charAt(contentStart) != '\n') {
 			contentStart++;
 		}
 		if (contentStart < markdownCode.length() && markdownCode.charAt(contentStart) == '\n') {
-			contentStart++; // Skip the newline after language spec
+			contentStart++;
 		}
 
-		// Find the closing delimiter
 		String closingDelimiter = "`".repeat(delimiterLength);
 		int endIndex = markdownCode.indexOf(closingDelimiter, contentStart);
 
 		if (endIndex == -1) {
-			// No closing delimiter found, return from content start to end
-			return markdownCode.substring(contentStart);
+			return new CodeBlock(markdownCode.substring(contentStart), markdownCode.length());
 		}
 
-		// Extract just the content between delimiters
-		return markdownCode.substring(contentStart, endIndex);
+		return new CodeBlock(markdownCode.substring(contentStart, endIndex), endIndex + delimiterLength);
+	}
+
+	private static final class CodeBlock {
+
+		private final String rawText;
+
+		private final int nextSearchIndex;
+
+		private CodeBlock(String rawText, int nextSearchIndex) {
+			this.rawText = rawText;
+			this.nextSearchIndex = nextSearchIndex;
+		}
+
 	}
 
 }

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/nl2sql/Nl2SqlServiceImplTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/nl2sql/Nl2SqlServiceImplTest.java
@@ -202,10 +202,46 @@ class Nl2SqlServiceImplTest {
 	}
 
 	@Test
-	void sqlTrim_multipleBacktickBlocks_extractsFirst() {
-		String sql = "```sql\nSELECT 1\n```\nSome text\n```sql\nSELECT 2\n```";
+	void sqlTrim_multipleSqlBlocks_returnsLastSqlBlock() {
+		String sql = """
+				```sql
+				SELECT create_by
+				FROM sys_dept
+				WHERE dept_name = '研发部'
+				```
+				Some text
+				```sql
+				SELECT user_id
+				FROM sys_user
+				WHERE user_id IN (
+				SELECT create_by
+				FROM sys_dept
+				WHERE dept_name = '研发部'
+				)
+				```
+				More text
+				```sql
+				SELECT *
+				FROM sys_user
+				WHERE user_id IN (
+				SELECT create_by
+				FROM sys_dept
+				WHERE dept_name = '研发部'
+				)
+				```
+				""";
+		String expected = """
+				SELECT *
+				FROM sys_user
+				WHERE user_id IN (
+				SELECT create_by
+				FROM sys_dept
+				WHERE dept_name = '研发部'
+				)
+				""".trim();
+
 		String result = nl2SqlService.sqlTrim(sql);
-		assertNotNull(result);
+		assertEquals(expected, result);
 	}
 
 	@Test

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/util/MarkdownParserUtilTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/util/MarkdownParserUtilTest.java
@@ -46,6 +46,24 @@ class MarkdownParserUtilTest {
 	}
 
 	@Test
+	void testExtractLastRawText_singleBlock() {
+		String input = "```sql\nSELECT 1\n```";
+		assertEquals("SELECT 1\n", MarkdownParserUtil.extractLastRawText(input));
+	}
+
+	@Test
+	void testExtractLastRawText_multipleBlocks_returnsLast() {
+		String input = "```sql\nSELECT 1\n```\n```sql\nSELECT 2\n```";
+		assertEquals("SELECT 2\n", MarkdownParserUtil.extractLastRawText(input));
+	}
+
+	@Test
+	void testExtractLastRawText_noCodeBlock_returnsOriginal() {
+		String input = "plain SQL text";
+		assertEquals("plain SQL text", MarkdownParserUtil.extractLastRawText(input));
+	}
+
+	@Test
 	void testExtractText_replacesNewlines() {
 		String input = "```sql\nSELECT *\nFROM users;\n```";
 		String result = MarkdownParserUtil.extractText(input);


### PR DESCRIPTION
### Describe what this PR does / why we need it

This PR fixes an NL2SQL issue where SQL cleanup may extract the first intermediate SQL block instead of the final SQL when the model output contains multiple fenced SQL code blocks.

In the current flow, `SqlGenerateNode` cleans the model output through `Nl2SqlService.sqlTrim()` and stores the result in `SQL_GENERATE_OUTPUT`. The downstream `SemanticConsistencyNode` and `SqlExecuteNode` then consume this SQL. The previous logic extracted the first fenced code block, which could pass a non-final SQL to downstream nodes if the first SQL block was only an intermediate query.

### Does this pull request fix one issue?

Fixes #486

### Describe how you did it

- Kept the existing behavior of `MarkdownParserUtil.extractRawText()` unchanged to avoid affecting other Markdown code block parsing scenarios, such as JSON, Python, and chart configuration parsing.
- Added `MarkdownParserUtil.extractLastRawText()` to extract the last fenced code block.
- Updated `Nl2SqlService.sqlTrim()` to use `extractLastRawText()`, so SQL cleanup uses the last fenced block when multiple code blocks are present.
- Added regression tests to cover model output with multiple fenced SQL outputs and verify that the final SQL output is returned.

The reason for choosing the last block in the SQL cleanup path is that the model output is generated in one pass. It does not actually execute the first SQL and then generate the second SQL based on runtime results. In multiple-SQL-block outputs, earlier SQL blocks are often intermediate or helper queries, while the later SQL block is more likely to be the final executable SQL that already combines the intermediate logic through a subquery or JOIN. Since the current execution pipeline handles a single SQL statement, passing the last SQL block downstream better matches the existing architecture.

### Describe how to verify it

Ran the following local tests:

```powershell
.\mvnw.cmd -pl data-agent-management "-Dtest=MarkdownParserUtilTest,Nl2SqlServiceImplTest" test
```

Result:

```text
Tests run: 26, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

### Special notes for reviews

This PR only changes code block selection in the SQL cleanup path. It does not modify `SqlGenerateNode`, the Graph flow, prompts, or add support for sequential execution of multiple SQL statements.