### PR TITLE
fix(management): 测试模型连接时跳过 HTTP 重试 (#530)

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/DynamicModelFactory.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/DynamicModelFactory.java
@@ -35,6 +35,7 @@ import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.ai.retry.RetryUtils;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -48,11 +49,16 @@ import reactor.netty.transport.ProxyProvider;
 @RequiredArgsConstructor
 public class DynamicModelFactory {
 
+	public static final RetryTemplate NO_RETRY_TEMPLATE = RetryTemplate.builder().maxAttempts(1).build();
+
 	/**
 	 * 统一使用 OpenAiChatModel，通过 baseUrl 实现多厂商兼容
 	 */
 	public ChatModel createChatModel(ModelConfigDTO config) {
+		return createChatModel(config, RetryUtils.DEFAULT_RETRY_TEMPLATE);
+	}
 
+	public ChatModel createChatModel(ModelConfigDTO config, RetryTemplate retryTemplate) {
 		log.info("Creating NEW ChatModel instance. Provider: {}, Model: {}, BaseUrl: {}", config.getProvider(),
 				config.getModelName(), config.getBaseUrl());
 		// 1. 验证参数
@@ -79,13 +85,21 @@ public class DynamicModelFactory {
 			.streamUsage(true)
 			.build();
 		// 4. 返回统一的 OpenAiChatModel
-		return OpenAiChatModel.builder().openAiApi(openAiApi).defaultOptions(openAiChatOptions).build();
+		return OpenAiChatModel.builder()
+			.openAiApi(openAiApi)
+			.defaultOptions(openAiChatOptions)
+			.retryTemplate(retryTemplate)
+			.build();
 	}
 
 	/**
 	 * Embedding 同理
 	 */
 	public EmbeddingModel createEmbeddingModel(ModelConfigDTO config) {
+		return createEmbeddingModel(config, RetryUtils.DEFAULT_RETRY_TEMPLATE);
+	}
+
+	public EmbeddingModel createEmbeddingModel(ModelConfigDTO config, RetryTemplate retryTemplate) {
 		log.info("Creating NEW EmbeddingModel instance. Provider: {}, Model: {}, BaseUrl: {}", config.getProvider(),
 				config.getModelName(), config.getBaseUrl());
 		checkBasic(config);
@@ -103,8 +117,7 @@ public class DynamicModelFactory {
 
 		OpenAiApi openAiApi = apiBuilder.build();
 		return new OpenAiEmbeddingModel(openAiApi, MetadataMode.EMBED,
-				OpenAiEmbeddingOptions.builder().model(config.getModelName()).build(),
-				RetryUtils.DEFAULT_RETRY_TEMPLATE);
+				OpenAiEmbeddingOptions.builder().model(config.getModelName()).build(), retryTemplate);
 	}
 
 	private static void checkBasic(ModelConfigDTO config) {

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigOpsService.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigOpsService.java
@@ -135,7 +135,7 @@ public class ModelConfigOpsService {
 				config.getModelName());
 
 		// 1. 创建临时模型
-		ChatModel tempModel = modelFactory.createChatModel(config);
+		ChatModel tempModel = modelFactory.createChatModel(config, DynamicModelFactory.NO_RETRY_TEMPLATE);
 
 		// 2. 发起最轻量的请求
 		String promptText = "Hello";
@@ -154,7 +154,7 @@ public class ModelConfigOpsService {
 		log.info("Testing Embedding Model connection, provider: {} modelName: {}", config.getProvider(),
 				config.getModelName());
 		// 1. 创建临时模型
-		EmbeddingModel tempModel = modelFactory.createEmbeddingModel(config);
+		EmbeddingModel tempModel = modelFactory.createEmbeddingModel(config, DynamicModelFactory.NO_RETRY_TEMPLATE);
 
 		// 2. 发起请求
 		float[] embedding = tempModel.embed("Test");

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigOpsServiceTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigOpsServiceTest.java
@@ -114,7 +114,7 @@ class ModelConfigOpsServiceTest {
 		dto.setModelName("gpt-4");
 
 		ChatModel chatModel = mock(ChatModel.class);
-		when(modelFactory.createChatModel(dto)).thenReturn(chatModel);
+		when(modelFactory.createChatModel(dto, DynamicModelFactory.NO_RETRY_TEMPLATE)).thenReturn(chatModel);
 		when(chatModel.call("Hello")).thenReturn("Hi there");
 
 		assertDoesNotThrow(() -> service.testConnection(dto));
@@ -128,7 +128,7 @@ class ModelConfigOpsServiceTest {
 		dto.setModelName("text-embedding");
 
 		EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
-		when(modelFactory.createEmbeddingModel(dto)).thenReturn(embeddingModel);
+		when(modelFactory.createEmbeddingModel(dto, DynamicModelFactory.NO_RETRY_TEMPLATE)).thenReturn(embeddingModel);
 		when(embeddingModel.embed("Test")).thenReturn(new float[] { 0.1f, 0.2f });
 
 		assertDoesNotThrow(() -> service.testConnection(dto));
@@ -148,7 +148,7 @@ class ModelConfigOpsServiceTest {
 		dto.setModelType("CHAT");
 
 		ChatModel chatModel = mock(ChatModel.class);
-		when(modelFactory.createChatModel(dto)).thenReturn(chatModel);
+		when(modelFactory.createChatModel(dto, DynamicModelFactory.NO_RETRY_TEMPLATE)).thenReturn(chatModel);
 		when(chatModel.call("Hello")).thenReturn("");
 
 		assertThrows(RuntimeException.class, () -> service.testConnection(dto));
@@ -160,7 +160,7 @@ class ModelConfigOpsServiceTest {
 		dto.setModelType("EMBEDDING");
 
 		EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
-		when(modelFactory.createEmbeddingModel(dto)).thenReturn(embeddingModel);
+		when(modelFactory.createEmbeddingModel(dto, DynamicModelFactory.NO_RETRY_TEMPLATE)).thenReturn(embeddingModel);
 		when(embeddingModel.embed("Test")).thenReturn(new float[0]);
 
 		assertThrows(RuntimeException.class, () -> service.testConnection(dto));


### PR DESCRIPTION
Closes #530

根因：测试连接路径复用了 Spring AI 默认重试模板（10 次 + 指数退避，并重试 ResourceAccessException），当 endpoint 错误或不可达时会长时间重试，导致前端一直停在“测试中”。

改动：为 DynamicModelFactory 增加 no-retry 模板重载，测试连接显式使用该模板；运行时 AiModelRegistry 继续走默认重试模板。