### PR TITLE
feat: feat-agentscope 分支兼容 OpenAI Responses API（含 tool calling）

### DIFF
--- a/data-agent-frontend/src/services/modelConfig.ts
+++ b/data-agent-frontend/src/services/modelConfig.ts
@@ -34,6 +34,7 @@ export interface ModelConfig {
   proxyPort?: number;
   proxyUsername?: string;
   proxyPassword?: string;
+  chatApiProtocol?: string; // Chat模型接口协议: CHAT_COMPLETIONS（默认）或 RESPONSES
 }
 
 export interface ModelCheckReady {

--- a/data-agent-frontend/src/views/ModelConfig.vue
+++ b/data-agent-frontend/src/views/ModelConfig.vue
@@ -230,12 +230,30 @@
 
           <el-form-item
             v-if="formData.modelType === 'CHAT'"
-            label="Completions路径"
+            label="接口协议"
+            prop="chatApiProtocol"
+          >
+            <el-select v-model="formData.chatApiProtocol" style="width: 100%">
+              <el-option label="Chat Completions（默认）" value="CHAT_COMPLETIONS" />
+              <el-option label="Responses API" value="RESPONSES" />
+            </el-select>
+            <div class="form-tip">
+              部分模型服务商仅支持 Responses API 格式，此时请选择 Responses API
+            </div>
+          </el-form-item>
+
+          <el-form-item
+            v-if="formData.modelType === 'CHAT'"
+            :label="formData.chatApiProtocol === 'RESPONSES' ? 'Responses路径' : 'Completions路径'"
             prop="completionsPath"
           >
             <el-input
               v-model="formData.completionsPath"
-              placeholder="附加到base-url的路径。留空则使用默认值/v1/chat/completions"
+              :placeholder="
+                formData.chatApiProtocol === 'RESPONSES'
+                  ? '附加到base-url的路径。留空则使用默认值/v1/responses'
+                  : '附加到base-url的路径。留空则使用默认值/v1/chat/completions'
+              "
             />
           </el-form-item>
 
@@ -374,6 +392,7 @@
         proxyPort: 7890, // 给个常用的默认端口
         proxyUsername: '',
         proxyPassword: '',
+        chatApiProtocol: 'CHAT_COMPLETIONS',
       });
 
       // 提供商与API地址的映射
@@ -493,13 +512,18 @@
           completionsPath: '',
           embeddingsPath: '',
           isActive: false,
+          chatApiProtocol: 'CHAT_COMPLETIONS',
         };
         dialogVisible.value = true;
       };
 
       const handleEdit = (config: ModelConfig) => {
         isEditMode.value = true;
-        formData.value = { ...config };
+        // 历史数据的 chatApiProtocol 可能为空（该字段为后续版本新增），回填默认协议避免下拉框空白
+        formData.value = {
+          ...config,
+          chatApiProtocol: config.chatApiProtocol || 'CHAT_COMPLETIONS',
+        };
         dialogVisible.value = true;
       };
 

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/converter/ModelConfigConverter.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/converter/ModelConfigConverter.java
@@ -17,8 +17,10 @@ package com.alibaba.cloud.ai.dataagent.converter;
 
 import com.alibaba.cloud.ai.dataagent.dto.ModelConfigDTO;
 import com.alibaba.cloud.ai.dataagent.entity.ModelConfig;
+import com.alibaba.cloud.ai.dataagent.enums.ChatApiProtocol;
 import com.alibaba.cloud.ai.dataagent.enums.ModelType;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 
