### PR TITLE
fix: make vector store selection profile-driven

### DIFF
--- a/data-agent-management/pom.xml
+++ b/data-agent-management/pom.xml
@@ -333,18 +333,6 @@
             <artifactId>protobuf-java</artifactId>
             <version>3.25.5</version>
         </dependency>
-        <!-- 显式添加Elasticsearch Java客户端依赖以解决DenseVectorSimilarity类缺失问题 -->
-        <dependency>
-            <groupId>co.elastic.clients</groupId>
-            <artifactId>elasticsearch-java</artifactId>
-            <version>${elasticsearch-client.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.elasticsearch.client</groupId>
-            <artifactId>elasticsearch-rest-client</artifactId>
-            <version>${elasticsearch-client.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/config/DataAgentConfiguration.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/config/DataAgentConfiguration.java
@@ -111,17 +111,20 @@ public class DataAgentConfiguration implements DisposableBean {
 	private ExecutorService dbOperationExecutor;
 
 	@Bean
+	@ConditionalOnMissingBean(LlmService.class)
 	public LlmService llmService(DataAgentProperties properties, AiModelRegistry aiModelRegistry) {
 		return new LlmServiceFactory(properties, aiModelRegistry).getObject();
 	}
 
 	@Bean
+	@ConditionalOnMissingBean(FileStorageService.class)
 	public FileStorageService fileStorageService(FileStorageProperties properties,
 			OssStorageProperties ossStorageProperties) {
 		return new FileStorageServiceFactory(properties, ossStorageProperties).getObject();
 	}
 
 	@Bean
+	@ConditionalOnMissingBean(CodePoolExecutorService.class)
 	public CodePoolExecutorService codePoolExecutorService(CodeExecutorProperties properties, LlmService llmService,
 			DockerExecutorFactory dockerExecutorFactory) {
 		return new CodePoolExecutorServiceFactory(properties, llmService, dockerExecutorFactory).getObject();

--- a/data-agent-management/src/main/resources/application-elasticsearch.yml
+++ b/data-agent-management/src/main/resources/application-elasticsearch.yml
@@ -1,0 +1,12 @@
+spring:
+  elasticsearch:
+    uris: ${ELASTICSEARCH_URIS:http://127.0.0.1:9200}
+    username: ${ELASTICSEARCH_USERNAME:}
+    password: ${ELASTICSEARCH_PASSWORD:}
+  ai:
+    vectorstore:
+      type: elasticsearch
+      elasticsearch:
+        index-name: ${ELASTICSEARCH_INDEX_NAME:spring-ai-document-index}
+        dimensions: ${ELASTICSEARCH_DIMENSIONS:1024}
+        initialize-schema: ${ELASTICSEARCH_INITIALIZE_SCHEMA:true}

--- a/data-agent-management/src/main/resources/application-milvus.yml
+++ b/data-agent-management/src/main/resources/application-milvus.yml
@@ -1,0 +1,11 @@
+spring:
+  ai:
+    vectorstore:
+      type: milvus
+      milvus:
+        host: ${MILVUS_HOST:127.0.0.1}
+        port: ${MILVUS_PORT:19530}
+        database-name: ${MILVUS_DATABASE:default}
+        collection-name: ${MILVUS_COLLECTION:vector_store}
+        embedding-dimension: ${MILVUS_DIMENSION:1024}
+        initialize-schema: true

--- a/data-agent-management/src/main/resources/application.yml
+++ b/data-agent-management/src/main/resources/application.yml
@@ -9,11 +9,6 @@ springdoc:
 
 # 存储 DataAgent 业务数据的数据库，并非Agent分析数据的来源
 spring:
-  main:
-    allow-bean-definition-overriding: true
-  autoconfigure:
-    exclude:
-      - org.springframework.ai.vectorstore.elasticsearch.autoconfigure.ElasticsearchVectorStoreAutoConfiguration
   datasource:
     url: ${DATA_AGENT_DATASOURCE_URL:jdbc:mysql://127.0.0.1:3306/saa_data_agent?useUnicode=true&characterEncoding=utf-8&zeroDateTimeBehavior=convertToNull&transformedBitIsBoolean=true&allowMultiQueries=true&allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=Asia/Shanghai}
     username: ${DATA_AGENT_DATASOURCE_USERNAME:root}
@@ -34,14 +29,7 @@ spring:
           jdbc:
             initialize-schema: always
     vectorstore:
-      type: milvus  # 指定向量库类型，不加此配置会回退到 SimpleVectorStore（内存）
-      milvus:
-        host: ${MILVUS_HOST:127.0.0.1}
-        port: ${MILVUS_PORT:19530}
-        database-name: ${MILVUS_DATABASE:default}
-        collection-name: ${MILVUS_COLLECTION:vector_store}
-        embedding-dimension: ${MILVUS_DIMENSION:1024}  # text-embedding-v4 输出 1024 维
-        initialize-schema: true  # 首次启动时自动创建 Collection
+      type: simple
     alibaba:
       data-agent:
         vector-store:

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/config/VectorStoreConfigurationTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/config/VectorStoreConfigurationTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.config;
+
+import com.alibaba.cloud.ai.dataagent.properties.CodeExecutorProperties;
+import com.alibaba.cloud.ai.dataagent.properties.DataAgentProperties;
+import com.alibaba.cloud.ai.dataagent.properties.FileStorageProperties;
+import com.alibaba.cloud.ai.dataagent.properties.OssStorageProperties;
+import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.AiModelRegistry;
+import com.alibaba.cloud.ai.dataagent.service.code.docker.DockerExecutorFactory;
+import com.alibaba.cloud.ai.dataagent.service.llm.LlmService;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.ClassPathResource;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VectorStoreConfigurationTest {
+
+	private final YamlPropertySourceLoader loader = new YamlPropertySourceLoader();
+
+	@Test
+	void vectorStoreProfiles_useExplicitSpringAiStarterTypes() throws Exception {
+		assertThat(property("application.yml", "spring.ai.vectorstore.type")).isEqualTo("simple");
+		assertThat(property("application-milvus.yml", "spring.ai.vectorstore.type")).isEqualTo("milvus");
+		assertThat(property("application-elasticsearch.yml", "spring.ai.vectorstore.type")).isEqualTo("elasticsearch");
+	}
+
+	@Test
+	void replaceableRuntimeServices_areConditionalOnMissingBean() throws Exception {
+		assertConditional("llmService", DataAgentProperties.class, AiModelRegistry.class);
+		assertConditional("fileStorageService", FileStorageProperties.class, OssStorageProperties.class);
+		assertConditional("codePoolExecutorService", CodeExecutorProperties.class, LlmService.class,
+				DockerExecutorFactory.class);
+	}
+
+	private Object property(String resource, String name) throws Exception {
+		List<PropertySource<?>> sources = loader.load(resource, new ClassPathResource(resource));
+		return sources.stream()
+			.map(source -> source.getProperty(name))
+			.filter(value -> value != null)
+			.findFirst()
+			.orElse(null);
+	}
+
+	private void assertConditional(String methodName, Class<?>... parameterTypes) throws Exception {
+		Method method = DataAgentConfiguration.class.getDeclaredMethod(methodName, parameterTypes);
+		ConditionalOnMissingBean condition = method.getAnnotation(ConditionalOnMissingBean.class);
+		assertThat(condition).isNotNull();
+		assertThat(condition.value()).isNotEmpty();
+	}
+
+}


### PR DESCRIPTION
## Summary

- select vector stores through Spring profiles and Spring AI starter configuration
- keep `simple` as the safe default and add `milvus` / `elasticsearch` profile files
- remove global bean overriding and the global Elasticsearch auto-configuration exclusion
- add `@ConditionalOnMissingBean` extension points for application services
- remove duplicate direct Elasticsearch client dependencies already supplied by the starter

## Root cause

Vector-store selection was mixed with global auto-configuration exclusions and bean overriding. That made profiles non-isolated and hid accidental duplicate beans instead of using Spring Boot's conditional configuration model.

## Validation

- `./mvnw test -q`
- configuration tests parse the real YAML profiles and verify conditional bean contracts
- verified as the second commit in the four-PR integration sequence

