### PR TITLE
fix: 修复人工反馈节点循环逻辑问题

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/config/DataAgentConfiguration.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/config/DataAgentConfiguration.java
@@ -241,7 +241,9 @@ public class DataAgentConfiguration implements DisposableBean {
 					// If plan is approved, continue with execution
 					PLAN_EXECUTOR_NODE, PLAN_EXECUTOR_NODE,
 					// If max repair attempts are reached, end the process
-					END, END))
+					END, END,
+					// If human feedback data is null, go back to HumanFeedbackNode
+					HUMAN_FEEDBACK_NODE, HUMAN_FEEDBACK_NODE))
 			.addEdge(REPORT_GENERATOR_NODE, END)
 			// sql generate and sql execute node
 			.addConditionalEdges(SQL_GENERATE_NODE, nodeBeanUtil.getEdgeBeanAsync(SqlGenerateDispatcher.class),

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/dispatcher/HumanFeedbackDispatcher.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/dispatcher/HumanFeedbackDispatcher.java
@@ -18,6 +18,7 @@ package com.alibaba.cloud.ai.dataagent.workflow.dispatcher;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.action.EdgeAction;
 
+import static com.alibaba.cloud.ai.dataagent.constant.Constant.HUMAN_FEEDBACK_NODE;
 import static com.alibaba.cloud.ai.graph.StateGraph.END;
 
 /**
@@ -33,7 +34,7 @@ public class HumanFeedbackDispatcher implements EdgeAction {
 
 		// 如果是等待反馈状态，返回END让图暂停
 		if ("WAIT_FOR_FEEDBACK".equals(nextNode)) {
-			return END;
+			return HUMAN_FEEDBACK_NODE;
 		}
 
 		return nextNode;


### PR DESCRIPTION
### Describe what this PR does / why we need it

在HumanFeedbackNode中，若feedbackData为Empty，则图走向END，根据HumanFeedbackDispatcher描述看是希望等待人工介入，这里走向END或许应该走向HumanFeedbackNode？虽然在GraphServiceImpl中已经能够保证节点feedbackData非Empty了，但是在该节点写了这个判断逻辑。

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it

只保留START-HUMAN_FEEDBACK_NODE-END，保留HUMAN_FEEDBACK_NODE后面的条件边，第一次调用/stream/search获取threadId等，连续两次调用，使用human节点，修改后会连续触发interrupt nodeoutput


### Special notes for reviews