@@ -75,7 +77,10 @@ public class ModelConfigConverter {
 		entity.setProxyPort(dto.getProxyPort());
 		entity.setProxyUsername(dto.getProxyUsername());
 		entity.setProxyPassword(dto.getProxyPassword());
-		entity.setChatApiProtocol(dto.getChatApiProtocol());
+		// chatApiProtocol 为空时回填默认协议：INSERT 显式写入 NULL 会绕过数据库列的 DEFAULT 值，
+		// 统一在转换层兜底，保证新增数据与列默认值口径一致
+		entity.setChatApiProtocol(StringUtils.hasText(dto.getChatApiProtocol()) ? dto.getChatApiProtocol()
+				: ChatApiProtocol.CHAT_COMPLETIONS.getCode());
 		// 默认值处理
 		entity.setIsActive(false);
 		entity.setIsDeleted(0);

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/converter/ModelConfigConverter.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/converter/ModelConfigConverter.java
@@ -48,6 +48,7 @@ public class ModelConfigConverter {
 			.proxyPort(entity.getProxyPort())
 			.proxyUsername(entity.getProxyUsername())
 			.proxyPassword(entity.getProxyPassword())
+			.chatApiProtocol(entity.getChatApiProtocol())
 			.build();
 	}
 
@@ -74,6 +75,7 @@ public class ModelConfigConverter {
 		entity.setProxyPort(dto.getProxyPort());
 		entity.setProxyUsername(dto.getProxyUsername());
 		entity.setProxyPassword(dto.getProxyPassword());
+		entity.setChatApiProtocol(dto.getChatApiProtocol());
 		// 默认值处理
 		entity.setIsActive(false);
 		entity.setIsDeleted(0);

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/dto/ModelConfigDTO.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/dto/ModelConfigDTO.java
@@ -69,4 +69,7 @@ public class ModelConfigDTO {
 
 	private String proxyPassword;
 
+	// Chat 模型接口协议：CHAT_COMPLETIONS（默认）或 RESPONSES，仅 modelType=CHAT 时生效
+	private String chatApiProtocol;
+
 }

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/entity/ModelConfig.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/entity/ModelConfig.java
@@ -70,4 +70,7 @@ public class ModelConfig {
 
 	private String proxyPassword;
 
+	// Chat 模型接口协议：CHAT_COMPLETIONS（默认）或 RESPONSES，仅 modelType=CHAT 时生效
+	private String chatApiProtocol;
+
 }

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/enums/ChatApiProtocol.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/enums/ChatApiProtocol.java
@@ -40,4 +40,17 @@ public enum ChatApiProtocol {
 		this.code = code;
 	}
 
+	/**
+	 * 根据代码解析枚举（忽略大小写）。 非法值直接抛异常拦截在保存入口：若不拦截，拼写错误的协议值会在 DynamicModelFactory 静默落入默认的 Chat
+	 * Completions 分支，用户配置悄悄失效且难以排查。
+	 */
+	public static ChatApiProtocol fromCode(String code) {
+		for (ChatApiProtocol protocol : values()) {
+			if (protocol.getCode().equalsIgnoreCase(code)) {
+				return protocol;
+			}
+		}
+		throw new IllegalArgumentException("不支持的 Chat 接口协议: " + code + "，仅支持 CHAT_COMPLETIONS 或 RESPONSES");
+	}
+
 }

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/enums/ChatApiProtocol.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/enums/ChatApiProtocol.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.enums;
+
+import lombok.Getter;
+
+/**
+ * Chat 模型接口协议枚举。 CHAT_COMPLETIONS：标准 OpenAI Chat Completions 格式（默认，/v1/chat/completions）；
+ * RESPONSES：OpenAI Responses API 格式（/v1/responses），用于仅支持该协议的模型服务商。
+ */
+@Getter
+public enum ChatApiProtocol {
+
+	/**
+	 * 标准 Chat Completions 协议（默认）
+	 */
+	CHAT_COMPLETIONS("CHAT_COMPLETIONS"),
+
+	/**
+	 * OpenAI Responses API 协议
+	 */
+	RESPONSES("RESPONSES");
+
+	private final String code;
+
+	ChatApiProtocol(String code) {
+		this.code = code;
+	}
+
+}

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/mapper/ModelConfigMapper.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/mapper/ModelConfigMapper.java
@@ -26,7 +26,7 @@ public interface ModelConfigMapper {
 	@Select("""
 			SELECT id, provider, base_url, api_key, model_name, temperature, is_active, max_tokens,
 			       model_type, completions_path, embeddings_path, created_time, updated_time, is_deleted,
-			       proxy_enabled, proxy_host, proxy_port, proxy_username, proxy_password
+			       proxy_enabled, proxy_host, proxy_port, proxy_username, proxy_password, chat_api_protocol
 			FROM model_config WHERE is_deleted = 0 ORDER BY created_time DESC
 			""")
 	List<ModelConfig> findAll();
@@ -34,7 +34,7 @@ public interface ModelConfigMapper {
 	@Select("""
 			SELECT id, provider, base_url, api_key, model_name, temperature, is_active, max_tokens,
 			       model_type, completions_path, embeddings_path, created_time, updated_time, is_deleted,
-			       proxy_enabled, proxy_host, proxy_port, proxy_username, proxy_password
+			       proxy_enabled, proxy_host, proxy_port, proxy_username, proxy_password, chat_api_protocol
 			FROM model_config WHERE id = #{id} AND is_deleted = 0
 			""")
 	ModelConfig findById(Integer id);
@@ -42,7 +42,7 @@ public interface ModelConfigMapper {
 	@Select("""
 			SELECT id, provider, base_url, api_key, model_name, temperature, is_active, max_tokens,
 			       model_type, completions_path, embeddings_path, created_time, updated_time, is_deleted,
-			       proxy_enabled, proxy_host, proxy_port, proxy_username, proxy_password
+			       proxy_enabled, proxy_host, proxy_port, proxy_username, proxy_password, chat_api_protocol
 			FROM model_config WHERE model_type = #{modelType} AND is_active = 1 AND is_deleted = 0 LIMIT 1
 			""")
 	ModelConfig selectActiveByType(@Param("modelType") String modelType);
@@ -54,7 +54,7 @@ public interface ModelConfigMapper {
 			<script>
 			   SELECT id, provider, base_url, api_key, model_name, temperature, is_active, max_tokens,
 			          model_type, completions_path, embeddings_path, created_time, updated_time, is_deleted,
-			          proxy_enabled, proxy_host, proxy_port, proxy_username, proxy_password
+			          proxy_enabled, proxy_host, proxy_port, proxy_username, proxy_password, chat_api_protocol
 			   FROM model_config
 			   <where>
 			      is_deleted = 0
@@ -86,10 +86,10 @@ public interface ModelConfigMapper {
 	@Insert("""
 			INSERT INTO model_config (provider, base_url, api_key, model_name, temperature, is_active, max_tokens,
 			                         model_type, completions_path, embeddings_path, created_time, updated_time, is_deleted,
-			                         proxy_enabled, proxy_host, proxy_port, proxy_username, proxy_password)
+			                         proxy_enabled, proxy_host, proxy_port, proxy_username, proxy_password, chat_api_protocol)
 			VALUES (#{provider}, #{baseUrl}, #{apiKey}, #{modelName}, #{temperature}, #{isActive}, #{maxTokens},
 			        #{modelType}, #{completionsPath}, #{embeddingsPath}, NOW(), NOW(), 0,
-			        #{proxyEnabled}, #{proxyHost}, #{proxyPort}, #{proxyUsername}, #{proxyPassword})
+			        #{proxyEnabled}, #{proxyHost}, #{proxyPort}, #{proxyUsername}, #{proxyPassword}, #{chatApiProtocol})
 			""")
 	@Options(useGeneratedKeys = true, keyProperty = "id", keyColumn = "id")
 	int insert(ModelConfig modelConfig);
@@ -114,6 +114,7 @@ public interface ModelConfigMapper {
 			            <if test='proxyPort != null'>proxy_port = #{proxyPort},</if>
 			            <if test='proxyUsername != null'>proxy_username = #{proxyUsername},</if>
 			            <if test='proxyPassword != null'>proxy_password = #{proxyPassword},</if>
+			            <if test='chatApiProtocol != null'>chat_api_protocol = #{chatApiProtocol},</if>
 			            updated_time = NOW()
 			          </trim>
 			          WHERE id = #{id}

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/DynamicModelFactory.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/DynamicModelFactory.java
@@ -16,6 +16,9 @@
 package com.alibaba.cloud.ai.dataagent.service.aimodelconfig;
 
 import com.alibaba.cloud.ai.dataagent.dto.ModelConfigDTO;
+import com.alibaba.cloud.ai.dataagent.enums.ChatApiProtocol;
+import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApi;
+import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApiChatModel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hc.client5.http.auth.AuthScope;
@@ -49,15 +52,51 @@ import reactor.netty.transport.ProxyProvider;
 public class DynamicModelFactory {
 
 	/**
-	 * 统一使用 OpenAiChatModel，通过 baseUrl 实现多厂商兼容
+	 * 根据配置的接口协议创建 ChatModel。 RESPONSES 协议走自研 ResponsesApiChatModel； CHAT_COMPLETIONS（默认）走
+	 * OpenAiChatModel。 两者均实现 ChatModel 接口，对上层完全透明。
 	 */
 	public ChatModel createChatModel(ModelConfigDTO config) {
 
-		log.info("Creating NEW ChatModel instance. Provider: {}, Model: {}, BaseUrl: {}", config.getProvider(),
-				config.getModelName(), config.getBaseUrl());
+		log.info("Creating NEW ChatModel instance. Provider: {}, Model: {}, BaseUrl: {}, Protocol: {}",
+				config.getProvider(), config.getModelName(), config.getBaseUrl(), config.getChatApiProtocol());
 		// 1. 验证参数
 		checkBasic(config);
 
+		// 按接口协议分支：RESPONSES 走自研适配层，其余保持现状走 OpenAiChatModel
+		if (ChatApiProtocol.RESPONSES.name().equalsIgnoreCase(config.getChatApiProtocol())) {
+			return createResponsesApiChatModel(config);
+		}
+
+		// 默认：Chat Completions 协议（现有逻辑，零变更）
+		return createCompletionsChatModel(config);
+	}
+
+	/**
+	 * 创建基于 Responses API 的 ChatModel。 复用现有的 proxy RestClient/WebClient 构建体系，代理能力天然继承。
+	 * completionsPath 在 RESPONSES 协议下复用为自定义 responses 路径（默认 /v1/responses）。
+	 */
+	private ChatModel createResponsesApiChatModel(ModelConfigDTO config) {
+		String apiKey = StringUtils.hasText(config.getApiKey()) ? config.getApiKey() : "";
+		// completionsPath 复用为 Responses API 路径，默认 /v1/responses
+		String responsesPath = StringUtils.hasText(config.getCompletionsPath()) ? config.getCompletionsPath()
+				: "/v1/responses";
+
+		ResponsesApi responsesApi = new ResponsesApi(config.getBaseUrl(), apiKey, responsesPath,
+				getProxiedRestClientBuilder(config), getProxiedWebClientBuilder(config));
+
+		OpenAiChatOptions chatOptions = OpenAiChatOptions.builder()
+			.model(config.getModelName())
+			.temperature(config.getTemperature())
+			.maxTokens(config.getMaxTokens())
+			.build();
+
+		return new ResponsesApiChatModel(responsesApi, chatOptions);
+	}
+
+	/**
+	 * 创建基于 Chat Completions 协议的 ChatModel（原有逻辑）
+	 */
+	private ChatModel createCompletionsChatModel(ModelConfigDTO config) {
 		// 2. 构建 OpenAiApi (核心通讯对象)
 		String apiKey = StringUtils.hasText(config.getApiKey()) ? config.getApiKey() : "";
 		OpenAiApi.Builder apiBuilder = OpenAiApi.builder()

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigDataServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigDataServiceImpl.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.cloud.ai.dataagent.service.aimodelconfig;
 
+import com.alibaba.cloud.ai.dataagent.enums.ChatApiProtocol;
 import com.alibaba.cloud.ai.dataagent.enums.ModelType;
 import com.alibaba.cloud.ai.dataagent.converter.ModelConfigConverter;
 import com.alibaba.cloud.ai.dataagent.dto.ModelConfigDTO;
@@ -24,6 +25,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -80,6 +82,12 @@ public class ModelConfigDataServiceImpl implements ModelConfigDataService {
 		}
 		if (dto.getEmbeddingsPath() != null) {
 			dto.setEmbeddingsPath(dto.getEmbeddingsPath().trim());
+		}
+		// 校验并归一化接口协议：前端下拉框虽限制了取值，但 API 直调可能传任意字符串，
+		// 非法值若不在保存入口拦截，会在 DynamicModelFactory 静默落入默认协议分支导致配置悄悄失效。
+		// fromCode 忽略大小写，归一为枚举标准值后存库，保证库内口径统一
+		if (StringUtils.hasText(dto.getChatApiProtocol())) {
+			dto.setChatApiProtocol(ChatApiProtocol.fromCode(dto.getChatApiProtocol().trim()).getCode());
 		}
 	}
 

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigDataServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigDataServiceImpl.java
@@ -124,6 +124,7 @@ public class ModelConfigDataServiceImpl implements ModelConfigDataService {
 		oldEntity.setProxyPort(dto.getProxyPort());
 		oldEntity.setProxyUsername(dto.getProxyUsername());
 		oldEntity.setProxyPassword(dto.getProxyPassword());
+		oldEntity.setChatApiProtocol(dto.getChatApiProtocol());
 
 		// 只有当前端传来的 Key 不包含 "****" 时，才说明用户真的改了 Key，否则保持原样
 		if (dto.getApiKey() != null && !dto.getApiKey().contains("****")) {

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/responses/ResponsesApi.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/responses/ResponsesApi.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.retry.RetryUtils;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerSentEvent;
@@ -35,9 +36,9 @@ import java.util.Map;
 
 /**
  * OpenAI Responses API 低层 HTTP 客户端。 负责构建请求、解析非流式响应与流式 SSE 事件。 协议 DTO 以内嵌 record/class
- * 形式定义，覆盖 DataAgent 实际用到的字段子集。
+ * 形式定义，覆盖 DataAgent 实际用到的字段子集（含 function calling）。
  * <p>
- * 不传 store、previous_response_id、tools 等字段，DataAgent 不使用这些特性。
+ * 不传 store、previous_response_id 等会话状态字段，DataAgent 自行管理对话历史。
  */
 @Slf4j
 public class ResponsesApi {
@@ -55,10 +56,15 @@ public class ResponsesApi {
 			WebClient.Builder webClientBuilder) {
 		this.responsesPath = StringUtils.hasText(responsesPath) ? responsesPath : "/v1/responses";
 
-		// 构建同步 RestClient（用于阻塞调用）
+		// 构建同步 RestClient（用于阻塞调用）。
+		// 必须挂载 DEFAULT_RESPONSE_ERROR_HANDLER：它把 4xx 映射为 NonTransientAiException、
+		// 5xx 映射为 TransientAiException，而上层 DEFAULT_RETRY_TEMPLATE 只对 TransientAiException
+		// 重试——
+		// 若不挂载，HTTP 错误抛出的是 RestClientResponseException，重试模板会直接放行，重试形同虚设
 		this.restClient = restClientBuilder.baseUrl(baseUrl)
 			.defaultHeader("Authorization", "Bearer " + apiKey)
 			.defaultHeader("Content-Type", "application/json")
+			.defaultStatusHandler(RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER)
 			.build();
 
 		// 构建异步 WebClient（用于 SSE 流式调用）
@@ -77,8 +83,7 @@ public class ResponsesApi {
 	 */
 	public ResponsesResponse call(ResponsesRequest request) {
 		// 确保非流式
-		ResponsesRequest syncRequest = new ResponsesRequest(request.model(), request.instructions(), request.input(),
-				request.temperature(), request.maxOutputTokens(), false);
+		ResponsesRequest syncRequest = request.withStream(false);
 
 		return restClient.post().uri(this.responsesPath).body(syncRequest).retrieve().body(ResponsesResponse.class);
 	}
@@ -93,8 +98,7 @@ public class ResponsesApi {
 	 */
 	public Flux<StreamEvent> stream(ResponsesRequest request) {
 		// 确保流式
-		ResponsesRequest streamRequest = new ResponsesRequest(request.model(), request.instructions(), request.input(),
-				request.temperature(), request.maxOutputTokens(), true);
+		ResponsesRequest streamRequest = request.withStream(true);
 
 		return webClient.post()
 			.uri(this.responsesPath)
@@ -161,9 +165,22 @@ public class ResponsesApi {
 			// readValue 抛 JsonProcessingException；convertValue 结构不匹配时抛
 			// IllegalArgumentException。
 			// 两者都按"单条事件损坏"处理：记录日志后跳过，不让一条畸形事件中断整个 SSE 流
-			log.warn("解析 Responses API SSE 事件失败，跳过: {}", data, e);
+			log.warn("解析 Responses API SSE 事件失败，跳过: {}", abbreviate(data), e);
 			return null;
 		}
+	}
+
+	/** 日志输出时保留的 SSE 负载最大长度 */
+	private static final int LOG_PAYLOAD_MAX_LENGTH = 500;
+
+	/**
+	 * 截断过长的 SSE 负载用于日志输出。 事件体可能携带完整模型输出，全量打印会造成日志膨胀并把对话内容写进日志， 截断后保留的前缀足够定位事件类型与结构问题。
+	 */
+	private static String abbreviate(String data) {
+		if (data == null || data.length() <= LOG_PAYLOAD_MAX_LENGTH) {
+			return data;
+		}
+		return data.substring(0, LOG_PAYLOAD_MAX_LENGTH) + "...(已截断，总长度 " + data.length() + ")";
 	}
 
 	/**
@@ -194,24 +211,73 @@ public class ResponsesApi {
 	// ======================== 协议 DTO ========================
 
 	/**
-	 * Responses API 请求体。 只包含 DataAgent 实际需要的字段，不传 tools/store/previous_response_id 等。
+	 * Responses API 请求体。 只包含 DataAgent 实际需要的字段，不传 store/previous_response_id 等。 tools
+	 * 字段用于声明可调用的 function 工具（AgentScope 链路依赖）。
 	 */
 	@JsonInclude(JsonInclude.Include.NON_NULL)
-	public record ResponsesRequest(String model, String instructions, List<InputItem> input, Double temperature,
-			@JsonProperty("max_output_tokens") Integer maxOutputTokens, Boolean stream) {
+	public record ResponsesRequest(String model, String instructions, List<InputItem> input, List<FunctionTool> tools,
+			Double temperature, @JsonProperty("max_output_tokens") Integer maxOutputTokens, Boolean stream) {
+
+		/**
+		 * 返回仅覆盖 stream 标志的副本。 call/stream 入口统一经此方法强制流式开关， 避免在多处手工重建
+		 * record——后续给请求体加字段时只需改这一处，防止字段漏拷
+		 */
+		public ResponsesRequest withStream(boolean stream) {
+			return new ResponsesRequest(model, instructions, input, tools, temperature, maxOutputTokens, stream);
+		}
 	}
 
 	/**
-	 * 输入消息项：对应 Responses API 的 input 数组元素。 DataAgent 只使用 user 角色的文本消息。
+	 * function 工具声明：对应请求 tools 数组元素。 Responses API 采用扁平结构（name/description/parameters 与
+	 * type 平级），与 Chat Completions 的嵌套 function 结构不同。
 	 */
 	@JsonInclude(JsonInclude.Include.NON_NULL)
-	public record InputItem(String role, List<ContentPart> content) {
+	public record FunctionTool(String type, String name, String description, Map<String, Object> parameters) {
 
 		/**
-		 * 构造 user 消息
+		 * 构造 function 类型工具声明
+		 */
+		public static FunctionTool function(String name, String description, Map<String, Object> parameters) {
+			return new FunctionTool("function", name, description, parameters);
+		}
+	}
+
+	/**
+	 * 输入项：对应 Responses API 的 input 数组元素。 一个 record 承载三种形态（按 type 区分）： 普通消息（type 为空，含
+	 * role+content）、function_call（助手历史中的工具调用）、 function_call_output（工具执行结果，模型靠 callId
+	 * 与调用配对）。
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record InputItem(String type, String role, List<ContentPart> content, @JsonProperty("call_id") String callId,
+			String name, String arguments, String output) {
+
+		/**
+		 * 构造 user 消息（content 类型为 input_text）
 		 */
 		public static InputItem userMessage(String text) {
-			return new InputItem("user", List.of(new ContentPart("input_text", text)));
+			return new InputItem(null, "user", List.of(new ContentPart("input_text", text)), null, null, null, null);
+		}
+
+		/**
+		 * 构造 assistant 历史消息（content 类型为 output_text，与 user 消息不同）
+		 */
+		public static InputItem assistantMessage(String text) {
+			return new InputItem(null, "assistant", List.of(new ContentPart("output_text", text)), null, null, null,
+					null);
+		}
+
+		/**
+		 * 构造助手历史中的工具调用项，多轮 agent 循环回放历史时必须携带， 否则模型无法将 function_call_output 与调用配对
+		 */
+		public static InputItem functionCall(String callId, String name, String arguments) {
+			return new InputItem("function_call", null, null, callId, name, arguments, null);
+		}
+
+		/**
+		 * 构造工具执行结果项
+		 */
+		public static InputItem functionCallOutput(String callId, String output) {
+			return new InputItem("function_call_output", null, null, callId, null, null, output);
 		}
 	}
 
@@ -233,11 +299,12 @@ public class ResponsesApi {
 	}
 
 	/**
-	 * 输出项：对应 output 数组元素。 type 为 "message" 时包含 content 数组；DataAgent 只关注 output_text
-	 * 类型的文本内容。
+	 * 输出项：对应 output 数组元素。 type 为 "message" 时包含 content 数组（文本回复）； type 为 "function_call"
+	 * 时包含 callId/name/arguments（模型发起的工具调用）。
 	 */
 	@JsonIgnoreProperties(ignoreUnknown = true)
-	public record OutputItem(String type, String role, List<ContentPart> content) {
+	public record OutputItem(String type, String role, List<ContentPart> content,
+			@JsonProperty("call_id") String callId, String name, String arguments) {
 	}
 
 	/**

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/responses/ResponsesApi.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/responses/ResponsesApi.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * OpenAI Responses API 低层 HTTP 客户端。 负责构建请求、解析非流式响应与流式 SSE 事件。 协议 DTO 以内嵌 record/class
+ * 形式定义，覆盖 DataAgent 实际用到的字段子集。
+ * <p>
+ * 不传 store、previous_response_id、tools 等字段，DataAgent 不使用这些特性。
+ */
+@Slf4j
+public class ResponsesApi {
+
+	private final RestClient restClient;
+
+	private final WebClient webClient;
+
+	private final String responsesPath;
+
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+		.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+	public ResponsesApi(String baseUrl, String apiKey, String responsesPath, RestClient.Builder restClientBuilder,
+			WebClient.Builder webClientBuilder) {
+		this.responsesPath = StringUtils.hasText(responsesPath) ? responsesPath : "/v1/responses";
+
+		// 构建同步 RestClient（用于阻塞调用）
+		this.restClient = restClientBuilder.baseUrl(baseUrl)
+			.defaultHeader("Authorization", "Bearer " + apiKey)
+			.defaultHeader("Content-Type", "application/json")
+			.build();
+
+		// 构建异步 WebClient（用于 SSE 流式调用）
+		this.webClient = webClientBuilder.baseUrl(baseUrl)
+			.defaultHeader("Authorization", "Bearer " + apiKey)
+			.defaultHeader("Content-Type", "application/json")
+			.build();
+	}
+
+	// ======================== 同步调用 ========================
+
+	/**
+	 * 非流式调用 Responses API，返回完整响应。
+	 * @param request 请求体（stream 字段会被忽略/覆盖为 false）
+	 * @return 完整的 Responses 响应
+	 */
+	public ResponsesResponse call(ResponsesRequest request) {
+		// 确保非流式
+		ResponsesRequest syncRequest = new ResponsesRequest(request.model(), request.instructions(), request.input(),
+				request.temperature(), request.maxOutputTokens(), false);
+
+		return restClient.post().uri(this.responsesPath).body(syncRequest).retrieve().body(ResponsesResponse.class);
+	}
+
+	// ======================== 流式调用 ========================
+
+	/**
+	 * 流式调用 Responses API，返回 SSE 事件流。 解析 Responses API 特有的事件类型（response.output_text.delta、
+	 * response.completed 等）。 对于未知事件类型一律忽略，保证向前兼容。
+	 * @param request 请求体（stream 字段会被覆盖为 true）
+	 * @return SSE 事件流，每个事件已解析为 StreamEvent
+	 */
+	public Flux<StreamEvent> stream(ResponsesRequest request) {
+		// 确保流式
+		ResponsesRequest streamRequest = new ResponsesRequest(request.model(), request.instructions(), request.input(),
+				request.temperature(), request.maxOutputTokens(), true);
+
+		return webClient.post()
+			.uri(this.responsesPath)
+			.bodyValue(streamRequest)
+			.accept(MediaType.TEXT_EVENT_STREAM)
+			.retrieve()
+			.bodyToFlux(new ParameterizedTypeReference<ServerSentEvent<String>>() {
+			})
+			.filter(sse -> StringUtils.hasText(sse.data()))
+			.mapNotNull(this::parseStreamEvent);
+	}
+
+	/**
+	 * 解析单个 SSE 事件的 data 负载。 按事件 type 分发：delta / completed / incomplete / failed / error。
+	 * 未知事件类型静默忽略（返回 null 被 mapNotNull 过滤掉）。 包私有可见性用于单元测试直接覆盖各事件分支。
+	 */
+	StreamEvent parseStreamEvent(ServerSentEvent<String> sse) {
+		String data = sse.data();
+		if (!StringUtils.hasText(data)) {
+			return null;
+		}
+		try {
+			Map<String, Object> eventMap = OBJECT_MAPPER.readValue(data, Map.class);
+			String type = (String) eventMap.get("type");
+			if (type == null) {
+				return null;
+			}
+
+			return switch (type) {
+				// 文本增量：产出一个 delta 文本块
+				case "response.output_text.delta" -> {
+					String delta = (String) eventMap.get("delta");
+					yield new StreamEvent(StreamEvent.Type.DELTA, delta, null, null);
+				}
+				// 响应完成：携带完整响应（含 usage）
+				case "response.completed" -> {
+					ResponsesResponse response = OBJECT_MAPPER.convertValue(eventMap.get("response"),
+							ResponsesResponse.class);
+					yield new StreamEvent(StreamEvent.Type.COMPLETED, null, response, null);
+				}
+				// 响应被截断（如达到 max_output_tokens）
+				case "response.incomplete" -> {
+					ResponsesResponse response = OBJECT_MAPPER.convertValue(eventMap.get("response"),
+							ResponsesResponse.class);
+					yield new StreamEvent(StreamEvent.Type.INCOMPLETE, null, response, null);
+				}
+				// 响应失败
+				case "response.failed" -> {
+					ResponsesResponse response = OBJECT_MAPPER.convertValue(eventMap.get("response"),
+							ResponsesResponse.class);
+					String errorMsg = extractErrorMessage(response);
+					yield new StreamEvent(StreamEvent.Type.ERROR, null, response, errorMsg);
+				}
+				// 全局错误事件
+				case "error" -> {
+					String errorMsg = extractErrorFromMap(eventMap);
+					yield new StreamEvent(StreamEvent.Type.ERROR, null, null, errorMsg);
+				}
+				// 其余事件（created、in_progress、output_item.added、output_text.done 等）一律忽略
+				default -> null;
+			};
+		}
+		catch (JsonProcessingException | IllegalArgumentException e) {
+			// readValue 抛 JsonProcessingException；convertValue 结构不匹配时抛
+			// IllegalArgumentException。
+			// 两者都按"单条事件损坏"处理：记录日志后跳过，不让一条畸形事件中断整个 SSE 流
+			log.warn("解析 Responses API SSE 事件失败，跳过: {}", data, e);
+			return null;
+		}
+	}
+
+	/**
+	 * 从 ResponsesResponse 的 error 字段提取错误消息
+	 */
+	private String extractErrorMessage(ResponsesResponse response) {
+		if (response != null && response.error() != null) {
+			return response.error().message();
+		}
+		return "Responses API 调用失败（未知原因）";
+	}
+
+	/**
+	 * 从原始事件 map 的 error 字段提取错误消息
+	 */
+	@SuppressWarnings("unchecked")
+	private String extractErrorFromMap(Map<String, Object> eventMap) {
+		Object error = eventMap.get("error");
+		if (error instanceof Map<?, ?> errorMap) {
+			Object message = errorMap.get("message");
+			if (message instanceof String msg) {
+				return msg;
+			}
+		}
+		return "Responses API 返回错误事件";
+	}
+
+	// ======================== 协议 DTO ========================
+
+	/**
+	 * Responses API 请求体。 只包含 DataAgent 实际需要的字段，不传 tools/store/previous_response_id 等。
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record ResponsesRequest(String model, String instructions, List<InputItem> input, Double temperature,
+			@JsonProperty("max_output_tokens") Integer maxOutputTokens, Boolean stream) {
+	}
+
+	/**
+	 * 输入消息项：对应 Responses API 的 input 数组元素。 DataAgent 只使用 user 角色的文本消息。
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record InputItem(String role, List<ContentPart> content) {
+
+		/**
+		 * 构造 user 消息
+		 */
+		public static InputItem userMessage(String text) {
+			return new InputItem("user", List.of(new ContentPart("input_text", text)));
+		}
+	}
+
+	/**
+	 * 内容块：对应 input/output 中的 content 数组元素
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record ContentPart(String type, String text) {
+	}
+
+	/**
+	 * Responses API 完整响应体
+	 */
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record ResponsesResponse(String id, String model, String status, List<OutputItem> output,
+			ResponsesUsage usage, @JsonProperty("incomplete_details") IncompleteDetails incompleteDetails,
+			ResponsesError error) {
+	}
+
+	/**
+	 * 输出项：对应 output 数组元素。 type 为 "message" 时包含 content 数组；DataAgent 只关注 output_text
+	 * 类型的文本内容。
+	 */
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record OutputItem(String type, String role, List<ContentPart> content) {
+	}
+
+	/**
+	 * token 用量统计
+	 */
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record ResponsesUsage(@JsonProperty("input_tokens") Integer inputTokens,
+			@JsonProperty("output_tokens") Integer outputTokens, @JsonProperty("total_tokens") Integer totalTokens) {
+	}
+
+	/**
+	 * 截断详情（status=incomplete 时附带）
+	 */
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record IncompleteDetails(String reason) {
+	}
+
+	/**
+	 * 错误信息
+	 */
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record ResponsesError(String type, String message, String code) {
+	}
+
+	/**
+	 * 流式 SSE 事件的统一封装
+	 */
+	public record StreamEvent(Type type, String delta, ResponsesResponse response, String errorMessage) {
+
+		public enum Type {
+
+			/** 文本增量 */
+			DELTA,
+			/** 响应完成（携带 usage） */
+			COMPLETED,
+			/** 响应被截断 */
+			INCOMPLETE,
+			/** 错误 */
+			ERROR
+
+		}
+	}
+
+}

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/responses/ResponsesApiChatModel.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/responses/ResponsesApiChatModel.java
@@ -16,15 +16,19 @@
 package com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses;
 
 import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApi.ContentPart;
+import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApi.FunctionTool;
 import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApi.InputItem;
 import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApi.OutputItem;
 import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApi.ResponsesRequest;
 import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApi.ResponsesResponse;
 import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApi.ResponsesUsage;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
-import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.DefaultUsage;
@@ -33,21 +37,36 @@ import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.retry.RetryUtils;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * 基于 OpenAI Responses API 的 ChatModel 实现。 将 Spring AI 的 Prompt 转换为 Responses API 请求， 将
  * Responses API 的响应转换回 Spring AI 的 ChatResponse。
  * <p>
  * 设计要点：实现 ChatModel 接口后，对上层 AiModelRegistry / LlmService / 全部 16 个图节点完全透明，无需任何改动。
+ * <p>
+ * Tool calling 支持（AgentScope 链路依赖）：识别 ToolCallingChatOptions 中的工具声明并映射为 tools
+ * 字段；助手历史中的工具调用与工具执行结果分别映射为 function_call / function_call_output 输入项。 注意：本实现不在框架内部执行工具
+ * （等价于 internalToolExecutionEnabled=false），工具调用以 AssistantMessage.toolCalls
+ * 形式返回给调用方，由调用方（AgentScope runtime）负责执行并回传结果。
  */
 @Slf4j
 public class ResponsesApiChatModel implements ChatModel {
+
+	/** 用于解析工具 inputSchema JSON 字符串，无状态可安全共享 */
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
 	private final ResponsesApi responsesApi;
 
@@ -75,30 +94,38 @@ public class ResponsesApiChatModel implements ChatModel {
 	public Flux<ChatResponse> stream(Prompt prompt) {
 		ResponsesRequest request = buildRequest(prompt, true);
 
-		// 将 SSE 事件转为 ChatResponse 流，与 OpenAiChatModel 的流式行为对齐：
-		// - delta 事件 → 包含文本块的 ChatResponse（逐 token 推送）
-		// - completed 事件 → 终包：空文本 + usage 元数据（Langfuse token 统计依赖此包）
-		// - incomplete 事件 → 终包：finishReason=LENGTH
-		// - error 事件 → Flux.error 向上传播，由节点重试机制接管
-		return responsesApi.stream(request).concatMap(event -> switch (event.type()) {
-			case DELTA -> {
-				// 文本增量：构建只含文本的 ChatResponse；delta 为 null 时按空串处理，避免 NPE
-				String delta = event.delta() != null ? event.delta() : "";
-				Generation generation = new Generation(new AssistantMessage(delta));
-				yield Flux.just(new ChatResponse(List.of(generation)));
-			}
-			case COMPLETED -> {
-				// 完成事件：构建携带 usage 元数据的终包
-				yield Flux.just(buildCompletedResponse(event.response(), "STOP"));
-			}
-			case INCOMPLETE -> {
-				// 截断事件：finishReason 为 LENGTH
-				yield Flux.just(buildCompletedResponse(event.response(), "LENGTH"));
-			}
-			case ERROR -> {
-				// 错误事件：转为异常向上传播
-				yield Flux.error(new RuntimeException("Responses API 错误: " + event.errorMessage()));
-			}
+		// 标记本次流是否收到过文本增量事件：个别兼容实现可能不推送 output_text.delta，
+		// 文本只出现在 completed 事件的完整 output 中，此时终包需降级携带全文，否则文本整体丢失。
+		// 每次订阅独立创建（defer），避免同一 Flux 被多次订阅时状态串扰
+		return Flux.defer(() -> {
+			AtomicBoolean deltaReceived = new AtomicBoolean(false);
+
+			// 将 SSE 事件转为 ChatResponse 流，与 OpenAiChatModel 的流式行为对齐：
+			// - delta 事件 → 包含文本块的 ChatResponse（逐 token 推送）
+			// - completed 事件 → 终包：空文本 + usage 元数据（Langfuse token 统计依赖此包）
+			// - incomplete 事件 → 终包：finishReason=LENGTH
+			// - error 事件 → Flux.error 向上传播，由节点重试机制接管
+			return responsesApi.stream(request).concatMap(event -> switch (event.type()) {
+				case DELTA -> {
+					// 文本增量：构建只含文本的 ChatResponse；delta 为 null 时按空串处理，避免 NPE
+					deltaReceived.set(true);
+					String delta = event.delta() != null ? event.delta() : "";
+					Generation generation = new Generation(new AssistantMessage(delta));
+					yield Flux.just(new ChatResponse(List.of(generation)));
+				}
+				case COMPLETED -> {
+					// 完成事件：构建携带 usage 元数据的终包
+					yield Flux.just(buildCompletedResponse(event.response(), "STOP", deltaReceived.get()));
+				}
+				case INCOMPLETE -> {
+					// 截断事件：finishReason 为 LENGTH
+					yield Flux.just(buildCompletedResponse(event.response(), "LENGTH", deltaReceived.get()));
+				}
+				case ERROR -> {
+					// 错误事件：转为异常向上传播
+					yield Flux.error(new RuntimeException("Responses API 错误: " + event.errorMessage()));
+				}
+			});
 		});
 	}
 
@@ -111,23 +138,27 @@ public class ResponsesApiChatModel implements ChatModel {
 
 	/**
 	 * 将 Spring AI Prompt 转换为 Responses API 请求。 映射规则：SystemMessage → instructions
-	 * 字段，UserMessage → input 数组。
+	 * 字段；UserMessage → input 数组消息项；AssistantMessage（含历史工具调用）→ assistant 消息项 +
+	 * function_call 项；ToolResponseMessage → function_call_output 项。 多轮 agent
+	 * 循环回放历史时，function_call 与 function_call_output 必须成对出现，模型靠 callId 配对。
 	 */
 	private ResponsesRequest buildRequest(Prompt prompt, boolean stream) {
 		String instructions = null;
 		List<InputItem> inputItems = new ArrayList<>();
 
-		// 从 Prompt 中提取消息，分类映射到 Responses API 字段
+		// 从 Prompt 中提取消息，按类型分类映射到 Responses API 字段
 		for (Message message : prompt.getInstructions()) {
-			if (message.getMessageType() == MessageType.SYSTEM) {
-				// SystemMessage 映射为 instructions（Responses API 推荐的系统提示词方式）
-				instructions = message.getText();
+			switch (message.getMessageType()) {
+				// SystemMessage 映射为 instructions（Responses API 推荐的系统提示词方式）。
+				// 多条系统消息按出现顺序拼接：instructions 只有一个字段，直接赋值覆盖会静默丢失前文
+				case SYSTEM -> instructions = mergeInstructions(instructions, message.getText());
+				// UserMessage 映射为 input 数组消息项
+				case USER -> inputItems.add(InputItem.userMessage(message.getText()));
+				// 助手历史消息：文本和工具调用分别映射
+				case ASSISTANT -> appendAssistantItems((AssistantMessage) message, inputItems);
+				// 工具执行结果：映射为 function_call_output 项
+				case TOOL -> appendToolOutputItems((ToolResponseMessage) message, inputItems);
 			}
-			else if (message.getMessageType() == MessageType.USER) {
-				// UserMessage 映射为 input 数组项
-				inputItems.add(InputItem.userMessage(message.getText()));
-			}
-			// AssistantMessage 和其他类型在 DataAgent 当前链路中不会出现，忽略
 		}
 
 		// 合并运行时 options 与默认 options，运行时优先。
@@ -150,21 +181,113 @@ public class ResponsesApiChatModel implements ChatModel {
 			}
 		}
 
-		return new ResponsesRequest(model, instructions, inputItems.isEmpty() ? null : inputItems, temperature,
-				maxTokens, stream);
+		return new ResponsesRequest(model, instructions, inputItems.isEmpty() ? null : inputItems,
+				buildTools(runtimeOptions), temperature, maxTokens, stream);
+	}
+
+	/**
+	 * 合并多条 SystemMessage 为单个 instructions。 Responses API 只有一个 instructions 字段， 上游（如
+	 * AgentScope 链路）可能注入多条系统消息，这里用空行拼接保证语义完整、顺序不变。
+	 */
+	private String mergeInstructions(String existing, String text) {
+		if (!StringUtils.hasText(text)) {
+			return existing;
+		}
+		return existing == null ? text : existing + "\n\n" + text;
+	}
+
+	/**
+	 * 将助手历史消息拆解为 input 项。 文本部分映射为 assistant 消息项；工具调用部分逐个映射为 function_call 项，
+	 * 缺失任何一个都会导致模型无法将后续的 function_call_output 与调用配对而报错。
+	 */
+	private void appendAssistantItems(AssistantMessage message, List<InputItem> inputItems) {
+		if (StringUtils.hasText(message.getText())) {
+			inputItems.add(InputItem.assistantMessage(message.getText()));
+		}
+		if (message.hasToolCalls()) {
+			for (AssistantMessage.ToolCall toolCall : message.getToolCalls()) {
+				// arguments 为空时降级为空对象，Responses API 要求该字段必须是合法 JSON 字符串
+				String arguments = StringUtils.hasText(toolCall.arguments()) ? toolCall.arguments() : "{}";
+				inputItems.add(InputItem.functionCall(toolCall.id(), toolCall.name(), arguments));
+			}
+		}
+	}
+
+	/**
+	 * 将工具执行结果消息映射为 function_call_output 项，callId 必须与历史 function_call 一致
+	 */
+	private void appendToolOutputItems(ToolResponseMessage message, List<InputItem> inputItems) {
+		for (ToolResponseMessage.ToolResponse toolResponse : message.getResponses()) {
+			// responseData 为 null 时兜底空串：output 字段若被 NON_NULL 序列化策略整体省略，
+			// 部分服务端会因缺少必填字段拒绝请求
+			String output = toolResponse.responseData() != null ? toolResponse.responseData() : "";
+			inputItems.add(InputItem.functionCallOutput(toolResponse.id(), output));
+		}
+	}
+
+	/**
+	 * 从 ToolCallingChatOptions 中提取工具声明并映射为 Responses API 的 tools 字段。 AgentScope 链路通过
+	 * ToolCallingChatOptions 传入 toolCallbacks；非工具场景（普通 ChatOptions）返回 null，请求中不出现 tools
+	 * 字段。
+	 */
+	private List<FunctionTool> buildTools(ChatOptions options) {
+		if (!(options instanceof ToolCallingChatOptions toolOptions)) {
+			return null;
+		}
+		// Spring AI 约定 internalToolExecutionEnabled 为 null 时默认 true（框架内部执行工具并自动循环），
+		// 但本实现不支持内部执行，工具调用一律以 AssistantMessage.toolCalls 返回给调用方。
+		// 对依赖内部执行语义的调用方显式告警，避免"拿到原始 toolCalls 却无人执行"的静默行为偏差
+		if (ToolCallingChatOptions.isInternalToolExecutionEnabled(toolOptions)
+				&& !CollectionUtils.isEmpty(toolOptions.getToolCallbacks())) {
+			log.warn("ResponsesApiChatModel 不支持框架内部执行工具（internalToolExecutionEnabled={}），"
+					+ "工具调用将以 toolCalls 返回给调用方自行执行", toolOptions.getInternalToolExecutionEnabled());
+		}
+		// 仅支持 toolCallbacks 方式声明工具；toolNames + ToolCallbackResolver 方式无法在此解析，
+		// 显式告警避免工具被静默丢弃后难以排查
+		if (!CollectionUtils.isEmpty(toolOptions.getToolNames())) {
+			log.warn("ResponsesApiChatModel 不支持 toolNames 方式注册的工具，已忽略: {}", toolOptions.getToolNames());
+		}
+		List<FunctionTool> tools = new ArrayList<>();
+		for (ToolCallback toolCallback : toolOptions.getToolCallbacks()) {
+			ToolDefinition definition = toolCallback.getToolDefinition();
+			tools.add(FunctionTool.function(definition.name(), definition.description(),
+					parseInputSchema(definition.inputSchema())));
+		}
+		return tools.isEmpty() ? null : tools;
+	}
+
+	/**
+	 * 将 ToolDefinition 的 inputSchema（JSON 字符串）解析为 Map。 Responses API 的 parameters 字段要求
+	 * JSON 对象而非字符串；解析失败时降级为空参数 schema，保证工具声明本身不缺失。
+	 */
+	private Map<String, Object> parseInputSchema(String inputSchema) {
+		if (!StringUtils.hasText(inputSchema)) {
+			return Map.of("type", "object", "properties", Map.of());
+		}
+		try {
+			return OBJECT_MAPPER.readValue(inputSchema, new TypeReference<Map<String, Object>>() {
+			});
+		}
+		catch (JsonProcessingException e) {
+			log.warn("解析工具 inputSchema 失败，降级为空参数 schema: {}", inputSchema, e);
+			return Map.of("type", "object", "properties", Map.of());
+		}
 	}
 
 	// ======================== 响应转换 ========================
 
 	/**
-	 * 将 Responses API 完整响应转换为 ChatResponse（非流式场景）。 从 output 数组中提取 type=message 的文本内容，拼接为
-	 * AssistantMessage。
+	 * 将 Responses API 完整响应转换为 ChatResponse（非流式场景）。 从 output 数组中提取 type=message 的文本内容拼接为
+	 * AssistantMessage，并提取 type=function_call 的工具调用。 存在工具调用时 finishReason 为 TOOL_CALLS，与
+	 * OpenAiChatModel 行为对齐。
 	 */
 	private ChatResponse convertToChatResponse(ResponsesResponse response) {
 		String text = extractOutputText(response);
-		String finishReason = mapFinishReason(response);
+		List<AssistantMessage.ToolCall> toolCalls = extractToolCalls(response);
+		String finishReason = toolCalls.isEmpty() ? mapFinishReason(response) : "TOOL_CALLS";
 
-		Generation generation = new Generation(new AssistantMessage(text),
+		AssistantMessage assistantMessage = AssistantMessage.builder().content(text).toolCalls(toolCalls).build();
+		Generation generation = new Generation(assistantMessage,
 				ChatGenerationMetadata.builder().finishReason(finishReason).build());
 
 		ChatResponseMetadata metadata = buildResponseMetadata(response);
@@ -175,15 +298,56 @@ public class ResponsesApiChatModel implements ChatModel {
 	 * 构建流式完成/截断事件的终包 ChatResponse。 携带 usage 元数据，与 OpenAiChatModel streamUsage(true)
 	 * 的末包行为对齐。
 	 * <p>
-	 * 关键约束：终包文本必须为空串。completed/incomplete 事件的 response 中携带完整 output 全文， 而上层 FluxUtil
-	 * 会对流中每个 chunk 的文本做 append 聚合——若此处再返回全文， 聚合结果会出现"全部 delta + 整段全文"的重复，破坏 SQL/JSON 解析。
+	 * 关键约束一：正常路径下终包文本必须为空串。completed/incomplete 事件的 response 中携带完整 output 全文， 而上层
+	 * FluxUtil 会对流中每个 chunk 的文本做 append 聚合——若此处再返回全文， 聚合结果会出现"全部 delta + 整段全文"的重复，破坏
+	 * SQL/JSON 解析。 例外：若整个流从未收到 delta 事件（个别兼容实现不推送增量），说明文本只存在于终包的完整 output 中，
+	 * 此时降级在终包携带全文，否则文本会整体丢失。
+	 * <p>
+	 * 关键约束二：工具调用必须在终包携带。文本会通过 delta 事件逐块推送，但 function_call 项只在 completed 事件的完整 output
+	 * 中出现一次（参数增量事件被适配层忽略）；调用方（AgentScope 桥接层）对每个 chunk 都读取 toolCalls，终包单次携带完整调用即可驱动工具执行。
+	 * @param deltaReceived 本次流是否已收到过文本增量事件，决定终包是否需要降级携带全文
 	 */
-	private ChatResponse buildCompletedResponse(ResponsesResponse response, String finishReason) {
-		Generation generation = new Generation(new AssistantMessage(""),
-				ChatGenerationMetadata.builder().finishReason(finishReason).build());
+	private ChatResponse buildCompletedResponse(ResponsesResponse response, String finishReason,
+			boolean deltaReceived) {
+		List<AssistantMessage.ToolCall> toolCalls = extractToolCalls(response);
+		String resolvedFinishReason = toolCalls.isEmpty() ? finishReason : "TOOL_CALLS";
+
+		// 正常路径终包为空文本（见约束一）；从未收到 delta 且完整 output 中有文本时降级携带全文
+		String text = "";
+		if (!deltaReceived) {
+			String fullText = extractOutputText(response);
+			if (StringUtils.hasText(fullText)) {
+				log.warn("Responses API 流式响应未收到任何文本增量事件，终包降级携带完整文本（长度 {}）", fullText.length());
+				text = fullText;
+			}
+		}
+
+		AssistantMessage assistantMessage = AssistantMessage.builder().content(text).toolCalls(toolCalls).build();
+		Generation generation = new Generation(assistantMessage,
+				ChatGenerationMetadata.builder().finishReason(resolvedFinishReason).build());
 
 		ChatResponseMetadata metadata = buildResponseMetadata(response);
 		return new ChatResponse(List.of(generation), metadata);
+	}
+
+	/**
+	 * 从 output 数组中提取 type=function_call 的工具调用项，转为 Spring AI 的 ToolCall。 id 取
+	 * call_id（而非输出项自身 id），后续 function_call_output 回传依赖它配对。
+	 */
+	private List<AssistantMessage.ToolCall> extractToolCalls(ResponsesResponse response) {
+		if (response == null || response.output() == null) {
+			return List.of();
+		}
+		List<AssistantMessage.ToolCall> toolCalls = new ArrayList<>();
+		for (OutputItem outputItem : response.output()) {
+			if ("function_call".equals(outputItem.type())) {
+				// arguments 缺失时降级为空对象，保证调用方 JSON 解析不报错
+				String arguments = outputItem.arguments() != null ? outputItem.arguments() : "{}";
+				toolCalls
+					.add(new AssistantMessage.ToolCall(outputItem.callId(), "function", outputItem.name(), arguments));
+			}
+		}
+		return toolCalls;
 	}
 
 	/**

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/responses/ResponsesApiChatModel.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/responses/ResponsesApiChatModel.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses;
+
+import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApi.ContentPart;
+import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApi.InputItem;
+import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApi.OutputItem;
+import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApi.ResponsesRequest;
+import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApi.ResponsesResponse;
+import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApi.ResponsesUsage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.retry.RetryUtils;
+import reactor.core.publisher.Flux;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 基于 OpenAI Responses API 的 ChatModel 实现。 将 Spring AI 的 Prompt 转换为 Responses API 请求， 将
+ * Responses API 的响应转换回 Spring AI 的 ChatResponse。
+ * <p>
+ * 设计要点：实现 ChatModel 接口后，对上层 AiModelRegistry / LlmService / 全部 16 个图节点完全透明，无需任何改动。
+ */
+@Slf4j
+public class ResponsesApiChatModel implements ChatModel {
+
+	private final ResponsesApi responsesApi;
+
+	private final OpenAiChatOptions defaultOptions;
+
+	public ResponsesApiChatModel(ResponsesApi responsesApi, OpenAiChatOptions defaultOptions) {
+		this.responsesApi = responsesApi;
+		this.defaultOptions = defaultOptions;
+	}
+
+	// ======================== 非流式调用 ========================
+
+	@Override
+	public ChatResponse call(Prompt prompt) {
+		ResponsesRequest request = buildRequest(prompt, false);
+		// 与 OpenAiChatModel 的容错行为对齐：同步调用使用统一重试模板，
+		// 网络抖动或服务端瞬时错误时自动重试，避免两种协议容错能力不一致
+		ResponsesResponse response = RetryUtils.DEFAULT_RETRY_TEMPLATE.execute(ctx -> responsesApi.call(request));
+		return convertToChatResponse(response);
+	}
+
+	// ======================== 流式调用 ========================
+
+	@Override
+	public Flux<ChatResponse> stream(Prompt prompt) {
+		ResponsesRequest request = buildRequest(prompt, true);
+
+		// 将 SSE 事件转为 ChatResponse 流，与 OpenAiChatModel 的流式行为对齐：
+		// - delta 事件 → 包含文本块的 ChatResponse（逐 token 推送）
+		// - completed 事件 → 终包：空文本 + usage 元数据（Langfuse token 统计依赖此包）
+		// - incomplete 事件 → 终包：finishReason=LENGTH
+		// - error 事件 → Flux.error 向上传播，由节点重试机制接管
+		return responsesApi.stream(request).concatMap(event -> switch (event.type()) {
+			case DELTA -> {
+				// 文本增量：构建只含文本的 ChatResponse；delta 为 null 时按空串处理，避免 NPE
+				String delta = event.delta() != null ? event.delta() : "";
+				Generation generation = new Generation(new AssistantMessage(delta));
+				yield Flux.just(new ChatResponse(List.of(generation)));
+			}
+			case COMPLETED -> {
+				// 完成事件：构建携带 usage 元数据的终包
+				yield Flux.just(buildCompletedResponse(event.response(), "STOP"));
+			}
+			case INCOMPLETE -> {
+				// 截断事件：finishReason 为 LENGTH
+				yield Flux.just(buildCompletedResponse(event.response(), "LENGTH"));
+			}
+			case ERROR -> {
+				// 错误事件：转为异常向上传播
+				yield Flux.error(new RuntimeException("Responses API 错误: " + event.errorMessage()));
+			}
+		});
+	}
+
+	@Override
+	public ChatOptions getDefaultOptions() {
+		return this.defaultOptions;
+	}
+
+	// ======================== 请求构建 ========================
+
+	/**
+	 * 将 Spring AI Prompt 转换为 Responses API 请求。 映射规则：SystemMessage → instructions
+	 * 字段，UserMessage → input 数组。
+	 */
+	private ResponsesRequest buildRequest(Prompt prompt, boolean stream) {
+		String instructions = null;
+		List<InputItem> inputItems = new ArrayList<>();
+
+		// 从 Prompt 中提取消息，分类映射到 Responses API 字段
+		for (Message message : prompt.getInstructions()) {
+			if (message.getMessageType() == MessageType.SYSTEM) {
+				// SystemMessage 映射为 instructions（Responses API 推荐的系统提示词方式）
+				instructions = message.getText();
+			}
+			else if (message.getMessageType() == MessageType.USER) {
+				// UserMessage 映射为 input 数组项
+				inputItems.add(InputItem.userMessage(message.getText()));
+			}
+			// AssistantMessage 和其他类型在 DataAgent 当前链路中不会出现，忽略
+		}
+
+		// 合并运行时 options 与默认 options，运行时优先。
+		// 使用 ChatOptions 接口取值而非 instanceof 具体实现类：
+		// ChatClient 可能传入 DefaultChatOptions 等任意实现，按接口读取保证运行时参数不被静默忽略
+		String model = defaultOptions.getModel();
+		Double temperature = defaultOptions.getTemperature();
+		Integer maxTokens = defaultOptions.getMaxTokens();
+
+		ChatOptions runtimeOptions = prompt.getOptions();
+		if (runtimeOptions != null) {
+			if (runtimeOptions.getModel() != null) {
+				model = runtimeOptions.getModel();
+			}
+			if (runtimeOptions.getTemperature() != null) {
+				temperature = runtimeOptions.getTemperature();
+			}
+			if (runtimeOptions.getMaxTokens() != null) {
+				maxTokens = runtimeOptions.getMaxTokens();
+			}
+		}
+
+		return new ResponsesRequest(model, instructions, inputItems.isEmpty() ? null : inputItems, temperature,
+				maxTokens, stream);
+	}
+
+	// ======================== 响应转换 ========================
+
+	/**
+	 * 将 Responses API 完整响应转换为 ChatResponse（非流式场景）。 从 output 数组中提取 type=message 的文本内容，拼接为
+	 * AssistantMessage。
+	 */
+	private ChatResponse convertToChatResponse(ResponsesResponse response) {
+		String text = extractOutputText(response);
+		String finishReason = mapFinishReason(response);
+
+		Generation generation = new Generation(new AssistantMessage(text),
+				ChatGenerationMetadata.builder().finishReason(finishReason).build());
+
+		ChatResponseMetadata metadata = buildResponseMetadata(response);
+		return new ChatResponse(List.of(generation), metadata);
+	}
+
+	/**
+	 * 构建流式完成/截断事件的终包 ChatResponse。 携带 usage 元数据，与 OpenAiChatModel streamUsage(true)
+	 * 的末包行为对齐。
+	 * <p>
+	 * 关键约束：终包文本必须为空串。completed/incomplete 事件的 response 中携带完整 output 全文， 而上层 FluxUtil
+	 * 会对流中每个 chunk 的文本做 append 聚合——若此处再返回全文， 聚合结果会出现"全部 delta + 整段全文"的重复，破坏 SQL/JSON 解析。
+	 */
+	private ChatResponse buildCompletedResponse(ResponsesResponse response, String finishReason) {
+		Generation generation = new Generation(new AssistantMessage(""),
+				ChatGenerationMetadata.builder().finishReason(finishReason).build());
+
+		ChatResponseMetadata metadata = buildResponseMetadata(response);
+		return new ChatResponse(List.of(generation), metadata);
+	}
+
+	/**
+	 * 从 ResponsesResponse 的 output 数组中提取所有文本内容并拼接。 只处理 type=message 且 content 中
+	 * type=output_text 的内容块。
+	 */
+	private String extractOutputText(ResponsesResponse response) {
+		if (response == null || response.output() == null) {
+			return "";
+		}
+
+		StringBuilder sb = new StringBuilder();
+		for (OutputItem outputItem : response.output()) {
+			// 只处理 message 类型的输出项
+			if ("message".equals(outputItem.type()) && outputItem.content() != null) {
+				for (ContentPart part : outputItem.content()) {
+					// 只提取 output_text 类型的文本内容
+					if ("output_text".equals(part.type()) && part.text() != null) {
+						sb.append(part.text());
+					}
+				}
+			}
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * 根据 Responses API 的 status 映射 finishReason。 completed → STOP；incomplete +
+	 * max_output_tokens → LENGTH；failed → ERROR
+	 */
+	private String mapFinishReason(ResponsesResponse response) {
+		if (response == null || response.status() == null) {
+			return "STOP";
+		}
+
+		return switch (response.status()) {
+			case "completed" -> "STOP";
+			case "incomplete" -> {
+				// 检查截断原因
+				if (response.incompleteDetails() != null
+						&& "max_output_tokens".equals(response.incompleteDetails().reason())) {
+					yield "LENGTH";
+				}
+				yield "STOP";
+			}
+			case "failed" -> "ERROR";
+			default -> "STOP";
+		};
+	}
+
+	/**
+	 * 构建包含 usage 统计的响应元数据。 将 Responses API 的 input_tokens/output_tokens 映射为 Spring AI 的
+	 * promptTokens/completionTokens。
+	 */
+	private ChatResponseMetadata buildResponseMetadata(ResponsesResponse response) {
+		ChatResponseMetadata.Builder builder = ChatResponseMetadata.builder();
+		if (response != null) {
+			if (response.id() != null) {
+				builder.id(response.id());
+			}
+			if (response.model() != null) {
+				builder.model(response.model());
+			}
+			// usage 映射：input_tokens → promptTokens，output_tokens → completionTokens
+			if (response.usage() != null) {
+				ResponsesUsage u = response.usage();
+				builder.usage(new DefaultUsage(u.inputTokens() != null ? u.inputTokens() : 0,
+						u.outputTokens() != null ? u.outputTokens() : 0,
+						u.totalTokens() != null ? u.totalTokens() : 0));
+			}
+		}
+		return builder.build();
+	}
+
+}

--- a/data-agent-management/src/main/resources/sql/h2/schema-h2.sql
+++ b/data-agent-management/src/main/resources/sql/h2/schema-h2.sql
@@ -278,5 +278,6 @@ CREATE TABLE IF NOT EXISTS `model_config` (
   `proxy_port` int(11) DEFAULT NULL COMMENT '代理端口',
   `proxy_username` varchar(255) DEFAULT NULL COMMENT '代理用户名（可选）',
   `proxy_password` varchar(255) DEFAULT NULL COMMENT '代理密码（可选）',
+  `chat_api_protocol` varchar(32) DEFAULT 'CHAT_COMPLETIONS' COMMENT 'Chat模型接口协议：CHAT_COMPLETIONS（默认Chat Completions格式）、RESPONSES（OpenAI Responses API格式）。仅model_type=CHAT时生效',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;

--- a/data-agent-management/src/main/resources/sql/schema.sql
+++ b/data-agent-management/src/main/resources/sql/schema.sql
@@ -278,5 +278,6 @@ CREATE TABLE IF NOT EXISTS `model_config` (
     `proxy_port` int(11) DEFAULT NULL COMMENT '代理端口',
     `proxy_username` varchar(255) DEFAULT NULL COMMENT '代理用户名（可选）',
     `proxy_password` varchar(255) DEFAULT NULL COMMENT '代理密码（可选）',
+    `chat_api_protocol` varchar(32) DEFAULT 'CHAT_COMPLETIONS' COMMENT 'Chat模型接口协议：CHAT_COMPLETIONS（默认Chat Completions格式）、RESPONSES（OpenAI Responses API格式）。仅model_type=CHAT时生效',
     PRIMARY KEY (`id`)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/converter/ModelConfigConverterTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/converter/ModelConfigConverterTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.converter;
+
+import com.alibaba.cloud.ai.dataagent.dto.ModelConfigDTO;
+import com.alibaba.cloud.ai.dataagent.entity.ModelConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * ModelConfigConverter 转换逻辑单元测试。 重点回归 chatApiProtocol 的默认值兜底： INSERT 显式写入 NULL
+ * 会绕过数据库列默认值，必须在转换层回填。
+ */
+class ModelConfigConverterTest {
+
+	private ModelConfigDTO buildDto(String chatApiProtocol) {
+		return ModelConfigDTO.builder()
+			.provider("openai")
+			.baseUrl("https://api.example.com")
+			.apiKey("sk-test")
+			.modelName("test-model")
+			.modelType("CHAT")
+			.chatApiProtocol(chatApiProtocol)
+			.build();
+	}
+
+	@Test
+	void toEntity_backfillsDefaultProtocolWhenNull() {
+		ModelConfig entity = ModelConfigConverter.toEntity(buildDto(null));
+		assertEquals("CHAT_COMPLETIONS", entity.getChatApiProtocol());
+	}
+
+	@Test
+	void toEntity_backfillsDefaultProtocolWhenBlank() {
+		ModelConfig entity = ModelConfigConverter.toEntity(buildDto("  "));
+		assertEquals("CHAT_COMPLETIONS", entity.getChatApiProtocol());
+	}
+
+	@Test
+	void toEntity_keepsExplicitProtocol() {
+		ModelConfig entity = ModelConfigConverter.toEntity(buildDto("RESPONSES"));
+		assertEquals("RESPONSES", entity.getChatApiProtocol());
+	}
+
+}

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/enums/ChatApiProtocolTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/enums/ChatApiProtocolTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.enums;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * ChatApiProtocol 协议解析单元测试。 重点回归：非法值必须抛异常拦截在保存入口， 不能静默落入默认协议分支导致用户配置悄悄失效。
+ */
+class ChatApiProtocolTest {
+
+	@Test
+	void fromCode_resolvesStandardValues() {
+		assertEquals(ChatApiProtocol.CHAT_COMPLETIONS, ChatApiProtocol.fromCode("CHAT_COMPLETIONS"));
+		assertEquals(ChatApiProtocol.RESPONSES, ChatApiProtocol.fromCode("RESPONSES"));
+	}
+
+	@Test
+	void fromCode_ignoresCase() {
+		// 与 DynamicModelFactory 的 equalsIgnoreCase 容忍口径一致
+		assertEquals(ChatApiProtocol.RESPONSES, ChatApiProtocol.fromCode("responses"));
+		assertEquals(ChatApiProtocol.CHAT_COMPLETIONS, ChatApiProtocol.fromCode("chat_completions"));
+	}
+
+	@Test
+	void fromCode_rejectsUnknownValue() {
+		// 拼写错误（如漏掉 S）必须报错，而不是静默回退默认协议
+		assertThrows(IllegalArgumentException.class, () -> ChatApiProtocol.fromCode("RESPONSE"));
+		assertThrows(IllegalArgumentException.class, () -> ChatApiProtocol.fromCode(""));
+		assertThrows(IllegalArgumentException.class, () -> ChatApiProtocol.fromCode(null));
+	}
+
+}

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/responses/ResponsesApiChatModelTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/responses/ResponsesApiChatModelTest.java
@@ -25,12 +25,17 @@ import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesA
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
 import reactor.core.publisher.Flux;
 
 import java.util.List;
@@ -66,8 +71,18 @@ class ResponsesApiChatModelTest {
 	 * 构造一个携带文本输出和 usage 的完整响应
 	 */
 	private ResponsesResponse completedResponse(String text) {
-		OutputItem item = new OutputItem("message", "assistant", List.of(new ContentPart("output_text", text)));
+		OutputItem item = new OutputItem("message", "assistant", List.of(new ContentPart("output_text", text)), null,
+				null, null);
 		return new ResponsesResponse("resp_1", "gpt-test", "completed", List.of(item), new ResponsesUsage(10, 5, 15),
+				null, null);
+	}
+
+	/**
+	 * 构造一个携带 function_call 工具调用的完整响应
+	 */
+	private ResponsesResponse functionCallResponse() {
+		OutputItem call = new OutputItem("function_call", null, null, "call_1", "search", "{\"q\":\"北京天气\"}");
+		return new ResponsesResponse("resp_fc", "gpt-test", "completed", List.of(call), new ResponsesUsage(20, 8, 28),
 				null, null);
 	}
 
@@ -116,6 +131,20 @@ class ResponsesApiChatModelTest {
 		assertEquals(123, request.maxOutputTokens());
 	}
 
+	@Test
+	void call_multipleSystemMessages_concatenatedIntoInstructions() {
+		when(responsesApi.call(any())).thenReturn(completedResponse("ok"));
+
+		// 多条系统消息必须按顺序拼接为单个 instructions，直接覆盖会静默丢失前文
+		Prompt prompt = new Prompt(
+				List.of(new SystemMessage("first rule"), new SystemMessage("second rule"), new UserMessage("hi")));
+		chatModel.call(prompt);
+
+		ArgumentCaptor<ResponsesRequest> captor = ArgumentCaptor.forClass(ResponsesRequest.class);
+		verify(responsesApi).call(captor.capture());
+		assertEquals("first rule\n\nsecond rule", captor.getValue().instructions());
+	}
+
 	// ======================== 非流式响应转换 ========================
 
 	@Test
@@ -132,7 +161,8 @@ class ResponsesApiChatModelTest {
 
 	@Test
 	void call_incompleteWithMaxTokens_mapsToLengthFinishReason() {
-		OutputItem item = new OutputItem("message", "assistant", List.of(new ContentPart("output_text", "partial")));
+		OutputItem item = new OutputItem("message", "assistant", List.of(new ContentPart("output_text", "partial")),
+				null, null, null);
 		ResponsesResponse incomplete = new ResponsesResponse("resp_2", "gpt-test", "incomplete", List.of(item), null,
 				new IncompleteDetails("max_output_tokens"), null);
 		when(responsesApi.call(any())).thenReturn(incomplete);
@@ -199,6 +229,35 @@ class ResponsesApiChatModelTest {
 	}
 
 	@Test
+	void stream_noDeltaReceived_terminalCarriesFullText() {
+		// 个别兼容实现不推送 output_text.delta，文本只出现在 completed 事件的完整 output 中，
+		// 此时终包必须降级携带全文，否则文本整体丢失
+		when(responsesApi.stream(any())).thenReturn(
+				Flux.just(new StreamEvent(StreamEvent.Type.COMPLETED, null, completedResponse("full text only"), null)));
+
+		List<ChatResponse> chunks = chatModel.stream(new Prompt(List.of(new UserMessage("hi")))).collectList().block();
+
+		assertNotNull(chunks);
+		assertEquals(1, chunks.size());
+		assertEquals("full text only", chunks.get(0).getResult().getOutput().getText());
+		assertEquals("STOP", chunks.get(0).getResult().getMetadata().getFinishReason());
+	}
+
+	@Test
+	void stream_withDelta_terminalStaysEmptyEvenIfOutputHasText() {
+		// 已收到 delta 时终包必须保持空文本（防聚合重复），不能因 output 中有全文而降级
+		when(responsesApi.stream(any()))
+			.thenReturn(Flux.just(new StreamEvent(StreamEvent.Type.DELTA, "Hello world", null, null),
+					new StreamEvent(StreamEvent.Type.COMPLETED, null, completedResponse("Hello world"), null)));
+
+		List<ChatResponse> chunks = chatModel.stream(new Prompt(List.of(new UserMessage("hi")))).collectList().block();
+
+		assertNotNull(chunks);
+		assertEquals(2, chunks.size());
+		assertEquals("", chunks.get(1).getResult().getOutput().getText());
+	}
+
+	@Test
 	void stream_errorEvent_propagatesAsFluxError() {
 		when(responsesApi.stream(any()))
 			.thenReturn(Flux.just(new StreamEvent(StreamEvent.Type.ERROR, null, null, "boom")));
@@ -218,6 +277,158 @@ class ResponsesApiChatModelTest {
 		ArgumentCaptor<ResponsesRequest> captor = ArgumentCaptor.forClass(ResponsesRequest.class);
 		verify(responsesApi).stream(captor.capture());
 		assertTrue(captor.getValue().stream());
+	}
+
+	// ======================== Tool Calling ========================
+
+	/**
+	 * 构造一个用于测试的 ToolCallback（仅提供工具定义，不真正执行）
+	 */
+	private ToolCallback testToolCallback() {
+		return new ToolCallback() {
+			@Override
+			public ToolDefinition getToolDefinition() {
+				return ToolDefinition.builder()
+					.name("search")
+					.description("搜索工具")
+					.inputSchema("{\"type\":\"object\",\"properties\":{\"q\":{\"type\":\"string\"}}}")
+					.build();
+			}
+
+			@Override
+			public String call(String toolInput) {
+				return "";
+			}
+		};
+	}
+
+	@Test
+	void call_mapsToolCallbacksToFunctionTools() {
+		when(responsesApi.call(any())).thenReturn(completedResponse("ok"));
+
+		// AgentScope 链路通过 ToolCallingChatOptions 传入工具声明
+		ToolCallingChatOptions options = ToolCallingChatOptions.builder()
+			.toolCallbacks(testToolCallback())
+			.internalToolExecutionEnabled(false)
+			.build();
+		chatModel.call(new Prompt(List.of(new UserMessage("北京天气如何")), options));
+
+		ArgumentCaptor<ResponsesRequest> captor = ArgumentCaptor.forClass(ResponsesRequest.class);
+		verify(responsesApi).call(captor.capture());
+		ResponsesRequest request = captor.getValue();
+
+		assertNotNull(request.tools());
+		assertEquals(1, request.tools().size());
+		assertEquals("function", request.tools().get(0).type());
+		assertEquals("search", request.tools().get(0).name());
+		assertEquals("搜索工具", request.tools().get(0).description());
+		// inputSchema JSON 字符串应被解析为对象
+		assertEquals("object", request.tools().get(0).parameters().get("type"));
+	}
+
+	@Test
+	void call_withoutToolOptions_toolsFieldIsNull() {
+		when(responsesApi.call(any())).thenReturn(completedResponse("ok"));
+
+		chatModel.call(new Prompt(List.of(new UserMessage("hi"))));
+
+		ArgumentCaptor<ResponsesRequest> captor = ArgumentCaptor.forClass(ResponsesRequest.class);
+		verify(responsesApi).call(captor.capture());
+		// 非工具场景不应出现 tools 字段
+		assertNull(captor.getValue().tools());
+	}
+
+	@Test
+	void call_mapsToolHistoryToFunctionCallItems() {
+		when(responsesApi.call(any())).thenReturn(completedResponse("ok"));
+
+		// 模拟多轮 agent 循环的历史：助手发起工具调用 → 工具返回结果
+		AssistantMessage assistantWithToolCall = AssistantMessage.builder()
+			.content("")
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call_1", "function", "search", "{\"q\":\"北京天气\"}")))
+			.build();
+		ToolResponseMessage toolResult = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("call_1", "search", "{\"weather\":\"晴\"}")))
+			.build();
+
+		chatModel.call(new Prompt(
+				List.of(new UserMessage("北京天气如何"), assistantWithToolCall, toolResult, new UserMessage("继续"))));
+
+		ArgumentCaptor<ResponsesRequest> captor = ArgumentCaptor.forClass(ResponsesRequest.class);
+		verify(responsesApi).call(captor.capture());
+		List<ResponsesApi.InputItem> input = captor.getValue().input();
+
+		// 顺序：user → function_call → function_call_output → user
+		assertEquals(4, input.size());
+		assertEquals("user", input.get(0).role());
+		assertEquals("function_call", input.get(1).type());
+		assertEquals("call_1", input.get(1).callId());
+		assertEquals("search", input.get(1).name());
+		assertEquals("{\"q\":\"北京天气\"}", input.get(1).arguments());
+		assertEquals("function_call_output", input.get(2).type());
+		assertEquals("call_1", input.get(2).callId());
+		assertEquals("{\"weather\":\"晴\"}", input.get(2).output());
+		assertEquals("user", input.get(3).role());
+	}
+
+	@Test
+	void call_toolResponseWithNullData_mapsToEmptyOutput() {
+		when(responsesApi.call(any())).thenReturn(completedResponse("ok"));
+
+		// 工具结果为 null 时 output 字段必须兜底空串，整体省略可能被服务端拒绝
+		AssistantMessage assistantWithToolCall = AssistantMessage.builder()
+			.content("")
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call_1", "function", "search", "{}")))
+			.build();
+		ToolResponseMessage toolResult = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("call_1", "search", null)))
+			.build();
+
+		chatModel.call(new Prompt(List.of(new UserMessage("hi"), assistantWithToolCall, toolResult)));
+
+		ArgumentCaptor<ResponsesRequest> captor = ArgumentCaptor.forClass(ResponsesRequest.class);
+		verify(responsesApi).call(captor.capture());
+		List<ResponsesApi.InputItem> input = captor.getValue().input();
+		assertEquals("function_call_output", input.get(2).type());
+		assertEquals("", input.get(2).output());
+	}
+
+	@Test
+	void call_extractsToolCallsFromResponse() {
+		when(responsesApi.call(any())).thenReturn(functionCallResponse());
+
+		ChatResponse response = chatModel.call(new Prompt(List.of(new UserMessage("北京天气如何"))));
+
+		AssistantMessage output = response.getResult().getOutput();
+		assertTrue(output.hasToolCalls());
+		assertEquals(1, output.getToolCalls().size());
+		assertEquals("call_1", output.getToolCalls().get(0).id());
+		assertEquals("search", output.getToolCalls().get(0).name());
+		assertEquals("{\"q\":\"北京天气\"}", output.getToolCalls().get(0).arguments());
+		// 存在工具调用时 finishReason 为 TOOL_CALLS，与 OpenAiChatModel 对齐
+		assertEquals("TOOL_CALLS", response.getResult().getMetadata().getFinishReason());
+	}
+
+	@Test
+	void stream_terminalChunkCarriesToolCalls() {
+		// 流式场景下 function_call 只在 completed 事件的完整 output 中出现，
+		// 终包必须携带 toolCalls（文本仍为空串），否则 AgentScope 桥接层无法驱动工具执行
+		when(responsesApi.stream(any()))
+			.thenReturn(Flux.just(new StreamEvent(StreamEvent.Type.COMPLETED, null, functionCallResponse(), null)));
+
+		List<ChatResponse> chunks = chatModel.stream(new Prompt(List.of(new UserMessage("北京天气如何"))))
+			.collectList()
+			.block();
+
+		assertNotNull(chunks);
+		assertEquals(1, chunks.size());
+		AssistantMessage output = chunks.get(0).getResult().getOutput();
+		assertEquals("", output.getText());
+		assertTrue(output.hasToolCalls());
+		assertEquals("call_1", output.getToolCalls().get(0).id());
+		assertEquals("TOOL_CALLS", chunks.get(0).getResult().getMetadata().getFinishReason());
+		// usage 仍随终包携带
+		assertEquals(20, chunks.get(0).getMetadata().getUsage().getPromptTokens());
 	}
 
 }

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/responses/ResponsesApiChatModelTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/responses/ResponsesApiChatModelTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses;
+
+import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApi.ContentPart;
+import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApi.IncompleteDetails;
+import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApi.OutputItem;
+import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApi.ResponsesRequest;
+import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApi.ResponsesResponse;
+import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApi.ResponsesUsage;
+import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApi.StreamEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * ResponsesApiChatModel 协议转换单元测试。 覆盖 Prompt → Responses 请求映射、非流式响应转换、
+ * 流式事件转换（重点回归：终包必须为空文本，避免上层聚合时全文重复）。
+ */
+class ResponsesApiChatModelTest {
+
+	private ResponsesApi responsesApi;
+
+	private ResponsesApiChatModel chatModel;
+
+	@BeforeEach
+	void setUp() {
+		responsesApi = mock(ResponsesApi.class);
+		OpenAiChatOptions defaultOptions = OpenAiChatOptions.builder()
+			.model("default-model")
+			.temperature(0.1)
+			.maxTokens(1000)
+			.build();
+		chatModel = new ResponsesApiChatModel(responsesApi, defaultOptions);
+	}
+
+	/**
+	 * 构造一个携带文本输出和 usage 的完整响应
+	 */
+	private ResponsesResponse completedResponse(String text) {
+		OutputItem item = new OutputItem("message", "assistant", List.of(new ContentPart("output_text", text)));
+		return new ResponsesResponse("resp_1", "gpt-test", "completed", List.of(item), new ResponsesUsage(10, 5, 15),
+				null, null);
+	}
+
+	// ======================== 请求映射 ========================
+
+	@Test
+	void call_mapsSystemToInstructionsAndUserToInput() {
+		when(responsesApi.call(any())).thenReturn(completedResponse("ok"));
+
+		Prompt prompt = new Prompt(List.of(new SystemMessage("you are helpful"), new UserMessage("hi")));
+		chatModel.call(prompt);
+
+		ArgumentCaptor<ResponsesRequest> captor = ArgumentCaptor.forClass(ResponsesRequest.class);
+		verify(responsesApi).call(captor.capture());
+		ResponsesRequest request = captor.getValue();
+
+		assertEquals("you are helpful", request.instructions());
+		assertEquals(1, request.input().size());
+		assertEquals("user", request.input().get(0).role());
+		assertEquals("hi", request.input().get(0).content().get(0).text());
+		// 未指定运行时 options 时使用默认配置
+		assertEquals("default-model", request.model());
+		assertEquals(0.1, request.temperature());
+		assertEquals(1000, request.maxOutputTokens());
+	}
+
+	@Test
+	void call_runtimeOptionsOverrideDefaults_viaChatOptionsInterface() {
+		when(responsesApi.call(any())).thenReturn(completedResponse("ok"));
+
+		// 使用通用 ChatOptions 实现（非 OpenAiChatOptions），验证按接口取值不会被静默忽略
+		ChatOptions runtimeOptions = ChatOptions.builder()
+			.model("runtime-model")
+			.temperature(0.9)
+			.maxTokens(123)
+			.build();
+		Prompt prompt = new Prompt(List.of(new UserMessage("hi")), runtimeOptions);
+		chatModel.call(prompt);
+
+		ArgumentCaptor<ResponsesRequest> captor = ArgumentCaptor.forClass(ResponsesRequest.class);
+		verify(responsesApi).call(captor.capture());
+		ResponsesRequest request = captor.getValue();
+
+		assertEquals("runtime-model", request.model());
+		assertEquals(0.9, request.temperature());
+		assertEquals(123, request.maxOutputTokens());
+	}
+
+	// ======================== 非流式响应转换 ========================
+
+	@Test
+	void call_extractsTextAndUsage() {
+		when(responsesApi.call(any())).thenReturn(completedResponse("hello world"));
+
+		ChatResponse response = chatModel.call(new Prompt(List.of(new UserMessage("hi"))));
+
+		assertEquals("hello world", response.getResult().getOutput().getText());
+		assertEquals("STOP", response.getResult().getMetadata().getFinishReason());
+		assertEquals(10, response.getMetadata().getUsage().getPromptTokens());
+		assertEquals(5, response.getMetadata().getUsage().getCompletionTokens());
+	}
+
+	@Test
+	void call_incompleteWithMaxTokens_mapsToLengthFinishReason() {
+		OutputItem item = new OutputItem("message", "assistant", List.of(new ContentPart("output_text", "partial")));
+		ResponsesResponse incomplete = new ResponsesResponse("resp_2", "gpt-test", "incomplete", List.of(item), null,
+				new IncompleteDetails("max_output_tokens"), null);
+		when(responsesApi.call(any())).thenReturn(incomplete);
+
+		ChatResponse response = chatModel.call(new Prompt(List.of(new UserMessage("hi"))));
+
+		assertEquals("partial", response.getResult().getOutput().getText());
+		assertEquals("LENGTH", response.getResult().getMetadata().getFinishReason());
+	}
+
+	// ======================== 流式响应转换 ========================
+
+	@Test
+	void stream_terminalChunkMustBeEmptyText_toAvoidDuplication() {
+		// completed 事件的 response 中携带完整全文；上层 FluxUtil 会对每个 chunk 的文本做 append 聚合，
+		// 因此终包文本必须为空串，否则聚合结果为"全部 delta + 整段全文"的重复（P0 回归用例）
+		when(responsesApi.stream(any())).thenReturn(Flux.just(new StreamEvent(StreamEvent.Type.DELTA, "Hello", null, null),
+				new StreamEvent(StreamEvent.Type.DELTA, " world", null, null),
+				new StreamEvent(StreamEvent.Type.COMPLETED, null, completedResponse("Hello world"), null)));
+
+		List<ChatResponse> chunks = chatModel.stream(new Prompt(List.of(new UserMessage("hi")))).collectList().block();
+
+		assertNotNull(chunks);
+		assertEquals(3, chunks.size());
+		assertEquals("Hello", chunks.get(0).getResult().getOutput().getText());
+		assertEquals(" world", chunks.get(1).getResult().getOutput().getText());
+		// 终包：空文本 + finishReason + usage
+		assertEquals("", chunks.get(2).getResult().getOutput().getText());
+		assertEquals("STOP", chunks.get(2).getResult().getMetadata().getFinishReason());
+		assertEquals(10, chunks.get(2).getMetadata().getUsage().getPromptTokens());
+
+		// 模拟上层聚合行为：全部 chunk 文本拼接后应恰好等于一遍全文
+		StringBuilder aggregated = new StringBuilder();
+		chunks.forEach(c -> aggregated.append(c.getResult().getOutput().getText()));
+		assertEquals("Hello world", aggregated.toString());
+	}
+
+	@Test
+	void stream_incompleteEvent_mapsToLengthTerminal() {
+		ResponsesResponse incomplete = new ResponsesResponse("resp_3", "gpt-test", "incomplete", null, null,
+				new IncompleteDetails("max_output_tokens"), null);
+		when(responsesApi.stream(any()))
+			.thenReturn(Flux.just(new StreamEvent(StreamEvent.Type.DELTA, "part", null, null),
+					new StreamEvent(StreamEvent.Type.INCOMPLETE, null, incomplete, null)));
+
+		List<ChatResponse> chunks = chatModel.stream(new Prompt(List.of(new UserMessage("hi")))).collectList().block();
+
+		assertNotNull(chunks);
+		assertEquals(2, chunks.size());
+		assertEquals("", chunks.get(1).getResult().getOutput().getText());
+		assertEquals("LENGTH", chunks.get(1).getResult().getMetadata().getFinishReason());
+	}
+
+	@Test
+	void stream_nullDelta_treatedAsEmptyText() {
+		// delta 字段缺失时按空串处理，不应抛 NPE
+		when(responsesApi.stream(any()))
+			.thenReturn(Flux.just(new StreamEvent(StreamEvent.Type.DELTA, null, null, null)));
+
+		List<ChatResponse> chunks = chatModel.stream(new Prompt(List.of(new UserMessage("hi")))).collectList().block();
+
+		assertNotNull(chunks);
+		assertEquals("", chunks.get(0).getResult().getOutput().getText());
+	}
+
+	@Test
+	void stream_errorEvent_propagatesAsFluxError() {
+		when(responsesApi.stream(any()))
+			.thenReturn(Flux.just(new StreamEvent(StreamEvent.Type.ERROR, null, null, "boom")));
+
+		Flux<ChatResponse> flux = chatModel.stream(new Prompt(List.of(new UserMessage("hi"))));
+
+		RuntimeException ex = assertThrows(RuntimeException.class, flux::blockLast);
+		assertTrue(ex.getMessage().contains("boom"));
+	}
+
+	@Test
+	void stream_requestHasStreamFlagTrue() {
+		when(responsesApi.stream(any())).thenReturn(Flux.empty());
+
+		chatModel.stream(new Prompt(List.of(new UserMessage("hi")))).collectList().block();
+
+		ArgumentCaptor<ResponsesRequest> captor = ArgumentCaptor.forClass(ResponsesRequest.class);
+		verify(responsesApi).stream(captor.capture());
+		assertTrue(captor.getValue().stream());
+	}
+
+}

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/responses/ResponsesApiTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/responses/ResponsesApiTest.java
@@ -67,6 +67,24 @@ class ResponsesApiTest {
 	}
 
 	@Test
+	void parseCompletedEvent_parsesFunctionCallOutputItem() {
+		// completed 事件的 output 中包含 function_call 项时，call_id/name/arguments 必须正确反序列化，
+		// 否则 tool calling 链路无法将调用与结果配对
+		String data = """
+				{"type":"response.completed","response":{"id":"resp_fc","status":"completed",
+				"output":[{"type":"function_call","id":"fc_1","call_id":"call_1","name":"search",
+				"arguments":"{\\"q\\":\\"天气\\"}"}]}}
+				""";
+		StreamEvent event = parse(data);
+		assertNotNull(event);
+		assertEquals(StreamEvent.Type.COMPLETED, event.type());
+		assertEquals("function_call", event.response().output().get(0).type());
+		assertEquals("call_1", event.response().output().get(0).callId());
+		assertEquals("search", event.response().output().get(0).name());
+		assertEquals("{\"q\":\"天气\"}", event.response().output().get(0).arguments());
+	}
+
+	@Test
 	void parseIncompleteEvent_returnsIncompleteType() {
 		String data = """
 				{"type":"response.incomplete","response":{"id":"resp_2","status":"incomplete",

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/responses/ResponsesApiTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/responses/ResponsesApiTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses;
+
+import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.responses.ResponsesApi.StreamEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * ResponsesApi SSE 事件解析单元测试。 覆盖 delta / completed / incomplete / failed / error
+ * 各事件分支，以及畸形事件的容错行为。
+ */
+class ResponsesApiTest {
+
+	private ResponsesApi responsesApi;
+
+	@BeforeEach
+	void setUp() {
+		// 仅测试解析逻辑，不发起真实 HTTP 请求，baseUrl 等参数使用占位值
+		responsesApi = new ResponsesApi("http://localhost", "test-key", null, RestClient.builder(),
+				WebClient.builder());
+	}
+
+	private StreamEvent parse(String data) {
+		return responsesApi.parseStreamEvent(ServerSentEvent.builder(data).build());
+	}
+
+	@Test
+	void parseDeltaEvent_returnsDeltaText() {
+		StreamEvent event = parse("{\"type\":\"response.output_text.delta\",\"delta\":\"Hello\"}");
+		assertNotNull(event);
+		assertEquals(StreamEvent.Type.DELTA, event.type());
+		assertEquals("Hello", event.delta());
+	}
+
+	@Test
+	void parseCompletedEvent_returnsResponseWithUsage() {
+		String data = """
+				{"type":"response.completed","response":{"id":"resp_1","model":"gpt-test","status":"completed",
+				"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}],
+				"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15}}}
+				""";
+		StreamEvent event = parse(data);
+		assertNotNull(event);
+		assertEquals(StreamEvent.Type.COMPLETED, event.type());
+		assertEquals("resp_1", event.response().id());
+		assertEquals(10, event.response().usage().inputTokens());
+		assertEquals(5, event.response().usage().outputTokens());
+	}
+
+	@Test
+	void parseIncompleteEvent_returnsIncompleteType() {
+		String data = """
+				{"type":"response.incomplete","response":{"id":"resp_2","status":"incomplete",
+				"incomplete_details":{"reason":"max_output_tokens"}}}
+				""";
+		StreamEvent event = parse(data);
+		assertNotNull(event);
+		assertEquals(StreamEvent.Type.INCOMPLETE, event.type());
+		assertEquals("max_output_tokens", event.response().incompleteDetails().reason());
+	}
+
+	@Test
+	void parseFailedEvent_returnsErrorWithMessage() {
+		String data = """
+				{"type":"response.failed","response":{"id":"resp_3","status":"failed",
+				"error":{"type":"server_error","message":"boom","code":"500"}}}
+				""";
+		StreamEvent event = parse(data);
+		assertNotNull(event);
+		assertEquals(StreamEvent.Type.ERROR, event.type());
+		assertEquals("boom", event.errorMessage());
+	}
+
+	@Test
+	void parseErrorEvent_returnsErrorWithMessage() {
+		StreamEvent event = parse("{\"type\":\"error\",\"error\":{\"message\":\"rate limited\"}}");
+		assertNotNull(event);
+		assertEquals(StreamEvent.Type.ERROR, event.type());
+		assertEquals("rate limited", event.errorMessage());
+	}
+
+	@Test
+	void parseUnknownEventType_returnsNull() {
+		// 未知事件类型（如 response.created）应静默忽略，保证向前兼容
+		assertNull(parse("{\"type\":\"response.created\",\"response\":{\"id\":\"resp_4\"}}"));
+	}
+
+	@Test
+	void parseMalformedJson_returnsNull() {
+		// 畸形 JSON 不应抛异常中断流，应按单条事件损坏跳过
+		assertNull(parse("{not valid json"));
+	}
+
+	@Test
+	void parseCompletedEventWithWrongStructure_returnsNull() {
+		// response 字段结构不匹配时 convertValue 抛 IllegalArgumentException，
+		// 必须被捕获并跳过，不能让一条畸形事件中断整个 SSE 流（回归用例）
+		assertNull(parse("{\"type\":\"response.completed\",\"response\":\"not-an-object\"}"));
+	}
+
+	@Test
+	void parseEventWithoutType_returnsNull() {
+		assertNull(parse("{\"delta\":\"orphan\"}"));
+	}
+
+}


### PR DESCRIPTION
## 概述

将 #544 的 Responses API 协议兼容能力移植到 `feat-agentscope` 分支，并针对 AgentScope 链路的需求扩展了 **tool calling 支持**，使仅支持 `POST /v1/responses` 协议的模型也能驱动 AgentScope agent 的完整工具调用循环。

关联：#531（原始需求）、#544（main 分支的 Responses API 兼容实现）

## 改动内容

### 移植自 #544（cherry-pick）

- `ChatApiProtocol` 枚举、`ResponsesApi` HTTP 客户端、`ResponsesApiChatModel` 适配层
- `DynamicModelFactory` 按 `chatApiProtocol` 配置分支创建 ChatModel
- 数据层全链路（实体/DTO/Converter/Mapper/Service）与 MySQL/H2 schema 增加 `chat_api_protocol` 字段
- 前端模型配置增加"接口协议"选项

### 本 PR 新增：tool calling 支持

AgentScope 链路（`SpringAiAgentScopeModel` → `delegate.stream(prompt)`）依赖 Spring AI 的 tool calling 协议，本 PR 在适配层补齐双向映射：

**请求侧**
- 识别 `ToolCallingChatOptions`，将 `ToolCallback` 的 `ToolDefinition`（name/description/inputSchema）映射为 Responses API 的 `tools` 字段（扁平 function 结构，inputSchema JSON 字符串解析为对象）
- 助手历史消息中的 `AssistantMessage.toolCalls` → `function_call` 输入项
- `ToolResponseMessage` → `function_call_output` 输入项（靠 `call_id` 与调用配对，多轮 agent 循环回放历史依赖此映射）

**响应侧**
- 非流式：从 output 中提取 `type=function_call` 项转为 `AssistantMessage.ToolCall`，存在工具调用时 finishReason 为 `TOOL_CALLS`（与 `OpenAiChatModel` 对齐）
- 流式：`function_call` 项只在 completed 事件的完整 output 中出现一次，由终包携带 toolCalls（文本仍为空串，不破坏上层 FluxUtil 文本聚合）；参数增量事件被忽略，AgentScope 桥接层对每个 chunk 读取 toolCalls，单次完整携带即可驱动工具执行

## 设计边界

- 本实现**不在框架内部执行工具**（等价于 `internalToolExecutionEnabled=false`），工具调用返回给调用方执行——与 AgentScope runtime 自管工具执行的设计一致
- 非工具场景请求中不出现 `tools` 字段，纯文本链路行为与 #544 完全一致
- 未知 SSE 事件（含 `response.function_call_arguments.delta`）静默忽略，保证向前兼容

## 存量部署升级说明

已有 MySQL 部署需手动执行：

```sql
ALTER TABLE model_config
    ADD COLUMN chat_api_protocol varchar(32) DEFAULT 'CHAT_COMPLETIONS'
    COMMENT 'Chat模型接口协议：CHAT_COMPLETIONS（默认）、RESPONSES（OpenAI Responses API格式）。仅model_type=CHAT时生效';
```

## 测试方案

- [x] 单元测试 24 个（`ResponsesApiTest` 10 个 + `ResponsesApiChatModelTest` 14 个），新增覆盖：tools 字段映射、工具历史 function_call/function_call_output 映射、响应 toolCalls 提取、流式终包携带 toolCalls、function_call SSE 事件反序列化
- [x] 模块全部 50 个测试通过（0 failures, 0 errors）
- [x] `spring-javaformat:validate` + `checkstyle:check` 通过
- [x] 端到端验证（Qwen DashScope `/v1/responses`，模型 `qwen-plus`，见下）

### 端到端测试结果

| 场景 | 结果 |
|------|------|
| 非流式纯文本 `call()` | ✅ 文本/finishReason/usage 正确 |
| 流式纯文本 `stream()` | ✅ delta 逐块、终包空文本+usage、聚合无重复 |
| 非流式工具调用（声明 tools → 模型发起 `function_call`） | ✅ call_id/name/arguments 正确提取，finishReason=TOOL_CALLS |
| 流式工具调用 | ✅ 终包携带完整 toolCalls + 空文本 + usage + TOOL_CALLS |
| 工具结果回传（`function_call_output` 历史回放） | ⚠️ 被 DashScope 服务端 400 拒绝（见下） |

**关于回传步骤的说明**：用标准 OpenAI Responses API 格式的最小 curl 请求可复现同样错误——DashScope 兼容层内部将 `function_call_output` 转为 `role='tool'` 消息后，又被其自身校验器拒绝（只接受 user/assistant/system/function）。这是 DashScope `/v1/responses` 兼容实现的服务端限制，并非本适配层问题；本 PR 的请求格式符合 OpenAI 规范，在规范实现的服务端（如 OpenAI 官方）上完整工具循环可用。错误示例：

```
<400> InternalError.Algo.InvalidParameter: ... Value error, tool must be one of user,assistant,system,function [input_value='tool']
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)