### PR TITLE
fix: 用后端 sessionId 作为 threadId 修复多轮对话不工作的问题 (#535)

### DIFF
--- a/data-agent-frontend/src/services/graph.ts
+++ b/data-agent-frontend/src/services/graph.ts
@@ -17,6 +17,7 @@
 export interface GraphRequest {
   agentId: string;
   threadId?: string;
+  sessionId?: string;
   query: string;
   humanFeedback: boolean;
   humanFeedbackContent?: string;
@@ -72,6 +73,9 @@ class GraphService {
     params.append('rejectedPlan', request.rejectedPlan.toString());
     params.append('nl2sqlOnly', request.nl2sqlOnly.toString());
 
+    if (request.sessionId) {
+      params.append('sessionId', request.sessionId);
+    }
     if (request.humanFeedbackContent) {
       params.append('humanFeedbackContent', request.humanFeedbackContent);
     }

--- a/data-agent-frontend/src/views/AgentRun.vue
+++ b/data-agent-frontend/src/views/AgentRun.vue
@@ -612,6 +612,7 @@
             rejectedPlan: false,
             humanFeedbackContent: null,
             threadId: sessionState.lastRequest?.threadId || null,
+            sessionId: currentSession.value.id,
           };
 
           userInput.value = '';

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/controller/GraphController.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/controller/GraphController.java
@@ -49,7 +49,8 @@ public class GraphController {
 			@RequestParam(value = "humanFeedback", required = false) boolean humanFeedback,
 			@RequestParam(value = "humanFeedbackContent", required = false) String humanFeedbackContent,
 			@RequestParam(value = "rejectedPlan", required = false) boolean rejectedPlan,
-			@RequestParam(value = "nl2sqlOnly", required = false) boolean nl2sqlOnly, ServerHttpResponse response) {
+			@RequestParam(value = "nl2sqlOnly", required = false) boolean nl2sqlOnly,
+			@RequestParam(value = "sessionId", required = false) String sessionId, ServerHttpResponse response) {
 		// Set SSE-related HTTP headers
 		response.getHeaders().add("Cache-Control", "no-cache");
 		response.getHeaders().add("Connection", "keep-alive");
@@ -65,6 +66,7 @@ public class GraphController {
 			.humanFeedbackContent(humanFeedbackContent)
 			.rejectedPlan(rejectedPlan)
 			.nl2sqlOnly(nl2sqlOnly)
+			.sessionId(sessionId)
 			.build();
 		graphService.graphStreamProcess(sink, request);
 

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/dto/GraphRequest.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/dto/GraphRequest.java
@@ -40,4 +40,6 @@ public class GraphRequest {
 
 	private boolean nl2sqlOnly;
 
+	private String sessionId;
+
 }

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphServiceImpl.java
@@ -82,6 +82,13 @@ public class GraphServiceImpl implements GraphService {
 			graphRequest.setThreadId(UUID.randomUUID().toString());
 		}
 		String threadId = graphRequest.getThreadId();
+		// 如果前端传了 sessionId，用 sessionId 统一多轮对话的 threadId
+		if (StringUtils.hasText(graphRequest.getSessionId())) {
+			threadId = graphRequest.getSessionId();
+			graphRequest.setThreadId(threadId);
+		}
+		log.info("[多轮调试] graphStreamProcess 入口, threadId={}, sessionId={}, query={}", threadId,
+				graphRequest.getSessionId(), graphRequest.getQuery());
 		// 创建或获取 StreamContext
 		StreamContext context = streamContextMap.computeIfAbsent(threadId, k -> new StreamContext());
 		context.setSink(sink);
@@ -138,6 +145,7 @@ public class GraphServiceImpl implements GraphService {
 		context.setSpan(span);
 
 		String multiTurnContext = multiTurnContextManager.buildContext(threadId);
+		log.info("[多轮调试] handleNewProcess, threadId={}, multiTurnContext={}", threadId, multiTurnContext);
 		multiTurnContextManager.beginTurn(threadId, query);
 		Flux<NodeOutput> nodeOutputFlux = compiledGraph.stream(
 				Map.of(IS_ONLY_NL2SQL, nl2sqlOnly, INPUT_KEY, query, AGENT_ID, agentId, HUMAN_REVIEW_ENABLED,

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphServiceImpl.java
@@ -87,7 +87,7 @@ public class GraphServiceImpl implements GraphService {
 			threadId = graphRequest.getSessionId();
 			graphRequest.setThreadId(threadId);
 		}
-		log.info("[多轮调试] graphStreamProcess 入口, threadId={}, sessionId={}, query={}", threadId,
+		log.info("[多轮调试-修复后] graphStreamProcess 入口, threadId={}, sessionId={}, query={}", threadId,
 				graphRequest.getSessionId(), graphRequest.getQuery());
 		// 创建或获取 StreamContext
 		StreamContext context = streamContextMap.computeIfAbsent(threadId, k -> new StreamContext());

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/controller/GraphControllerTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/controller/GraphControllerTest.java
@@ -62,7 +62,7 @@ class GraphControllerTest {
 		doNothing().when(graphService).graphStreamProcess(any(Sinks.Many.class), any(GraphRequest.class));
 
 		Flux<ServerSentEvent<GraphNodeResponse>> result = graphController.streamSearch("agent-1", "thread-1",
-				"show me sales data", false, null, false, false, serverHttpResponse);
+				"show me sales data", false, null, false, false, null, serverHttpResponse);
 
 		assertNotNull(result);
 
@@ -81,7 +81,7 @@ class GraphControllerTest {
 		doNothing().when(graphService).graphStreamProcess(any(Sinks.Many.class), any(GraphRequest.class));
 
 		Flux<ServerSentEvent<GraphNodeResponse>> result = graphController.streamSearch("agent-1", "thread-2",
-				"approve this plan", true, "looks good", false, false, serverHttpResponse);
+				"approve this plan", true, "looks good", false, false, null, serverHttpResponse);
 
 		assertNotNull(result);
 
@@ -99,7 +99,7 @@ class GraphControllerTest {
 		doNothing().when(graphService).graphStreamProcess(any(Sinks.Many.class), any(GraphRequest.class));
 
 		Flux<ServerSentEvent<GraphNodeResponse>> result = graphController.streamSearch("agent-1", null, "SELECT query",
-				false, null, false, true, serverHttpResponse);
+				false, null, false, true, null, serverHttpResponse);
 
 		assertNotNull(result);
 


### PR DESCRIPTION
## Summary

Fixes #535

## Root Cause

多轮对话上下文 `multi_turn` 始终为空。`threadId` 由前端内存中的 `sessionState.lastRequest?.threadId` 管理,每个浏览器标签页拥有独立的 Vue ref 实例,导致同一 session 在不同标签页中 threadId 不一致。后端收到的 threadId 要么为 null(新标签页),要么是不同标签页各自缓存的值。

## Fix

后端已有完整的 ChatSession 体系,将 sessionId 作为多轮对话的唯一标识:

### Backend
- `GraphRequest.java`: 加 `sessionId` 字段
- `GraphController.java`: 接收 `sessionId` 参数
- `GraphServiceImpl.java`: 如果传了 sessionId,用它覆盖 threadId,保证同一 session 内 threadId 一致

### Frontend
- `graph.ts`: GraphRequest 接口加 `sessionId`,拼到 URL 参数
- `AgentRun.vue`: 发请求时传 `currentSession.value.id`

## Changes

| 文件 | 改动 |
|------|------|
| `GraphRequest.java` | +2 行,加 sessionId 字段 |
| `GraphController.java` | +3 行,接收并传递 sessionId |
| `GraphServiceImpl.java` | +6 行,核心逻辑 |
| `graph.ts` | +4 行,接口+URL参数 |
| `AgentRun.vue` | +1 行,传入 sessionId |

## Test

编译通过:`./mvnw compile -pl data-agent-management`

手动验证:
1. 同一 session 两次请求 → threadId 一致 → multiTurnContext 有历史内容
2. 不同 session → threadId 不同 → 隔离