### PR TITLE
fix: 多轮对话历史始终为空 — PlannerNode 节点名匹配错误 (#533)

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphServiceImpl.java
@@ -17,7 +17,7 @@ package com.alibaba.cloud.ai.dataagent.service.graph;
 
 import com.alibaba.cloud.ai.dataagent.service.langfuse.LangfuseService;
 import com.alibaba.cloud.ai.dataagent.enums.TextType;
-import com.alibaba.cloud.ai.dataagent.workflow.node.PlannerNode;
+
 import com.alibaba.cloud.ai.dataagent.dto.GraphRequest;
 import com.alibaba.cloud.ai.dataagent.service.graph.Context.MultiTurnContextManager;
 import com.alibaba.cloud.ai.dataagent.service.graph.Context.StreamContext;
@@ -321,7 +321,7 @@ public class GraphServiceImpl implements GraphService {
 		// 文本标记符号不返回给前端
 		if (!isTypeSign) {
 			context.appendOutput(chunk);
-			if (PlannerNode.class.getSimpleName().equals(node)) {
+			if (PLANNER_NODE.equals(node)) {
 				multiTurnContextManager.appendPlannerChunk(threadId, chunk);
 			}
 			GraphNodeResponse response = GraphNodeResponse.builder()


### PR DESCRIPTION
## Summary

Fixes #533

## Root Cause

`GraphServiceImpl.java:324` compared the streaming node name against `PlannerNode.class.getSimpleName()` which returns `"PlannerNode"`. However, the graph registers this node using the `PLANNER_NODE` constant (value `"PLANNER_NODE"`) in `DataAgentConfiguration.java:192`.

`"PlannerNode"` ≠ `"PLANNER_NODE"` — the condition was always false.

As a result, `appendPlannerChunk` was never called, the `planBuilder` remained empty, and `finishTurn()` silently skipped at line 83 because `StringUtils.isBlank(plan)` was true. Multi-turn conversation history was never written, so `buildContext()` always returned `(无)` regardless of how many conversation turns had completed.

## Fix

Replace `PlannerNode.class.getSimpleName()` with the `PLANNER_NODE` constant (already statically imported from `Constant.*`).

## Changes

- `GraphServiceImpl.java:324`: `PlannerNode.class.getSimpleName()` → `PLANNER_NODE`
- Removed unused `PlannerNode` import

## Test

```bash
./mvnw test -pl data-agent-management -Dtest="GraphServiceImplTest,MultiTurnContextManagerTest"
```
23 tests passed, 0 failures.