### PR TITLE
fix: separate chat memory and graph run lifecycle

### DIFF
--- a/data-agent-frontend-nuxt/app/services/graph/README.md
+++ b/data-agent-frontend-nuxt/app/services/graph/README.md
@@ -16,7 +16,9 @@
 export interface GraphRequest {
   /** 智能体 ID */
   agentId: string;
-  /** 会话线程 ID */
+  /** 聊天记忆会话 ID */
+  conversationId: string;
+  /** Graph 运行 ID，仅在人工反馈恢复时复用 */
   threadId?: string;
   /** 用户查询语句 */
   query: string;

--- a/data-agent-frontend-nuxt/app/services/graph/index.ts
+++ b/data-agent-frontend-nuxt/app/services/graph/index.ts
@@ -24,7 +24,9 @@
 export interface GraphRequest {
   /** 智能体 ID */
   agentId: string;
-  /** 会话线程 ID */
+  /** 聊天记忆会话 ID */
+  conversationId: string;
+  /** Graph 运行 ID，仅在人工反馈恢复时复用 */
   threadId?: string;
   /** 用户查询语句 */
   query: string;
@@ -100,6 +102,7 @@ class GraphService {
   ): Promise<() => void> {
     const params = new URLSearchParams();
     params.append("agentId", request.agentId);
+    params.append("conversationId", request.conversationId);
     if (request.threadId) {
       params.append("threadId", request.threadId);
     }

--- a/data-agent-frontend-nuxt/app/services/graph/index.ts
+++ b/data-agent-frontend-nuxt/app/services/graph/index.ts
@@ -92,14 +92,14 @@ class GraphService {
    * @param {(response: GraphNodeResponse) => Promise<void>} onMessage - 收到消息时的回调
    * @param {(error: Error) => Promise<void>} [onError] - 发生错误时的回调
    * @param {() => Promise<void>} [onComplete] - 搜索完成时的回调
-   * @returns {Promise<() => void>} 返回一个用于手动关闭流连接的函数
+   * @returns {Promise<(cancelRun?: boolean) => Promise<void>>} 返回一个用于关闭流连接并按需取消后端任务的函数
    */
   async streamSearch(
     request: GraphRequest,
     onMessage: (response: GraphNodeResponse) => Promise<void>,
     onError?: (error: Error) => Promise<void>,
     onComplete?: () => Promise<void>,
-  ): Promise<() => void> {
+  ): Promise<(cancelRun?: boolean) => Promise<void>> {
     const params = new URLSearchParams();
     params.append("agentId", request.agentId);
     params.append("conversationId", request.conversationId);
@@ -119,9 +119,12 @@ class GraphService {
 
     const eventSource = new EventSource(url);
 
+    let latestThreadId = request.threadId;
+
     eventSource.onmessage = async (event) => {
       try {
         const nodeResponse: GraphNodeResponse = JSON.parse(event.data);
+        latestThreadId = nodeResponse.threadId || latestThreadId;
         console.log(
           `Node: ${nodeResponse.nodeName}, message: ${nodeResponse.text}, type: ${nodeResponse.textType}`,
         );
@@ -174,8 +177,22 @@ class GraphService {
       }
     });
 
-    return () => {
+    return async (cancelRun = false) => {
+      isCompleted = true;
       eventSource.close();
+      if (!cancelRun) return;
+
+      const stopParams = new URLSearchParams({
+        conversationId: request.conversationId,
+      });
+      if (latestThreadId) stopParams.append("threadId", latestThreadId);
+      const response = await fetch(
+        `${API_BASE_URL}/stream/stop?${stopParams.toString()}`,
+        { method: "POST", keepalive: true },
+      );
+      if (!response.ok) {
+        throw new Error(`Failed to stop graph run: HTTP ${response.status}`);
+      }
     };
   }
 }

--- a/data-agent-frontend-nuxt/app/services/sessionStateManager/index.ts
+++ b/data-agent-frontend-nuxt/app/services/sessionStateManager/index.ts
@@ -30,7 +30,7 @@ export interface SessionRuntimeState {
   /** 图节点响应块列表 */
   nodeBlocks: GraphNodeResponse[][];
   /** 关闭流的回调函数 */
-  closeStream: (() => void) | null;
+  closeStream: ((cancelRun?: boolean) => Promise<void>) | null;
   /** 最后一次请求参数 */
   lastRequest: GraphRequest | null;
   /** HTML 报告内容 */
@@ -110,7 +110,7 @@ export function useSessionStateManager() {
   const deleteSessionState = (sessionId: string) => {
     const state = sessionStates.value.get(sessionId);
     if (state?.closeStream) {
-      state.closeStream();
+      void state.closeStream(true);
     }
     sessionStates.value.delete(sessionId);
   };

--- a/data-agent-frontend-nuxt/app/stores/chat.ts
+++ b/data-agent-frontend-nuxt/app/stores/chat.ts
@@ -328,14 +328,15 @@ export const useChatStore = defineStore('chat', () => {
 		const sessionState = getSessionState(currentSession.value.id);
 		const request: GraphRequest = {
 			agentId: String(currentAgentId.value || ''),
+			conversationId: currentSession.value.id,
 			query,
 			humanFeedback: requestOptions.value.humanFeedback,
 			nl2sqlOnly: requestOptions.value.nl2sqlOnly,
 			rejectedPlan: false,
 			humanFeedbackContent: undefined,
-			// Keep one stable graph thread per chat session so Spring AI Alibaba can
-			// restore checkpoints and Spring AI can restore chat memory after reloads.
-			threadId: sessionState.lastRequest?.threadId || currentSession.value.id,
+			// A normal message starts a fresh graph run. The backend returns its run ID
+			// and submitFeedback reuses it only when resuming an interrupted graph.
+			threadId: undefined,
 		};
 
 		await _sendGraphRequest(request, true);

--- a/data-agent-frontend-nuxt/app/stores/chat.ts
+++ b/data-agent-frontend-nuxt/app/stores/chat.ts
@@ -325,7 +325,6 @@ export const useChatStore = defineStore('chat', () => {
 		);
 		currentMessages.value.push(saved);
 
-		const sessionState = getSessionState(currentSession.value.id);
 		const request: GraphRequest = {
 			agentId: String(currentAgentId.value || ''),
 			conversationId: currentSession.value.id,
@@ -571,7 +570,8 @@ export const useChatStore = defineStore('chat', () => {
 				}
 
 				currentNodeName = null;
-				closeStream();
+				await closeStream();
+				sessionState.closeStream = null;
 				if (currentSession.value?.id === sessionId) {
 					currentMessages.value =
 						await chatService.getSessionMessages(sessionId);
@@ -589,7 +589,11 @@ export const useChatStore = defineStore('chat', () => {
 		const sessionState = getSessionState(sessionId);
 		if (!sessionState.closeStream) return;
 
-		sessionState.closeStream();
+		try {
+			await sessionState.closeStream(true);
+		} catch (error) {
+			console.error('停止后端图任务失败:', error);
+		}
 		sessionState.closeStream = null;
 		sessionState.isStreaming = false;
 		sessionState.nodeBlocks = [];

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/config/DataAgentConfiguration.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/config/DataAgentConfiguration.java
@@ -42,7 +42,9 @@ import com.alibaba.cloud.ai.graph.GraphRepresentation;
 import com.alibaba.cloud.ai.graph.KeyStrategy;
 import com.alibaba.cloud.ai.graph.KeyStrategyFactory;
 import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
 import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
 import com.alibaba.cloud.ai.graph.checkpoint.savers.mysql.CreateOption;
 import com.alibaba.cloud.ai.graph.checkpoint.savers.mysql.MysqlSaver;
 import com.alibaba.cloud.ai.graph.exception.GraphStateException;
@@ -301,13 +303,24 @@ public class DataAgentConfiguration implements DisposableBean {
 	 * datasource and the human-review interruption point.
 	 */
 	@Bean
-	public CompileConfig nl2sqlGraphCompileConfig(StateGraph nl2sqlGraph, DataSource dataSource) {
-		MysqlSaver checkpointSaver = MysqlSaver.builder()
+	@ConditionalOnProperty(name = "spring.ai.alibaba.data-agent.checkpoint.type", havingValue = "mysql",
+			matchIfMissing = true)
+	public BaseCheckpointSaver mysqlCheckpointSaver(StateGraph nl2sqlGraph, DataSource dataSource) {
+		return MysqlSaver.builder()
 			.dataSource(dataSource)
 			.stateSerializer(nl2sqlGraph.getStateSerializer())
 			.createOption(CreateOption.CREATE_IF_NOT_EXISTS)
 			.build();
+	}
 
+	@Bean
+	@ConditionalOnProperty(name = "spring.ai.alibaba.data-agent.checkpoint.type", havingValue = "memory")
+	public BaseCheckpointSaver memoryCheckpointSaver() {
+		return MemorySaver.builder().build();
+	}
+
+	@Bean
+	public CompileConfig nl2sqlGraphCompileConfig(BaseCheckpointSaver checkpointSaver) {
 		SaverConfig saverConfig = SaverConfig.builder().register(checkpointSaver).build();
 		return CompileConfig.builder().saverConfig(saverConfig).interruptBefore(HUMAN_FEEDBACK_NODE).build();
 	}

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/controller/GraphController.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/controller/GraphController.java
@@ -45,6 +45,7 @@ public class GraphController {
 
 	@GetMapping(value = "/stream/search", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
 	public Flux<ServerSentEvent<GraphNodeResponse>> streamSearch(@RequestParam("agentId") String agentId,
+			@RequestParam(value = "conversationId", required = false) String conversationId,
 			@RequestParam(value = "threadId", required = false) String threadId, @RequestParam("query") String query,
 			@RequestParam(value = "humanFeedback", required = false) boolean humanFeedback,
 			@RequestParam(value = "humanFeedbackContent", required = false) String humanFeedbackContent,
@@ -59,6 +60,7 @@ public class GraphController {
 
 		GraphRequest request = GraphRequest.builder()
 			.agentId(agentId)
+			.conversationId(conversationId)
 			.threadId(threadId)
 			.query(query)
 			.humanFeedback(humanFeedback)

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/controller/GraphController.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/controller/GraphController.java
@@ -21,8 +21,10 @@ import com.alibaba.cloud.ai.dataagent.vo.GraphNodeResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
@@ -92,6 +94,18 @@ public class GraphController {
 				}
 			})
 			.doOnComplete(() -> log.info("Stream completed successfully, threadId: {}", request.getThreadId()));
+	}
+
+	@PostMapping("/stream/stop")
+	public ResponseEntity<Void> stopStream(@RequestParam("conversationId") String conversationId,
+			@RequestParam(value = "threadId", required = false) String threadId) {
+		if (StringUtils.hasText(threadId)) {
+			graphService.stopStreamProcessing(threadId);
+		}
+		else {
+			graphService.stopStreamProcessingByConversationId(conversationId);
+		}
+		return ResponseEntity.noContent().build();
 	}
 
 }

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/dto/GraphRequest.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/dto/GraphRequest.java
@@ -28,6 +28,10 @@ public class GraphRequest {
 
 	private String agentId;
 
+	/** Stable chat-memory conversation identifier. */
+	private String conversationId;
+
+	/** Graph run identifier. Reused only when resuming human feedback. */
 	private String threadId;
 
 	private String query;

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/chat/ChatSessionServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/chat/ChatSessionServiceImpl.java
@@ -19,6 +19,7 @@ import com.alibaba.cloud.ai.dataagent.entity.ChatSession;
 import com.alibaba.cloud.ai.dataagent.mapper.ChatSessionMapper;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -31,6 +32,8 @@ import java.util.UUID;
 public class ChatSessionServiceImpl implements ChatSessionService {
 
 	private final ChatSessionMapper chatSessionMapper;
+
+	private final ChatMemory chatMemory;
 
 	/**
 	 * Get session list by agent ID
@@ -64,8 +67,10 @@ public class ChatSessionServiceImpl implements ChatSessionService {
 	 */
 	@Override
 	public void clearSessionsByAgentId(Integer agentId) {
+		List<ChatSession> sessions = chatSessionMapper.selectByAgentId(agentId);
 		LocalDateTime now = LocalDateTime.now();
 		int updated = chatSessionMapper.softDeleteByAgentId(agentId, now);
+		sessions.forEach(session -> chatMemory.clear(session.getId()));
 		log.info("Cleared {} sessions for agent: {}", updated, agentId);
 	}
 
@@ -105,6 +110,7 @@ public class ChatSessionServiceImpl implements ChatSessionService {
 	public void deleteSession(String sessionId) {
 		LocalDateTime now = LocalDateTime.now();
 		chatSessionMapper.softDeleteById(sessionId, now);
+		chatMemory.clear(sessionId);
 		log.info("Deleted session: {}", sessionId);
 	}
 

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/Context/StreamContext.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/Context/StreamContext.java
@@ -34,6 +34,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @Data
 public class StreamContext {
 
+	private String conversationId;
+
 	private Disposable disposable;
 
 	private Sinks.Many<ServerSentEvent<GraphNodeResponse>> sink;

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphService.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphService.java
@@ -49,4 +49,10 @@ public interface GraphService {
 	 */
 	void stopStreamProcessing(String threadId);
 
+	/**
+	 * 停止指定会话当前仍在运行的图任务。用于客户端尚未收到 threadId 时的取消兜底。
+	 * @param conversationId 会话ID
+	 */
+	void stopStreamProcessingByConversationId(String conversationId);
+
 }

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphServiceImpl.java
@@ -128,7 +128,6 @@ public class GraphServiceImpl implements GraphService {
 		log.info("Stopping stream processing for threadId: {}", threadId);
 		StreamContext context = streamContextMap.remove(threadId);
 		multiTurnContextManager.discardPending(context != null ? context.getConversationId() : threadId);
-		releaseCheckpoint(RunnableConfig.builder().threadId(threadId).build());
 		if (context != null) {
 			// 客户端断开，结束 Langfuse span
 			if (context.getSpan() != null && context.getSpan().isRecording()) {
@@ -137,6 +136,21 @@ public class GraphServiceImpl implements GraphService {
 			context.cleanup();
 			log.info("Cleaned up stream context for threadId: {}", threadId);
 		}
+		// Dispose the graph subscription before releasing its checkpoint so a
+		// cancelled run cannot write another checkpoint after the release.
+		releaseCheckpoint(RunnableConfig.builder().threadId(threadId).build());
+	}
+
+	@Override
+	public void stopStreamProcessingByConversationId(String conversationId) {
+		if (!StringUtils.hasText(conversationId)) {
+			return;
+		}
+		streamContextMap.forEach((threadId, context) -> {
+			if (conversationId.equals(context.getConversationId())) {
+				stopStreamProcessing(threadId);
+			}
+		});
 	}
 
 	private void handleNewProcess(GraphRequest graphRequest) {

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphServiceImpl.java
@@ -23,6 +23,7 @@ import com.alibaba.cloud.ai.dataagent.service.graph.Context.MultiTurnContextMana
 import com.alibaba.cloud.ai.dataagent.service.graph.Context.StreamContext;
 import com.alibaba.cloud.ai.dataagent.vo.GraphNodeResponse;
 import com.alibaba.cloud.ai.graph.*;
+import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
 import com.alibaba.cloud.ai.graph.exception.GraphRunnerException;
 import com.alibaba.cloud.ai.graph.exception.GraphStateException;
 import com.alibaba.cloud.ai.graph.streaming.StreamingOutput;
@@ -52,16 +53,19 @@ public class GraphServiceImpl implements GraphService {
 
 	private final ExecutorService executor;
 
+	private final BaseCheckpointSaver checkpointSaver;
+
 	private final ConcurrentHashMap<String, StreamContext> streamContextMap = new ConcurrentHashMap<>();
 
 	private final MultiTurnContextManager multiTurnContextManager;
 
 	private final LangfuseService langfuseReporter;
 
-	public GraphServiceImpl(StateGraph stateGraph, CompileConfig compileConfig, ExecutorService executorService,
-			MultiTurnContextManager multiTurnContextManager, LangfuseService langfuseReporter)
-			throws GraphStateException {
+	public GraphServiceImpl(StateGraph stateGraph, CompileConfig compileConfig, BaseCheckpointSaver checkpointSaver,
+			ExecutorService executorService, MultiTurnContextManager multiTurnContextManager,
+			LangfuseService langfuseReporter) throws GraphStateException {
 		this.compiledGraph = stateGraph.compile(compileConfig);
+		this.checkpointSaver = checkpointSaver;
 		this.executor = executorService;
 		this.multiTurnContextManager = multiTurnContextManager;
 		this.langfuseReporter = langfuseReporter;
@@ -69,21 +73,40 @@ public class GraphServiceImpl implements GraphService {
 
 	@Override
 	public String nl2sql(String naturalQuery, String agentId) throws GraphRunnerException {
-		OverAllState state = compiledGraph
-			.invoke(Map.of(IS_ONLY_NL2SQL, true, INPUT_KEY, naturalQuery, AGENT_ID, agentId),
-					RunnableConfig.builder().build())
-			.orElseThrow();
-		return state.value(SQL_GENERATE_OUTPUT, "");
+		RunnableConfig config = RunnableConfig.builder().threadId(UUID.randomUUID().toString()).build();
+		try {
+			OverAllState state = compiledGraph
+				.invoke(Map.of(IS_ONLY_NL2SQL, true, INPUT_KEY, naturalQuery, AGENT_ID, agentId), config)
+				.orElseThrow();
+			return state.value(SQL_GENERATE_OUTPUT, "");
+		}
+		finally {
+			releaseCheckpoint(config);
+		}
 	}
 
 	@Override
 	public void graphStreamProcess(Sinks.Many<ServerSentEvent<GraphNodeResponse>> sink, GraphRequest graphRequest) {
-		if (!StringUtils.hasText(graphRequest.getThreadId())) {
+		boolean resuming = StringUtils.hasText(graphRequest.getHumanFeedbackContent());
+		if (!resuming) {
+			if (!StringUtils.hasText(graphRequest.getConversationId())) {
+				graphRequest.setConversationId(StringUtils.hasText(graphRequest.getThreadId())
+						? graphRequest.getThreadId() : UUID.randomUUID().toString());
+			}
 			graphRequest.setThreadId(UUID.randomUUID().toString());
+		}
+		else if (!StringUtils.hasText(graphRequest.getThreadId())) {
+			throw new IllegalArgumentException("Graph run ID is required when resuming human feedback");
+		}
+		if (!StringUtils.hasText(graphRequest.getConversationId())) {
+			// Compatibility for existing clients: their old threadId was both the
+			// conversation ID and graph run ID.
+			graphRequest.setConversationId(graphRequest.getThreadId());
 		}
 		String threadId = graphRequest.getThreadId();
 		// 创建或获取 StreamContext
 		StreamContext context = streamContextMap.computeIfAbsent(threadId, k -> new StreamContext());
+		context.setConversationId(graphRequest.getConversationId());
 		context.setSink(sink);
 		if (StringUtils.hasText(graphRequest.getHumanFeedbackContent())) {
 			handleHumanFeedback(graphRequest);
@@ -103,8 +126,9 @@ public class GraphServiceImpl implements GraphService {
 			return;
 		}
 		log.info("Stopping stream processing for threadId: {}", threadId);
-		multiTurnContextManager.discardPending(threadId);
 		StreamContext context = streamContextMap.remove(threadId);
+		multiTurnContextManager.discardPending(context != null ? context.getConversationId() : threadId);
+		releaseCheckpoint(RunnableConfig.builder().threadId(threadId).build());
 		if (context != null) {
 			// 客户端断开，结束 Langfuse span
 			if (context.getSpan() != null && context.getSpan().isRecording()) {
@@ -119,9 +143,11 @@ public class GraphServiceImpl implements GraphService {
 		String query = graphRequest.getQuery();
 		String agentId = graphRequest.getAgentId();
 		String threadId = graphRequest.getThreadId();
+		String conversationId = graphRequest.getConversationId();
 		boolean nl2sqlOnly = graphRequest.isNl2sqlOnly();
 		boolean humanReviewEnabled = graphRequest.isHumanFeedback() & !(nl2sqlOnly);
-		if (!StringUtils.hasText(threadId) || !StringUtils.hasText(agentId) || !StringUtils.hasText(query)) {
+		if (!StringUtils.hasText(threadId) || !StringUtils.hasText(conversationId) || !StringUtils.hasText(agentId)
+				|| !StringUtils.hasText(query)) {
 			throw new IllegalArgumentException("Invalid arguments");
 		}
 		StreamContext context = streamContextMap.get(threadId);
@@ -137,8 +163,8 @@ public class GraphServiceImpl implements GraphService {
 		Span span = langfuseReporter.startLLMSpan("graph-stream", graphRequest);
 		context.setSpan(span);
 
-		String multiTurnContext = multiTurnContextManager.buildContext(threadId);
-		multiTurnContextManager.beginTurn(threadId, query);
+		String multiTurnContext = multiTurnContextManager.buildContext(conversationId);
+		multiTurnContextManager.beginTurn(conversationId, query);
 		Flux<NodeOutput> nodeOutputFlux = compiledGraph.stream(
 				Map.of(IS_ONLY_NL2SQL, nl2sqlOnly, INPUT_KEY, query, AGENT_ID, agentId, HUMAN_REVIEW_ENABLED,
 						humanReviewEnabled, MULTI_TURN_CONTEXT, multiTurnContext, TRACE_THREAD_ID, threadId),
@@ -149,8 +175,10 @@ public class GraphServiceImpl implements GraphService {
 	private void handleHumanFeedback(GraphRequest graphRequest) {
 		String agentId = graphRequest.getAgentId();
 		String threadId = graphRequest.getThreadId();
+		String conversationId = graphRequest.getConversationId();
 		String feedbackContent = graphRequest.getHumanFeedbackContent();
-		if (!StringUtils.hasText(threadId) || !StringUtils.hasText(agentId) || !StringUtils.hasText(feedbackContent)) {
+		if (!StringUtils.hasText(threadId) || !StringUtils.hasText(conversationId) || !StringUtils.hasText(agentId)
+				|| !StringUtils.hasText(feedbackContent)) {
 			throw new IllegalArgumentException("Invalid arguments");
 		}
 		StreamContext context = streamContextMap.get(threadId);
@@ -168,11 +196,11 @@ public class GraphServiceImpl implements GraphService {
 		Map<String, Object> feedbackData = Map.of("feedback", !graphRequest.isRejectedPlan(), "feedback_content",
 				feedbackContent);
 		if (graphRequest.isRejectedPlan()) {
-			multiTurnContextManager.restartLastTurn(threadId);
+			multiTurnContextManager.restartLastTurn(conversationId);
 		}
 		Map<String, Object> stateUpdate = new HashMap<>();
 		stateUpdate.put(HUMAN_FEEDBACK_DATA, feedbackData);
-		stateUpdate.put(MULTI_TURN_CONTEXT, multiTurnContextManager.buildContext(threadId));
+		stateUpdate.put(MULTI_TURN_CONTEXT, multiTurnContextManager.buildContext(conversationId));
 
 		RunnableConfig baseConfig = RunnableConfig.builder().threadId(threadId).build();
 		RunnableConfig updatedConfig;
@@ -207,8 +235,7 @@ public class GraphServiceImpl implements GraphService {
 				return;
 			}
 			Disposable disposable = nodeOutputFlux.subscribe(output -> handleNodeOutput(graphRequest, output),
-					error -> handleStreamError(agentId, threadId, error),
-					() -> handleStreamComplete(agentId, threadId));
+					error -> handleStreamError(graphRequest, error), () -> handleStreamComplete(graphRequest));
 			// 原子性地设置 Disposable，如果已经清理则立即释放
 			synchronized (context) {
 				if (context.isCleaned()) {
@@ -228,9 +255,13 @@ public class GraphServiceImpl implements GraphService {
 	/**
 	 * 处理流式错误 线程安全：使用 remove 操作确保只有一个线程能获取到 context
 	 */
-	private void handleStreamError(String agentId, String threadId, Throwable error) {
+	private void handleStreamError(GraphRequest request, Throwable error) {
+		String agentId = request.getAgentId();
+		String threadId = request.getThreadId();
 		log.error("Error in stream processing for threadId: {}: ", threadId, error);
 		StreamContext context = streamContextMap.remove(threadId);
+		multiTurnContextManager.discardPending(request.getConversationId());
+		releaseCheckpoint(RunnableConfig.builder().threadId(threadId).build());
 		if (context != null && !context.isCleaned()) {
 			// 结束 Langfuse span（失败）
 			if (context.getSpan() != null) {
@@ -254,9 +285,15 @@ public class GraphServiceImpl implements GraphService {
 	/**
 	 * 处理流式完成 线程安全：使用 remove 操作确保只有一个线程能获取到 context
 	 */
-	private void handleStreamComplete(String agentId, String threadId) {
+	private void handleStreamComplete(GraphRequest request) {
+		String agentId = request.getAgentId();
+		String threadId = request.getThreadId();
 		log.info("Stream processing completed successfully for threadId: {}", threadId);
-		multiTurnContextManager.finishTurn(threadId);
+		multiTurnContextManager.finishTurn(request.getConversationId());
+		RunnableConfig config = RunnableConfig.builder().threadId(threadId).build();
+		if (!isAwaitingHumanFeedback(request, config)) {
+			releaseCheckpoint(config);
+		}
 		StreamContext context = streamContextMap.remove(threadId);
 		if (context != null && !context.isCleaned()) {
 			// 结束 Langfuse span（成功）
@@ -322,7 +359,7 @@ public class GraphServiceImpl implements GraphService {
 		if (!isTypeSign) {
 			context.appendOutput(chunk);
 			if (PlannerNode.class.getSimpleName().equals(node)) {
-				multiTurnContextManager.appendPlannerChunk(threadId, chunk);
+				multiTurnContextManager.appendPlannerChunk(request.getConversationId(), chunk);
 			}
 			GraphNodeResponse response = GraphNodeResponse.builder()
 				.agentId(request.getAgentId())
@@ -339,6 +376,30 @@ public class GraphServiceImpl implements GraphService {
 				// 如果发送失败，停止处理
 				stopStreamProcessing(threadId);
 			}
+		}
+	}
+
+	private boolean isAwaitingHumanFeedback(GraphRequest request, RunnableConfig config) {
+		if (!request.isHumanFeedback() || StringUtils.hasText(request.getHumanFeedbackContent())) {
+			return false;
+		}
+		try {
+			return checkpointSaver.get(config)
+				.map(checkpoint -> HUMAN_FEEDBACK_NODE.equals(checkpoint.getNextNodeId()))
+				.orElse(false);
+		}
+		catch (Exception e) {
+			log.warn("Unable to inspect checkpoint for threadId: {}", request.getThreadId(), e);
+			return false;
+		}
+	}
+
+	private void releaseCheckpoint(RunnableConfig config) {
+		try {
+			checkpointSaver.release(config);
+		}
+		catch (Exception e) {
+			log.warn("Unable to release checkpoint for threadId: {}", config.threadId().orElse("unknown"), e);
 		}
 	}
 

--- a/data-agent-management/src/main/resources/application-h2.yml
+++ b/data-agent-management/src/main/resources/application-h2.yml
@@ -30,6 +30,8 @@ spring:
       type: simple
     alibaba:
       data-agent:
+        checkpoint:
+          type: memory
         vector-store:
           table-topk-limit: 10
           table-similarity-threshold: 0.2

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/config/DataAgentConfigurationTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/config/DataAgentConfigurationTest.java
@@ -20,14 +20,11 @@ import com.alibaba.cloud.ai.dataagent.service.file.FileStorageServiceFactory;
 import com.alibaba.cloud.ai.dataagent.service.llm.LlmServiceFactory;
 import com.alibaba.cloud.ai.graph.CompileConfig;
 import com.alibaba.cloud.ai.graph.RunnableConfig;
-import com.alibaba.cloud.ai.graph.StateGraph;
 import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
 import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
-import com.alibaba.cloud.ai.graph.checkpoint.savers.mysql.MysqlSaver;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.FactoryBean;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
 import java.util.Map;
 import java.util.UUID;
@@ -45,20 +42,10 @@ class DataAgentConfigurationTest {
 	}
 
 	@Test
-	void nl2sqlGraphCompileConfig_persistsCheckpointWithFrameworkMysqlSaver() throws Exception {
-		DriverManagerDataSource dataSource = new DriverManagerDataSource();
-		dataSource.setDriverClassName("org.h2.Driver");
-		dataSource.setUrl("jdbc:h2:mem:graph-checkpoint;MODE=MySQL;DB_CLOSE_DELAY=-1");
-		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-		// MysqlSaver intentionally uses MySQL JSON functions. Register harmless H2
-		// aliases so this focused test can exercise the framework's MySQL write path.
-		jdbcTemplate
-			.execute("CREATE ALIAS JSON_EXTRACT FOR '" + DataAgentConfigurationTest.class.getName() + ".jsonExtract'");
-		jdbcTemplate
-			.execute("CREATE ALIAS JSON_UNQUOTE FOR '" + DataAgentConfigurationTest.class.getName() + ".jsonUnquote'");
-
-		CompileConfig compileConfig = new DataAgentConfiguration().nl2sqlGraphCompileConfig(new StateGraph(),
-				dataSource);
+	void nl2sqlGraphCompileConfig_usesProvidedFrameworkSaver() throws Exception {
+		DataAgentConfiguration configuration = new DataAgentConfiguration();
+		BaseCheckpointSaver configuredSaver = configuration.memoryCheckpointSaver();
+		CompileConfig compileConfig = configuration.nl2sqlGraphCompileConfig(configuredSaver);
 		BaseCheckpointSaver checkpointSaver = compileConfig.checkpointSaver().orElseThrow();
 		RunnableConfig runnableConfig = RunnableConfig.builder().threadId("chat-session-1").build();
 		Checkpoint checkpoint = Checkpoint.builder()
@@ -70,18 +57,11 @@ class DataAgentConfigurationTest {
 
 		checkpointSaver.put(runnableConfig, checkpoint);
 
-		assertThat(checkpointSaver).isInstanceOf(MysqlSaver.class);
+		assertThat(checkpointSaver).isInstanceOf(MemorySaver.class);
 		assertThat(compileConfig.interruptsBefore()).contains(HUMAN_FEEDBACK_NODE);
-		assertThat(jdbcTemplate.queryForObject("SELECT COUNT(*) FROM GRAPH_THREAD", Integer.class)).isEqualTo(1);
-		assertThat(jdbcTemplate.queryForObject("SELECT COUNT(*) FROM GRAPH_CHECKPOINT", Integer.class)).isEqualTo(1);
-	}
-
-	public static String jsonExtract(String json, String path) {
-		return json;
-	}
-
-	public static String jsonUnquote(String value) {
-		return value;
+		assertThat(checkpointSaver.get(runnableConfig)).isPresent();
+		checkpointSaver.release(runnableConfig);
+		assertThat(checkpointSaver.get(runnableConfig)).isEmpty();
 	}
 
 }

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/controller/GraphControllerTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/controller/GraphControllerTest.java
@@ -61,8 +61,8 @@ class GraphControllerTest {
 	void streamSearch_validRequest_invokesGraphServiceAndReturnsFlux() {
 		doNothing().when(graphService).graphStreamProcess(any(Sinks.Many.class), any(GraphRequest.class));
 
-		Flux<ServerSentEvent<GraphNodeResponse>> result = graphController.streamSearch("agent-1", "thread-1",
-				"show me sales data", false, null, false, false, serverHttpResponse);
+		Flux<ServerSentEvent<GraphNodeResponse>> result = graphController.streamSearch("agent-1", "conversation-1",
+				"thread-1", "show me sales data", false, null, false, false, serverHttpResponse);
 
 		assertNotNull(result);
 
@@ -71,6 +71,7 @@ class GraphControllerTest {
 
 		GraphRequest captured = requestCaptor.getValue();
 		assertEquals("agent-1", captured.getAgentId());
+		assertEquals("conversation-1", captured.getConversationId());
 		assertEquals("thread-1", captured.getThreadId());
 		assertEquals("show me sales data", captured.getQuery());
 		assertFalse(captured.isHumanFeedback());
@@ -80,8 +81,8 @@ class GraphControllerTest {
 	void streamSearch_humanFeedback_passesHumanFeedbackParams() {
 		doNothing().when(graphService).graphStreamProcess(any(Sinks.Many.class), any(GraphRequest.class));
 
-		Flux<ServerSentEvent<GraphNodeResponse>> result = graphController.streamSearch("agent-1", "thread-2",
-				"approve this plan", true, "looks good", false, false, serverHttpResponse);
+		Flux<ServerSentEvent<GraphNodeResponse>> result = graphController.streamSearch("agent-1", "conversation-2",
+				"thread-2", "approve this plan", true, "looks good", false, false, serverHttpResponse);
 
 		assertNotNull(result);
 
@@ -98,8 +99,8 @@ class GraphControllerTest {
 	void streamSearch_nl2sqlOnly_setsNl2sqlOnlyFlag() {
 		doNothing().when(graphService).graphStreamProcess(any(Sinks.Many.class), any(GraphRequest.class));
 
-		Flux<ServerSentEvent<GraphNodeResponse>> result = graphController.streamSearch("agent-1", null, "SELECT query",
-				false, null, false, true, serverHttpResponse);
+		Flux<ServerSentEvent<GraphNodeResponse>> result = graphController.streamSearch("agent-1", "conversation-3",
+				null, "SELECT query", false, null, false, true, serverHttpResponse);
 
 		assertNotNull(result);
 

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/controller/GraphControllerTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/controller/GraphControllerTest.java
@@ -112,4 +112,20 @@ class GraphControllerTest {
 		assertNull(captured.getThreadId());
 	}
 
+	@Test
+	void stopStream_withRunId_stopsExactGraphRun() {
+		graphController.stopStream("conversation-4", "run-4");
+
+		verify(graphService).stopStreamProcessing("run-4");
+		verify(graphService, never()).stopStreamProcessingByConversationId(anyString());
+	}
+
+	@Test
+	void stopStream_withoutRunId_stopsConversationRun() {
+		graphController.stopStream("conversation-5", null);
+
+		verify(graphService).stopStreamProcessingByConversationId("conversation-5");
+		verify(graphService, never()).stopStreamProcessing(anyString());
+	}
+
 }

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/chat/ChatSessionServiceImplTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/chat/ChatSessionServiceImplTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.chat.memory.ChatMemory;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -38,9 +39,12 @@ class ChatSessionServiceImplTest {
 	@Mock
 	private ChatSessionMapper chatSessionMapper;
 
+	@Mock
+	private ChatMemory chatMemory;
+
 	@BeforeEach
 	void setUp() {
-		service = new ChatSessionServiceImpl(chatSessionMapper);
+		service = new ChatSessionServiceImpl(chatSessionMapper, chatMemory);
 	}
 
 	@Test
@@ -113,11 +117,16 @@ class ChatSessionServiceImplTest {
 
 	@Test
 	void clearSessionsByAgentId_callsSoftDelete() {
+		when(chatSessionMapper.selectByAgentId(1))
+			.thenReturn(List.of(ChatSession.builder().id("session-1").build(),
+					ChatSession.builder().id("session-2").build()));
 		when(chatSessionMapper.softDeleteByAgentId(eq(1), any(LocalDateTime.class))).thenReturn(3);
 
 		service.clearSessionsByAgentId(1);
 
 		verify(chatSessionMapper).softDeleteByAgentId(eq(1), any(LocalDateTime.class));
+		verify(chatMemory).clear("session-1");
+		verify(chatMemory).clear("session-2");
 	}
 
 	@Test
@@ -146,6 +155,7 @@ class ChatSessionServiceImplTest {
 		service.deleteSession("session-1");
 
 		verify(chatSessionMapper).softDeleteById(eq("session-1"), any(LocalDateTime.class));
+		verify(chatMemory).clear("session-1");
 	}
 
 }

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphServiceImplTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphServiceImplTest.java
@@ -40,8 +40,10 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
 
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -218,6 +220,37 @@ class GraphServiceImplTest {
 
 		graphService.stopStreamProcessing(runId);
 		verify(multiTurnContextManager).discardPending("conversation-to-stop");
+	}
+
+	@Test
+	void stopStreamProcessingByConversationId_cancelsActiveGraphSubscription() throws Exception {
+		GraphRequest request = GraphRequest.builder()
+			.agentId("1")
+			.conversationId("conversation-to-cancel")
+			.query("test query")
+			.build();
+		CountDownLatch subscribed = new CountDownLatch(1);
+		CountDownLatch cancelled = new CountDownLatch(1);
+		when(compiledGraph.stream(anyMap(), any(RunnableConfig.class)))
+			.thenReturn(Flux.<com.alibaba.cloud.ai.graph.NodeOutput>never()
+				.doOnSubscribe(ignored -> subscribed.countDown())
+				.doOnCancel(cancelled::countDown));
+
+		graphService.graphStreamProcess(Sinks.many().multicast().onBackpressureBuffer(), request);
+
+		assertTrue(subscribed.await(2, TimeUnit.SECONDS));
+		graphService.stopStreamProcessingByConversationId("conversation-to-cancel");
+
+		assertTrue(cancelled.await(2, TimeUnit.SECONDS));
+		verify(multiTurnContextManager).discardPending("conversation-to-cancel");
+		var configCaptor = org.mockito.ArgumentCaptor.forClass(RunnableConfig.class);
+		try {
+			verify(checkpointSaver).release(configCaptor.capture());
+		}
+		catch (Exception e) {
+			fail(e);
+		}
+		assertEquals(request.getThreadId(), configCaptor.getValue().threadId().orElseThrow());
 	}
 
 	@Test

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphServiceImplTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphServiceImplTest.java
@@ -24,6 +24,7 @@ import com.alibaba.cloud.ai.graph.CompileConfig;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
 import com.alibaba.cloud.ai.graph.exception.GraphRunnerException;
 import io.opentelemetry.api.trace.Span;
 import org.junit.jupiter.api.AfterEach;
@@ -60,6 +61,9 @@ class GraphServiceImplTest {
 	private LangfuseService langfuseReporter;
 
 	@Mock
+	private BaseCheckpointSaver checkpointSaver;
+
+	@Mock
 	private Span mockSpan;
 
 	private GraphServiceImpl graphService;
@@ -74,8 +78,8 @@ class GraphServiceImplTest {
 		when(mockStateGraph.compile(any())).thenReturn(compiledGraph);
 
 		CompileConfig compileConfig = CompileConfig.builder().build();
-		graphService = new GraphServiceImpl(mockStateGraph, compileConfig, executor, multiTurnContextManager,
-				langfuseReporter);
+		graphService = new GraphServiceImpl(mockStateGraph, compileConfig, checkpointSaver, executor,
+				multiTurnContextManager, langfuseReporter);
 
 		when(langfuseReporter.startLLMSpan(anyString(), any())).thenReturn(mockSpan);
 		when(mockSpan.isRecording()).thenReturn(true);
@@ -96,7 +100,16 @@ class GraphServiceImplTest {
 		String result = graphService.nl2sql("show all users", "1");
 
 		assertEquals("SELECT * FROM users", result);
-		verify(compiledGraph).invoke(anyMap(), any(RunnableConfig.class));
+		var configCaptor = org.mockito.ArgumentCaptor.forClass(RunnableConfig.class);
+		verify(compiledGraph).invoke(anyMap(), configCaptor.capture());
+		assertTrue(configCaptor.getValue().threadId().isPresent());
+		assertNotEquals(BaseCheckpointSaver.THREAD_ID_DEFAULT, configCaptor.getValue().threadId().orElseThrow());
+		try {
+			verify(checkpointSaver).release(configCaptor.getValue());
+		}
+		catch (Exception e) {
+			fail(e);
+		}
 	}
 
 	@Test
@@ -112,7 +125,11 @@ class GraphServiceImplTest {
 
 	@Test
 	void graphStreamProcess_newProcess_setsThreadIdIfMissing() {
-		GraphRequest request = GraphRequest.builder().agentId("1").query("test query").build();
+		GraphRequest request = GraphRequest.builder()
+			.agentId("1")
+			.conversationId("conversation-1")
+			.query("test query")
+			.build();
 
 		Sinks.Many<ServerSentEvent<GraphNodeResponse>> sink = Sinks.many().multicast().onBackpressureBuffer();
 
@@ -122,10 +139,11 @@ class GraphServiceImplTest {
 
 		assertNotNull(request.getThreadId());
 		assertFalse(request.getThreadId().isEmpty());
+		assertNotEquals(request.getConversationId(), request.getThreadId());
 	}
 
 	@Test
-	void graphStreamProcess_withThreadId_usesExistingThreadId() {
+	void graphStreamProcess_legacyThreadId_startsFreshRunAndKeepsConversationIdentity() {
 		GraphRequest request = GraphRequest.builder()
 			.agentId("1")
 			.threadId("existing-thread")
@@ -138,7 +156,30 @@ class GraphServiceImplTest {
 
 		graphService.graphStreamProcess(sink, request);
 
-		assertEquals("existing-thread", request.getThreadId());
+		assertEquals("existing-thread", request.getConversationId());
+		assertNotEquals("existing-thread", request.getThreadId());
+	}
+
+	@Test
+	void graphStreamProcess_humanFeedback_reusesInterruptedRunId() throws Exception {
+		GraphRequest request = GraphRequest.builder()
+			.agentId("1")
+			.conversationId("conversation-1")
+			.threadId("interrupted-run")
+			.query("test query")
+			.humanFeedback(true)
+			.humanFeedbackContent("approve")
+			.build();
+		RunnableConfig updatedConfig = RunnableConfig.builder().threadId("interrupted-run").build();
+		when(compiledGraph.updateState(any(RunnableConfig.class), anyMap())).thenReturn(updatedConfig);
+		when(compiledGraph.stream(isNull(), any(RunnableConfig.class))).thenReturn(Flux.empty());
+
+		graphService.graphStreamProcess(Sinks.many().multicast().onBackpressureBuffer(), request);
+
+		var configCaptor = org.mockito.ArgumentCaptor.forClass(RunnableConfig.class);
+		verify(compiledGraph).updateState(configCaptor.capture(), anyMap());
+		assertEquals("interrupted-run", configCaptor.getValue().threadId().orElseThrow());
+		assertEquals("interrupted-run", request.getThreadId());
 	}
 
 	@Test
@@ -157,6 +198,7 @@ class GraphServiceImplTest {
 	void stopStreamProcessing_existingThread_cleansUp() {
 		GraphRequest request = GraphRequest.builder()
 			.agentId("1")
+			.conversationId("conversation-to-stop")
 			.threadId("thread-to-stop")
 			.query("test query")
 			.build();
@@ -165,6 +207,7 @@ class GraphServiceImplTest {
 		when(compiledGraph.stream(anyMap(), any(RunnableConfig.class))).thenReturn(Flux.never());
 
 		graphService.graphStreamProcess(sink, request);
+		String runId = request.getThreadId();
 
 		try {
 			Thread.sleep(100);
@@ -173,8 +216,8 @@ class GraphServiceImplTest {
 			Thread.currentThread().interrupt();
 		}
 
-		graphService.stopStreamProcessing("thread-to-stop");
-		verify(multiTurnContextManager).discardPending("thread-to-stop");
+		graphService.stopStreamProcessing(runId);
+		verify(multiTurnContextManager).discardPending("conversation-to-stop");
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

- separate stable conversation identity from per-execution graph run identity
- use Spring AI Alibaba `BaseCheckpointSaver` implementations instead of a custom saver abstraction
- release completed/cancelled checkpoints while retaining human-feedback interrupts
- clear Spring AI `ChatMemory` when a chat session is cleared or deleted

## Root cause

The previous implementation reused `threadId` for conversation memory, graph execution, checkpoint persistence, feedback resume, MCP calls, and stream tracking. Concurrent turns could therefore overwrite each other's run state and completed checkpoints were not released consistently.

## Compatibility

Legacy requests that only provide `threadId` still map it to the conversation identity for normal runs. Human-feedback requests continue to reuse the interrupted run ID.

## Validation

- `./mvnw test -q`
- Nuxt `pnpm install --frozen-lockfile && pnpm build`
- verified as the first commit in the four-PR integration sequence

