### PR TITLE
fix: resolve stream 500, restore back button, fix stale connection_url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ uploads/*
 spring-ai-alibaba-1.1.0.0/
 .gstack/
 .codegraph/
+*/vectorstore/vectorstore.json

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/controller/GraphController.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/controller/GraphController.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2024-2026 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.alibaba.cloud.ai.dataagent.controller;
 
 import com.alibaba.cloud.ai.dataagent.dto.GraphRequest;
@@ -24,7 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.ServerSentEvent;
-import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
@@ -53,11 +37,7 @@ public class GraphController {
 			@RequestParam(value = "humanFeedback", required = false) boolean humanFeedback,
 			@RequestParam(value = "humanFeedbackContent", required = false) String humanFeedbackContent,
 			@RequestParam(value = "rejectedPlan", required = false) boolean rejectedPlan,
-			@RequestParam(value = "nl2sqlOnly", required = false) boolean nl2sqlOnly, ServerHttpResponse response) {
-		// Set SSE-related HTTP headers
-		response.getHeaders().add("Cache-Control", "no-cache");
-		response.getHeaders().add("Connection", "keep-alive");
-		response.getHeaders().add("Access-Control-Allow-Origin", "*");
+			@RequestParam(value = "nl2sqlOnly", required = false) boolean nl2sqlOnly) {
 
 		Sinks.Many<ServerSentEvent<GraphNodeResponse>> sink = Sinks.many().unicast().onBackpressureBuffer();
 

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/handler/DatasourceTypeHandler.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/handler/DatasourceTypeHandler.java
@@ -45,6 +45,9 @@ public interface DatasourceTypeHandler {
 	}
 
 	default String resolveConnectionUrl(Datasource datasource) {
+		if (hasRequiredConnectionFields(datasource)) {
+			return buildConnectionUrl(datasource);
+		}
 		String existing = datasource.getConnectionUrl();
 		if (StringUtils.hasText(existing)) {
 			return existing;


### PR DESCRIPTION
- Remove ServerHttpResponse parameter from GraphController to fix No primary constructor found error in Spring MVC mode
- Restore back button in ChatSessionSidebar and add missing ArrowLeft icon import
- Fix resolveConnectionUrl() ignoring updated host/port/database when a legacy connection_url is present in the database