### PR TITLE
fix: 修复SessionTitleServiceTest测试用例

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/config/DataAgentConfiguration.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/config/DataAgentConfiguration.java
@@ -241,7 +241,9 @@ public class DataAgentConfiguration implements DisposableBean {
 					// If plan is approved, continue with execution
 					PLAN_EXECUTOR_NODE, PLAN_EXECUTOR_NODE,
 					// If max repair attempts are reached, end the process
-					END, END))
+					END, END,
+					// If human feedback data is null, go back to HumanFeedbackNode
+					HUMAN_FEEDBACK_NODE, HUMAN_FEEDBACK_NODE))
 			.addEdge(REPORT_GENERATOR_NODE, END)
 			// sql generate and sql execute node
 			.addConditionalEdges(SQL_GENERATE_NODE, nodeBeanUtil.getEdgeBeanAsync(SqlGenerateDispatcher.class),

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/dispatcher/HumanFeedbackDispatcher.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/dispatcher/HumanFeedbackDispatcher.java
@@ -18,6 +18,7 @@ package com.alibaba.cloud.ai.dataagent.workflow.dispatcher;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.action.EdgeAction;
 
+import static com.alibaba.cloud.ai.dataagent.constant.Constant.HUMAN_FEEDBACK_NODE;
 import static com.alibaba.cloud.ai.graph.StateGraph.END;
 
 /**
@@ -33,7 +34,7 @@ public class HumanFeedbackDispatcher implements EdgeAction {
 
 		// 如果是等待反馈状态，返回END让图暂停
 		if ("WAIT_FOR_FEEDBACK".equals(nextNode)) {
-			return END;
+			return HUMAN_FEEDBACK_NODE;
 		}
 
 		return nextNode;

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/chat/SessionTitleServiceTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/chat/SessionTitleServiceTest.java
@@ -28,6 +28,7 @@ import reactor.core.publisher.Flux;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -113,9 +114,20 @@ class SessionTitleServiceTest {
 
 	@Test
 	void scheduleTitleGeneration_duplicateSessionId_skipsSecondCall() throws Exception {
-		ChatSession session = ChatSession.builder().id("session-1").agentId(1).title("\u65b0\u4f1a\u8bdd").build();
-		when(chatSessionService.findBySessionId("session-1")).thenReturn(session);
-
+		AtomicReference<ChatSession> sessionRef = new AtomicReference<>(
+				ChatSession.builder().id("session-1").agentId(1).title("\u65b0\u4f1a\u8bdd").build()
+		);
+		when(chatSessionService.findBySessionId("session-1")).thenReturn(sessionRef.get());
+		doAnswer(invocation -> {
+			String newTitle = invocation.getArgument(1);
+			ChatSession currentSession = sessionRef.get();
+			ChatSession updatedSession = ChatSession.builder().id(currentSession.getId())
+					.agentId(currentSession.getAgentId())
+					.title(newTitle)
+					.build();
+			sessionRef.set(updatedSession);
+			return null;
+		}).when(chatSessionService).renameSession(anyString(), anyString());
 		Flux<ChatResponse> chatResponseFlux = Flux.empty();
 		when(llmService.call(anyString(), anyString())).thenReturn(chatResponseFlux);
 		when(llmService.toStringFlux(chatResponseFlux)).thenReturn(Flux.just("Title"));

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/workflow/dispatcher/HumanFeedbackDispatcherTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/workflow/dispatcher/HumanFeedbackDispatcherTest.java
@@ -35,11 +35,11 @@ class HumanFeedbackDispatcherTest {
 	}
 
 	@Test
-	void apply_waitForFeedback_routesToEnd() throws Exception {
+	void apply_waitForFeedback_routesToHumanFeedback() throws Exception {
 		OverAllState state = new OverAllState();
 		state.updateState(Map.of("human_next_node", "WAIT_FOR_FEEDBACK"));
 
-		assertEquals(END, dispatcher.apply(state));
+		assertEquals(HUMAN_FEEDBACK_NODE, dispatcher.apply(state));
 	}
 
 	@Test


### PR DESCRIPTION
### Describe what this PR does / why we need it

scheduleTitleGeneration_duplicateSessionId_skipsSecondCall方法中，在以下情况下会出问题，即第一次任务执行结束后，第二次任务才开始执行，那么理论上应该在SessionTitleService.hasCustomTitle方法处将第二次拦截，但是由于测试用例设置了默认的findBySessionId返回值，导致这里仍然认为是新会话，而调用了第二次renameSession

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
