### PR TITLE
fix(graph): preserve clarification turns in context

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/Context/MultiTurnContextManager.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/Context/MultiTurnContextManager.java
@@ -72,7 +72,25 @@ public class MultiTurnContextManager {
 	}
 
 	/**
-	 * Finalize current turn and add to history if planner output is available.
+	 * Append assistant output chunk for the current turn. This is used as a
+	 * fallback history entry when a turn ends before PlannerNode, for example when
+	 * the feasibility assessment asks the user to clarify the query.
+	 * @param threadId conversation thread id
+	 * @param chunk assistant streaming chunk
+	 */
+	public void appendAssistantChunk(String threadId, String chunk) {
+		if (StringUtils.isAnyBlank(threadId, chunk)) {
+			return;
+		}
+		PendingTurn pending = pendingTurns.get(threadId);
+		if (pending != null) {
+			pending.assistantBuilder.append(chunk);
+		}
+	}
+
+	/**
+	 * Finalize current turn and add to history if planner or assistant output is
+	 * available.
 	 * @param threadId conversation thread id
 	 */
 	public void finishTurn(String threadId) {
@@ -81,18 +99,21 @@ public class MultiTurnContextManager {
 			return;
 		}
 		String plan = StringUtils.trimToEmpty(pending.planBuilder.toString());
-		if (StringUtils.isBlank(plan)) {
-			log.debug("No planner output recorded for thread {}, skipping history update", threadId);
+		String assistantOutput = StringUtils.trimToEmpty(pending.assistantBuilder.toString());
+		String response = StringUtils.isNotBlank(plan) ? plan : assistantOutput;
+		if (StringUtils.isBlank(response)) {
+			log.debug("No planner or assistant output recorded for thread {}, skipping history update", threadId);
 			return;
 		}
 
-		String trimmedPlan = StringUtils.abbreviate(plan, properties.getMaxplanlength());
+		String responseLabel = StringUtils.isNotBlank(plan) ? "AI计划" : "AI回复";
+		String trimmedResponse = StringUtils.abbreviate(response, properties.getMaxplanlength());
 		Deque<ConversationTurn> deque = history.computeIfAbsent(threadId, k -> new ArrayDeque<>());
 		synchronized (deque) {
 			while (deque.size() >= properties.getMaxturnhistory()) {
 				deque.pollFirst();
 			}
-			deque.addLast(new ConversationTurn(pending.userQuestion, trimmedPlan));
+			deque.addLast(new ConversationTurn(pending.userQuestion, responseLabel, trimmedResponse));
 		}
 	}
 
@@ -135,11 +156,11 @@ public class MultiTurnContextManager {
 			return "(无)";
 		}
 		return deque.stream()
-			.map(turn -> "用户: " + turn.userQuestion() + "\nAI计划: " + turn.plan())
+			.map(turn -> "用户: " + turn.userQuestion() + "\n" + turn.responseLabel() + ": " + turn.response())
 			.collect(Collectors.joining("\n"));
 	}
 
