### PR TITLE
fix(datasource): rebuild connection url when params change (#345)

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/impl/DatasourceServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/impl/DatasourceServiceImpl.java
@@ -115,9 +115,27 @@ public class DatasourceServiceImpl implements DatasourceService {
 
 	@Override
 	public Datasource updateDatasource(Integer id, Datasource datasource) {
-		// Regenerate connection URL
+		// 当连接参数发生变化时，需要重新生成连接 URL，避免继续保存客户端带回来的旧 URL。
+		// 参数未变化时仍保留 resolveConnectionUrl 的行为，避免覆盖用户手动填写的自定义 URL。
 		DatasourceTypeHandler handler = datasourceTypeHandlerRegistry.getRequired(datasource.getType());
-		String connectionUrl = handler.resolveConnectionUrl(datasource);
+		Datasource existing = datasourceMapper.selectById(id);
+		String connectionUrl;
+		if (existing != null && handler.hasRequiredConnectionFields(datasource)
+				&& connectionParamsChanged(existing, datasource)) {
+			// 仅采用 handler 能完整拼出、且不会把复合 databaseName 泄漏进 URL 的重建结果。
+			// 例如当前 Oracle 的 databaseName 可能是 "service|schema"，#509 合并前朴素重建会把
+			// "|schema" 拼进 URL；此时继续保留 resolveConnectionUrl 的结果。
+			String rebuilt = handler.buildConnectionUrl(datasource);
+			if (StringUtils.isNotBlank(rebuilt) && !rebuilt.contains("|")) {
+				connectionUrl = rebuilt;
+			}
+			else {
+				connectionUrl = handler.resolveConnectionUrl(datasource);
+			}
+		}
+		else {
+			connectionUrl = handler.resolveConnectionUrl(datasource);
+		}
 		if (StringUtils.isNotBlank(connectionUrl)) {
 			datasource.setConnectionUrl(connectionUrl);
 		}
@@ -133,6 +151,16 @@ public class DatasourceServiceImpl implements DatasourceService {
 
 		datasourceMapper.updateById(datasource);
 		return datasource;
+	}
+
+	/**
+	 * 判断会影响自动生成连接 URL 的参数是否发生变化。
+	 */
+	private boolean connectionParamsChanged(Datasource existing, Datasource incoming) {
+		return !Objects.equals(existing.getType(), incoming.getType())
+				|| !Objects.equals(existing.getHost(), incoming.getHost())
+				|| !Objects.equals(existing.getPort(), incoming.getPort())
+				|| !Objects.equals(existing.getDatabaseName(), incoming.getDatabaseName());
 	}
 
 	@Override

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/datasource/impl/DatasourceServiceImplTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/datasource/impl/DatasourceServiceImplTest.java
@@ -25,6 +25,9 @@ import com.alibaba.cloud.ai.dataagent.mapper.AgentDatasourceMapper;
 import com.alibaba.cloud.ai.dataagent.mapper.DatasourceMapper;
 import com.alibaba.cloud.ai.dataagent.mapper.LogicalRelationMapper;
 import com.alibaba.cloud.ai.dataagent.service.datasource.handler.DatasourceTypeHandler;
+import com.alibaba.cloud.ai.dataagent.service.datasource.handler.impl.MysqlDatasourceTypeHandler;
+import com.alibaba.cloud.ai.dataagent.service.datasource.handler.impl.OracleDatasourceTypeHandler;
+import com.alibaba.cloud.ai.dataagent.service.datasource.handler.impl.PostgreSqlDatasourceTypeHandler;
 import com.alibaba.cloud.ai.dataagent.service.datasource.handler.registry.DatasourceTypeHandlerRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -421,6 +424,126 @@ class DatasourceServiceImplTest {
 
 		assertEquals("", result.getUsername());
 		assertEquals("", result.getPassword());
+	}
+
+	@Test
+	void updateDatasource_rebuildsConnectionUrlWhenDatabaseNameChanges() {
+		// #345：修改数据库名后，即使客户端带回旧 URL，也要按新的连接参数重新生成。
+		Datasource existing = Datasource.builder()
+			.id(5)
+			.type("mysql")
+			.host("localhost")
+			.port(3306)
+			.databaseName("olddb")
+			.connectionUrl("jdbc:mysql://localhost:3306/olddb")
+			.build();
+		when(datasourceMapper.selectById(5)).thenReturn(existing);
+		when(handlerRegistry.getRequired("mysql")).thenReturn(new MysqlDatasourceTypeHandler());
+
+		Datasource incoming = Datasource.builder()
+			.type("mysql")
+			.host("localhost")
+			.port(3306)
+			.databaseName("newdb")
+			.connectionUrl("jdbc:mysql://localhost:3306/olddb")
+			.build();
+
+		Datasource result = datasourceService.updateDatasource(5, incoming);
+
+		assertTrue(result.getConnectionUrl().contains("/newdb"),
+				"URL should reflect the new database name but was: " + result.getConnectionUrl());
+		assertFalse(result.getConnectionUrl().contains("/olddb"), "URL should not keep the old database name");
+		verify(datasourceMapper).updateById(incoming);
+	}
+
+	@Test
+	void updateDatasource_preservesCustomUrlWhenParamsUnchanged() {
+		// 连接参数未变化时，认为 connectionUrl 是用户手动填写的自定义 URL，不主动覆盖。
+		Datasource existing = Datasource.builder()
+			.id(7)
+			.type("mysql")
+			.host("localhost")
+			.port(3306)
+			.databaseName("db")
+			.connectionUrl("jdbc:mysql://localhost:3306/db")
+			.build();
+		when(datasourceMapper.selectById(7)).thenReturn(existing);
+		when(handlerRegistry.getRequired("mysql")).thenReturn(new MysqlDatasourceTypeHandler());
+
+		String customUrl = "jdbc:mysql://localhost:3306/db?useSSL=true&customParam=keepme";
+		Datasource incoming = Datasource.builder()
+			.type("mysql")
+			.host("localhost")
+			.port(3306)
+			.databaseName("db")
+			.connectionUrl(customUrl)
+			.build();
+
+		Datasource result = datasourceService.updateDatasource(7, incoming);
+
+		assertEquals(customUrl, result.getConnectionUrl());
+		verify(datasourceMapper).updateById(incoming);
+	}
+
+	@Test
+	void updateDatasource_preservesUrlForCompositeDatabaseName() {
+		// Oracle 把 schema 编码进 databaseName（"service|schema"），朴素重建会把
+		// "|schema" 残留进 URL，因此这类结果保留原 URL（完整重建见 #509）。
+		Datasource existing = Datasource.builder()
+			.id(9)
+			.type("oracle")
+			.host("orahost")
+			.port(1521)
+			.databaseName("orcl|HR")
+			.connectionUrl("jdbc:oracle:thin:@orahost:1521/orcl")
+			.build();
+		when(datasourceMapper.selectById(9)).thenReturn(existing);
+		when(handlerRegistry.getRequired("oracle")).thenReturn(new OracleDatasourceTypeHandler());
+
+		Datasource incoming = Datasource.builder()
+			.type("oracle")
+			.host("orahost")
+			.port(1521)
+			.databaseName("orcl|SCOTT")
+			.connectionUrl("jdbc:oracle:thin:@orahost:1521/orcl")
+			.build();
+
+		Datasource result = datasourceService.updateDatasource(9, incoming);
+
+		assertEquals("jdbc:oracle:thin:@orahost:1521/orcl", result.getConnectionUrl());
+		verify(datasourceMapper).updateById(incoming);
+	}
+
+	@Test
+	void updateDatasource_rebuildsUrlForPostgresCompositeDatabaseName() {
+		// PostgreSQL 的 databaseName 同样是 "db|schema"，但 buildConnectionUrl 会切出 db。
+		// 重建结果不含 "|" 时应正常采用，避免误伤 PostgreSQL 的 #345 场景。
+		Datasource existing = Datasource.builder()
+			.id(11)
+			.type("postgresql")
+			.host("pghost")
+			.port(5432)
+			.databaseName("olddb|public")
+			.connectionUrl("jdbc:postgresql://pghost:5432/olddb")
+			.build();
+		when(datasourceMapper.selectById(11)).thenReturn(existing);
+		when(handlerRegistry.getRequired("postgresql")).thenReturn(new PostgreSqlDatasourceTypeHandler());
+
+		Datasource incoming = Datasource.builder()
+			.type("postgresql")
+			.host("pghost")
+			.port(5432)
+			.databaseName("newdb|public")
+			.connectionUrl("jdbc:postgresql://pghost:5432/olddb")
+			.build();
+
+		Datasource result = datasourceService.updateDatasource(11, incoming);
+
+		assertTrue(result.getConnectionUrl().contains("/newdb"),
+				"URL should reflect the new database but was: " + result.getConnectionUrl());
+		assertFalse(result.getConnectionUrl().contains("olddb"), "URL should not keep the old database");
+		assertFalse(result.getConnectionUrl().contains("|"), "schema separator must not leak into the URL");
+		verify(datasourceMapper).updateById(incoming);
 	}
 
 	@Test


### PR DESCRIPTION
### 这个 PR 做了什么 / 为什么需要

`updateDatasource` 之前直接使用 `resolveConnectionUrl`：当客户端带回原有 connectionUrl 时会原样保存，导致修改 databaseName / host / port 后，URL 中的库名等不随之更新(#345)。

这是 service 层的契约问题，而不仅是 UI 问题：#484 将 connectionUrl 标记为 `@JsonProperty(WRITE_ONLY)` 后，自带 UI 的 GET 不再返回 URL、提交时该字段为空，从而掩盖了 UI 上的症状；但 REST / MCP 等直接携带 URL 的调用方仍可稳定复现。

本 PR 在连接参数发生变化时，按参数重新生成连接 URL。

### 是否修复了某个 issue?

Fixes #345

### 如何实现的

- `updateDatasource`：当 `existing != null`、handler 具备必需连接字段、且连接参数(type / host / port / databaseName)发生变化时，调用 `buildConnectionUrl` 按参数重建；否则保留 `resolveConnectionUrl` 的结果，避免覆盖用户手动填写的自定义 URL。
- 仅采用「能完整拼出、且不会把复合 databaseName 泄漏进 URL」的重建结果：当重建结果包含 `|` 时回退到 `resolveConnectionUrl`、保留原 URL。目前 Oracle 的 databaseName 形如 `service|schema`，朴素重建会把 `|schema` 拼进 URL，此守卫可避免拼坏。
- Oracle URL 的完整(去 schema)重建由 #509 负责；#509 合并后其重建结果不再含 `|`，本逻辑会自动采用，无需后续改动。
- 仅改动 service 层，不修改任何 handler。
- 边界说明：参数变化时会以重建结果覆盖客户端带回的 URL(包括自定义 URL)，这是本修复的预期行为；SQL Server 没有参数化的 URL 构造(未覆写 `buildConnectionUrl`)，本 PR 不改变其现有行为，为其补充 URL 构造属于独立增强。

### 如何验证

新增 `DatasourceServiceImplTest` 用例：

- `updateDatasource_rebuildsConnectionUrlWhenDatabaseNameChanges`：MySQL 修改库名后 URL 反映新库名(复现 #345)。
- `updateDatasource_preservesCustomUrlWhenParamsUnchanged`：参数未变化时保留用户自定义 URL。
- `updateDatasource_preservesUrlForCompositeDatabaseName`：Oracle `service|schema` 仅 schema 变化时保留原 URL，不被拼坏。
- `updateDatasource_rebuildsUrlForPostgresCompositeDatabaseName`：PostgreSQL `db|schema` 修改库名时正常重建，且 `|` 不泄漏进 URL(验证守卫未误伤 PostgreSQL)。

执行以下命令通过：

- `./mvnw.cmd -pl data-agent-management test -Dtest=DatasourceServiceImplTest -Dcheckstyle.skip=true`
- `./mvnw.cmd -pl data-agent-management test -Dtest=DatasourceServiceImplTest,DatasourceControllerTest,*DatasourceTypeHandlerTest,DatasourceTypeHandlerRegistryTest -DfailIfNoTests=false`
- `./mvnw.cmd -pl data-agent-management spotless:check`
- `./mvnw.cmd -pl data-agent-management checkstyle:check`

### 给 reviewer 的特别说明

- 与 #509 互补、无方法级重叠：#509 改动 `OracleDatasourceTypeHandler.buildConnectionUrl` 与 `realConnectionTest`，本 PR 改动 `updateDatasource` 并新增 `connectionParamsChanged`；共用文件 `DatasourceServiceImpl.java` 的改动位于不同方法，合并冲突风险极低。
- 关于 #484 将 connectionUrl 标为 WRITE_ONLY 从而掩盖 UI 症状的背景见上节，本修复针对 service 层契约，对直接携带 URL 的调用方有效。