### PR TITLE
fix: 修复采集数据源时，表字段有sql保留字冲突的名称报错问题

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/enums/BizDataSourceTypeEnum.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/enums/BizDataSourceTypeEnum.java
@@ -159,6 +159,10 @@ public enum BizDataSourceTypeEnum {
 		return isDialect(typeName, DatabaseDialectEnum.ORACLE.getCode());
 	}
 
+	public static boolean isHiveDialect(String typeName) {
+		return isDialect(typeName, DatabaseDialectEnum.HIVE.getCode());
+	}
+
 	public static boolean isAdbPg(String typeName) {
 		BizDataSourceTypeEnum te = fromTypeName(typeName);
 		if (te == null) {

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/schema/TableMetadataService.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/schema/TableMetadataService.java
@@ -233,7 +233,7 @@ public class TableMetadataService {
 
 		try {
 			// 构建批量查询SQL，一次查询多个列的样本数据
-			String columnNames = columns.stream().map(ColumnInfoBO::getName).map(name -> "`" + name + "`").collect(Collectors.joining(", "));
+			String columnNames = SqlUtil.buildColumnsSql(dbConfig.getDialectType(), columns);
 			String sql = SqlUtil.buildSelectSql(dbConfig.getDialectType(), tableName, columnNames, 5);
 
 			DbQueryParameter batchParam = new DbQueryParameter();

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/schema/TableMetadataService.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/schema/TableMetadataService.java
@@ -233,7 +233,7 @@ public class TableMetadataService {
 
 		try {
 			// 构建批量查询SQL，一次查询多个列的样本数据
-			String columnNames = columns.stream().map(ColumnInfoBO::getName).collect(Collectors.joining(", "));
+			String columnNames = columns.stream().map(ColumnInfoBO::getName).map(name -> "`" + name + "`").collect(Collectors.joining(", "));
 			String sql = SqlUtil.buildSelectSql(dbConfig.getDialectType(), tableName, columnNames, 5);
 
 			DbQueryParameter batchParam = new DbQueryParameter();

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/util/SqlUtil.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/util/SqlUtil.java
@@ -15,8 +15,13 @@
  */
 package com.alibaba.cloud.ai.dataagent.util;
 
+import com.alibaba.cloud.ai.dataagent.bo.schema.ColumnInfoBO;
 import com.alibaba.cloud.ai.dataagent.enums.BizDataSourceTypeEnum;
 import lombok.experimental.UtilityClass;
+import org.apache.commons.collections.CollectionUtils;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * SQL 工具类
@@ -27,6 +32,22 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class SqlUtil {
 
+	/**
+	 * 构建Columns SQL块
+	 * @param typeName 数据源类型
+	 * @param columnInfoBOs 列名
+	 * @return Columns SQL块
+	 */
+	public static String buildColumnsSql(String typeName, List<ColumnInfoBO> columnInfoBOs) {
+		if (CollectionUtils.isEmpty(columnInfoBOs)) {
+			return "*";
+		}
+		if (BizDataSourceTypeEnum.isMysqlDialect(typeName)) {
+			// mysql使用``标识对象
+			return columnInfoBOs.stream().map(ColumnInfoBO::getName).map(name -> String.format("`%s`", name)).collect(Collectors.joining(", "));
+		}
+		return columnInfoBOs.stream().map(ColumnInfoBO::getName).map(name -> String.format("\"%s\"", name)).collect(Collectors.joining(", "));
+	}
 	/**
 	 * 构建SELECT SQL语句
 	 * @param typeName 数据源类型

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/util/SqlUtil.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/util/SqlUtil.java
@@ -42,8 +42,8 @@ public class SqlUtil {
 		if (CollectionUtils.isEmpty(columnInfoBOs)) {
 			return "*";
 		}
-		if (BizDataSourceTypeEnum.isMysqlDialect(typeName)) {
-			// mysql使用``标识对象
+		if (BizDataSourceTypeEnum.isMysqlDialect(typeName) || BizDataSourceTypeEnum.isHiveDialect(typeName)) {
+			// mysql/hive使用``标识对象
 			return columnInfoBOs.stream().map(ColumnInfoBO::getName).map(name -> String.format("`%s`", name)).collect(Collectors.joining(", "));
 		}
 		return columnInfoBOs.stream().map(ColumnInfoBO::getName).map(name -> String.format("\"%s\"", name)).collect(Collectors.joining(", "));

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/enums/BizDataSourceTypeEnumTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/enums/BizDataSourceTypeEnumTest.java
@@ -147,6 +147,16 @@ class BizDataSourceTypeEnumTest {
 	}
 
 	@Test
+	void isHiveDialect_trueForHive() {
+		assertTrue(BizDataSourceTypeEnum.isHiveDialect("hive"));
+	}
+
+	@Test
+	void isHiveDialect_falseForOthers() {
+		assertFalse(BizDataSourceTypeEnum.isHiveDialect("mysql"));
+	}
+
+	@Test
 	void isAdbPg_trueForAdgPg() {
 		assertTrue(BizDataSourceTypeEnum.isAdbPg("adg_pg"));
 	}

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/util/SqlUtilTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/util/SqlUtilTest.java
@@ -15,7 +15,11 @@
  */
 package com.alibaba.cloud.ai.dataagent.util;
 
+import com.alibaba.cloud.ai.dataagent.bo.schema.ColumnInfoBO;
 import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -71,6 +75,83 @@ class SqlUtilTest {
 	@Test
 	void buildSelectSql_emptyTableName_throwsException() {
 		assertThrows(IllegalArgumentException.class, () -> SqlUtil.buildSelectSql("mysql", "", "*", 10));
+	}
+
+	@Test
+	void buildColumnsSql_mysql_appendsLimit() {
+		List<ColumnInfoBO> columnInfoBOS = Arrays.asList(
+				new ColumnInfoBO("id", "users", "id", "int", true, true, null),
+				new ColumnInfoBO("name", "users", "name", "varchar", false, false, null),
+				new ColumnInfoBO("desc", "users", "desc", "varchar", false, false, null)
+		);
+		String sql = SqlUtil.buildColumnsSql("mysql", columnInfoBOS);
+		assertEquals("`id`, `name`, `desc`", sql);
+	}
+	@Test
+	void buildColumnsSql_hive_appendsLimit() {
+		List<ColumnInfoBO> columnInfoBOS = Arrays.asList(
+				new ColumnInfoBO("id", "users", "id", "int", true, true, null),
+				new ColumnInfoBO("name", "users", "name", "varchar", false, false, null),
+				new ColumnInfoBO("desc", "users", "desc", "varchar", false, false, null)
+		);
+		String sql = SqlUtil.buildColumnsSql("hive", columnInfoBOS);
+		assertEquals("`id`, `name`, `desc`", sql);
+	}
+
+	@Test
+	void buildColumnsSql_postgresql_appendsLimit() {
+		List<ColumnInfoBO> columnInfoBOS = Arrays.asList(
+				new ColumnInfoBO("id", "users", "id", "int", true, true, null),
+				new ColumnInfoBO("name", "users", "name", "varchar", false, false, null),
+				new ColumnInfoBO("desc", "users", "desc", "varchar", false, false, null)
+		);
+		String sql = SqlUtil.buildColumnsSql("postgresql", columnInfoBOS);
+		assertEquals("\"id\", \"name\", \"desc\"", sql);
+	}
+
+	@Test
+	void buildColumnsSql_h2_appendsLimit() {
+		List<ColumnInfoBO> columnInfoBOS = Arrays.asList(
+				new ColumnInfoBO("id", "users", "id", "int", true, true, null),
+				new ColumnInfoBO("name", "users", "name", "varchar", false, false, null),
+				new ColumnInfoBO("desc", "users", "desc", "varchar", false, false, null)
+		);
+		String sql = SqlUtil.buildColumnsSql("h2", columnInfoBOS);
+		assertEquals("\"id\", \"name\", \"desc\"", sql);
+	}
+
+	@Test
+	void buildColumnsSql_sqlserver_prependsTop() {
+		List<ColumnInfoBO> columnInfoBOS = Arrays.asList(
+				new ColumnInfoBO("id", "users", "id", "int", true, true, null),
+				new ColumnInfoBO("name", "users", "name", "varchar", false, false, null),
+				new ColumnInfoBO("desc", "users", "desc", "varchar", false, false, null)
+		);
+		String sql = SqlUtil.buildColumnsSql("sqlserver", columnInfoBOS);
+		assertEquals("\"id\", \"name\", \"desc\"", sql);
+	}
+
+	@Test
+	void buildColumnsSql_oracle_appendsFetchFirst() {
+		List<ColumnInfoBO> columnInfoBOS = Arrays.asList(
+				new ColumnInfoBO("id", "users", "id", "int", true, true, null),
+				new ColumnInfoBO("name", "users", "name", "varchar", false, false, null),
+				new ColumnInfoBO("desc", "users", "desc", "varchar", false, false, null)
+		);
+		String sql = SqlUtil.buildColumnsSql("oracle", columnInfoBOS);
+		assertEquals("\"id\", \"name\", \"desc\"", sql);
+	}
+
+	@Test
+	void buildColumnsSql_nullColumnNames_defaultsToStar() {
+		String sql = SqlUtil.buildColumnsSql("mysql", null);
+		assertEquals("*", sql);
+	}
+
+	@Test
+	void buildColumnsSql_emptyColumnNames_defaultsToStar() {
+		String sql = SqlUtil.buildColumnsSql("mysql", Arrays.asList());
+		assertEquals("*", sql);
 	}
 
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it

初始化数据源时，当有与sql保留字冲突的字段名称，会初始化失败

### Does this pull request fix one issue?

Fixes #525

### Describe how you did it
数据源采集在拼接字段时，根据数据源类型使用标识符包裹字段名：mysql+hive使用``标识，其他使用""标识（标准sql）

### Describe how to verify it
可以采集一个有与sql保留字冲突字段名的表（例如desc字段）

### Special notes for reviews