-	private record ConversationTurn(String userQuestion, String plan) {
+	private record ConversationTurn(String userQuestion, String responseLabel, String response) {
 	}
 
 	private static class PendingTurn {
@@ -147,6 +168,8 @@ public class MultiTurnContextManager {
 		private final String userQuestion;
 
 		private final StringBuilder planBuilder = new StringBuilder();
+
+		private final StringBuilder assistantBuilder = new StringBuilder();
 
 		private PendingTurn(String userQuestion) {
 			this.userQuestion = userQuestion;

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphServiceImpl.java
@@ -324,6 +324,9 @@ public class GraphServiceImpl implements GraphService {
 			if (PlannerNode.class.getSimpleName().equals(node)) {
 				multiTurnContextManager.appendPlannerChunk(threadId, chunk);
 			}
+			else {
+				multiTurnContextManager.appendAssistantChunk(threadId, chunk);
+			}
 			GraphNodeResponse response = GraphNodeResponse.builder()
 				.agentId(request.getAgentId())
 				.threadId(threadId)

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/graph/MultiTurnContextManagerTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/graph/MultiTurnContextManagerTest.java
@@ -78,7 +78,18 @@ class MultiTurnContextManagerTest {
 	}
 
 	@Test
-	void finishTurn_noPlannerOutput_skipsHistory() {
+	void finishTurn_assistantOutputWithoutPlanner_storesHistory() {
+		contextManager.beginTurn("thread-1", "Query 1");
+		contextManager.appendAssistantChunk("thread-1", "Please clarify the metric.");
+		contextManager.finishTurn("thread-1");
+
+		String context = contextManager.buildContext("thread-1");
+		assertTrue(context.contains("Query 1"));
+		assertTrue(context.contains("AI回复: Please clarify the metric."));
+	}
+
+	@Test
+	void finishTurn_noOutput_skipsHistory() {
 		contextManager.beginTurn("thread-1", "Query 1");
 		contextManager.finishTurn("thread-1");
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

修复多轮对话中“用户澄清后无法稳定续接上一轮问题”的问题。

当前流程里，如果 `FeasibilityAssessmentNode` 将用户请求判断为“需要澄清”，Graph 会流式输出澄清问题，然后在进入 `PlannerNode` 之前结束本轮执行。

例如：

1. 用户输入：`找出最受欢迎的网络小说`
2. 后端返回：`请问您指的“最受欢迎”是按“评分”还是“点击数”来衡量呢？`
3. 用户下一轮输入：`按点击数`

修复前，`MultiTurnContextManager` 只会保存有 `PlannerNode` 输出的轮次。由于“需要澄清”的轮次没有进入 `PlannerNode`，`finishTurn` 会直接丢弃这一轮上下文，导致下一轮的 `按点击数` 会作为一个孤立的新 query 处理，`MULTI_TURN_CONTEXT` 中没有上一轮原始问题和澄清提示。

这会导致模型无法稳定判断用户是在回答上一轮澄清问题。

### Does this pull request fix one issue?

NONE

### Describe how you did it

本 PR 调整了多轮上下文记录逻辑：

1. 在 `MultiTurnContextManager` 中新增 assistant 输出缓存。
2. 在 `GraphServiceImpl` 中，`PlannerNode` 的流式输出仍然写入 planner 输出；非 `PlannerNode` 的流式输出会写入 assistant 输出。
3. `finishTurn` 时：
   - 如果有 planner 输出，继续按原逻辑保存为 `AI计划`
   - 如果没有 planner 输出，但有 assistant 输出，则保存为 `AI回复`
   - 如果两者都没有，仍然跳过历史写入

这样即使流程在澄清阶段结束，也会把本轮用户问题和 assistant 澄清回复保存到多轮上下文中。

修复后，下一轮同一个 `threadId` 的请求可以在 `MULTI_TURN_CONTEXT` 中看到：

```text
用户: 找出最受欢迎的网络小说
AI回复: 请问您指的“最受欢迎”是按“评分”还是“点击数”来衡量呢？
```

因此用户继续输入 `按点击数` 时，模型可以结合上下文理解这是对上一轮澄清问题的回答，而不是孤立的新 query。

### Describe how to verify it

可以通过以下场景验证：

1. 输入一个需要澄清的模糊问题，例如：`找出最受欢迎的网络小说`
2. 确认后端返回澄清问题，例如询问按“评分”还是“点击数”
3. 在同一个 `threadId` 下继续输入：`按点击数`
4. 确认第二轮请求的 `MULTI_TURN_CONTEXT` 中包含上一轮用户问题和 assistant 澄清回复
5. 确认模型能够将 `按点击数` 理解为上一轮问题的补充条件

已补充 `MultiTurnContextManagerTest`，覆盖无 `PlannerNode` 输出但有 assistant 回复时应保存上下文的场景。

本地尝试执行：

```bash
./mvnw -pl data-agent-management -Dtest=MultiTurnContextManagerTest test
```

但当前本地环境 Maven wrapper 执行超时，未能完成测试运行。

### Special notes for reviews

本次修改保持原有 planner 输出逻辑不变，仅在没有 planner 输出但存在 assistant 输出时，额外保存该轮上下文，避免澄清轮次丢失。