### PR TITLE
fix: stream SQL results without blocking on chart generation

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/llm/LlmService.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/llm/LlmService.java
@@ -23,6 +23,12 @@ public interface LlmService {
 
 	Flux<ChatResponse> call(String system, String user);
 
+	/**
+	 * Call the model with system and user messages plus Spring AI structured-output
+	 * validation.
+	 */
+	Flux<ChatResponse> call(String system, String user, Class<?> outputType);
+
 	Flux<ChatResponse> callSystem(String system);
 
 	Flux<ChatResponse> callUser(String user);

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/llm/impls/BlockLlmService.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/llm/impls/BlockLlmService.java
@@ -22,6 +22,7 @@ import org.springframework.ai.chat.client.advisor.StructuredOutputValidationAdvi
 import org.springframework.ai.chat.model.ChatResponse;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 @AllArgsConstructor
 public class BlockLlmService implements LlmService {
@@ -32,6 +33,24 @@ public class BlockLlmService implements LlmService {
 	public Flux<ChatResponse> call(String system, String user) {
 		return Mono
 			.fromCallable(() -> registry.getChatClient().prompt().system(system).user(user).call().chatResponse())
+			.flux();
+	}
+
+	@Override
+	public Flux<ChatResponse> call(String system, String user, Class<?> outputType) {
+		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
+			.outputType(outputType)
+			.maxRepeatAttempts(2)
+			.build();
+		return Mono
+			.fromCallable(() -> registry.getChatClient()
+				.prompt()
+				.system(system)
+				.user(user)
+				.advisors(advisor)
+				.call()
+				.chatResponse())
+			.subscribeOn(Schedulers.boundedElastic())
 			.flux();
 	}
 

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/llm/impls/StreamLlmService.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/llm/impls/StreamLlmService.java
@@ -35,6 +35,24 @@ public class StreamLlmService implements LlmService {
 	}
 
 	@Override
+	public Flux<ChatResponse> call(String system, String user, Class<?> outputType) {
+		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
+			.outputType(outputType)
+			.maxRepeatAttempts(2)
+			.build();
+		return Mono
+			.fromCallable(() -> registry.getChatClient()
+				.prompt()
+				.system(system)
+				.user(user)
+				.advisors(advisor)
+				.call()
+				.chatResponse())
+			.subscribeOn(Schedulers.boundedElastic())
+			.flux();
+	}
+
+	@Override
 	public Flux<ChatResponse> callSystem(String system) {
 		return registry.getChatClient().prompt().system(system).stream().chatResponse();
 	}

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/SqlExecuteNode.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/SqlExecuteNode.java
@@ -40,9 +40,7 @@ import com.alibaba.cloud.ai.dataagent.service.nl2sql.Nl2SqlService;
 import com.alibaba.cloud.ai.dataagent.util.ChatResponseUtil;
 import com.alibaba.cloud.ai.dataagent.util.DatabaseUtil;
 import com.alibaba.cloud.ai.dataagent.util.FluxUtil;
-import com.alibaba.cloud.ai.dataagent.util.JsonParseUtil;
 import com.alibaba.cloud.ai.dataagent.util.JsonUtil;
-import com.alibaba.cloud.ai.dataagent.util.MarkdownParserUtil;
 import com.alibaba.cloud.ai.dataagent.util.PlanProcessUtil;
 import com.alibaba.cloud.ai.dataagent.util.StateUtil;
 import com.alibaba.cloud.ai.graph.GraphResponse;
@@ -56,8 +54,11 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.converter.BeanOutputConverter;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * SQL execution node that executes SQL queries against the database.
@@ -82,9 +83,10 @@ public class SqlExecuteNode implements NodeAction {
 
 	private final DataAgentProperties properties;
 
-	private final JsonParseUtil jsonParseUtil;
-
 	private static final int SAMPLE_DATA_NUMBER = 20;
+
+	private static final BeanOutputConverter<DisplayStyleBO> DISPLAY_STYLE_CONVERTER = new BeanOutputConverter<>(
+			DisplayStyleBO.class);
 
 	@Override
 	public Map<String, Object> apply(OverAllState state) throws Exception {
@@ -135,70 +137,28 @@ public class SqlExecuteNode implements NodeAction {
 		Accessor dbAccessor = databaseUtil.getAgentAccessor(agentId);
 		final Map<String, Object> result = new HashMap<>();
 
-		// 先返回流式数据，在执行数据库查询
-		Flux<ChatResponse> displayFlux = Flux.create(emitter -> {
-			emitter.next(ChatResponseUtil.createResponse("开始执行SQL..."));
-			emitter.next(ChatResponseUtil.createResponse("执行SQL查询："));
-			emitter.next(ChatResponseUtil.createPureResponse(TextType.SQL.getStartSign()));
-			emitter.next(ChatResponseUtil.createResponse(sqlQuery));
-			emitter.next(ChatResponseUtil.createPureResponse(TextType.SQL.getEndSign()));
-			ResultBO resultBO = ResultBO.builder().build();
+		Flux<ChatResponse> startFlux = Flux.just(ChatResponseUtil.createResponse("开始执行SQL..."),
+				ChatResponseUtil.createResponse("执行SQL查询："),
+				ChatResponseUtil.createPureResponse(TextType.SQL.getStartSign()),
+				ChatResponseUtil.createResponse(sqlQuery),
+				ChatResponseUtil.createPureResponse(TextType.SQL.getEndSign()));
 
-			try {
-				// Execute SQL query and get results immediately
-				ResultSetBO resultSetBO = dbAccessor.executeSqlAndReturnObject(dbConfig, dbQueryParameter);
-				// 调用大模型获取图表配置信息并填充到ResultSetBO中
-				DisplayStyleBO displayStyleBO = enrichResultSetWithChartConfig(state, resultSetBO);
-				resultBO.setResultSet(resultSetBO);
-				resultBO.setDisplayStyle(displayStyleBO);
+		Mono<ExecutedSqlResult> sqlExecution = Mono
+			.fromCallable(() -> executeAndStoreResult(state, currentStep, sqlQuery, dbConfig, dbQueryParameter,
+					dbAccessor, result))
+			.subscribeOn(Schedulers.boundedElastic());
 
-				String strResultSetJson = JsonUtil.getObjectMapper().writeValueAsString(resultSetBO);
-				String strResultJson = JsonUtil.getObjectMapper().writeValueAsString(resultBO);
-
-				// 数据执行成功
-				emitter.next(ChatResponseUtil.createResponse("执行SQL完成"));
-				emitter.next(ChatResponseUtil.createResponse("SQL查询结果："));
-				emitter.next(ChatResponseUtil.createPureResponse(TextType.RESULT_SET.getStartSign()));
-				emitter.next(ChatResponseUtil.createPureResponse(strResultJson));
-				emitter.next(ChatResponseUtil.createPureResponse(TextType.RESULT_SET.getEndSign()));
-
-				log.info("SQL execution successful, result count: {}",
-						resultSetBO.getData() != null ? resultSetBO.getData().size() : 0);
-
-				// 先设置成功结果，防止后续 state 处理异常导致不必要的 SQL 重试
-				result.put(SQL_REGENERATE_REASON, SqlRetryDto.empty());
-				result.put(SQL_RESULT_LIST_MEMORY, resultSetBO.getData());
-				result.put(PLAN_CURRENT_STEP, currentStep + 1);
-				result.put(SQL_GENERATE_COUNT, 0);
-
-				// State 处理（非关键路径：即使失败也不应重试，因为 SQL 已成功执行）
-				try {
-					Map<String, String> existingResults = StateUtil.getObjectValue(state, SQL_EXECUTE_NODE_OUTPUT,
-							Map.class, new HashMap<>());
-					Map<String, String> updatedResults = PlanProcessUtil.addStepResult(existingResults, currentStep,
-							strResultSetJson);
-					result.put(SQL_EXECUTE_NODE_OUTPUT, updatedResults);
-
-					// 回写最终执行的sql，报告节点需要使用
-					ExecutionStep.ToolParameters currentStepParams = PlanProcessUtil.getCurrentExecutionStep(state)
-						.getToolParameters();
-					currentStepParams.setSqlQuery(sqlQuery);
-				}
-				catch (Exception stateEx) {
-					log.warn("State processing after successful SQL execution failed (non-critical): {}",
-							stateEx.getMessage());
-				}
-			}
-			catch (Exception e) {
+		Flux<ChatResponse> executionFlux = sqlExecution
+			.flatMapMany(executed -> Flux.concat(baseResultResponses(executed.resultSet()),
+					chartUpdateResponses(state, executed.resultSet())))
+			.onErrorResume(e -> {
 				String errorMessage = e.getMessage();
 				log.error("SQL execution failed - SQL as follows: \n {} \n ", sqlQuery, e);
 				result.put(SQL_REGENERATE_REASON, SqlRetryDto.sqlExecute(errorMessage));
-				emitter.next(ChatResponseUtil.createResponse("SQL执行失败: " + errorMessage));
-			}
-			finally {
-				emitter.complete();
-			}
-		});
+				return Flux.just(ChatResponseUtil.createResponse("SQL执行失败: " + errorMessage));
+			});
+
+		Flux<ChatResponse> displayFlux = Flux.concat(startFlux, executionFlux);
 
 		// Create generator using utility class, returning pre-computed business logic
 		// result
@@ -212,72 +172,130 @@ public class SqlExecuteNode implements NodeAction {
 	 * @param state 整体状态
 	 * @param resultSetBO SQL执行结果
 	 */
-	private DisplayStyleBO enrichResultSetWithChartConfig(OverAllState state, ResultSetBO resultSetBO) {
-		DisplayStyleBO defaultDisplayStyle = tableDisplayStyle();
+	private ExecutedSqlResult executeAndStoreResult(OverAllState state, Integer currentStep, String sqlQuery,
+			DbConfigBO dbConfig, DbQueryParameter dbQueryParameter, Accessor dbAccessor, Map<String, Object> result)
+			throws Exception {
+		ResultSetBO resultSetBO = dbAccessor.executeSqlAndReturnObject(dbConfig, dbQueryParameter);
+		String strResultSetJson = JsonUtil.getObjectMapper().writeValueAsString(resultSetBO);
+
+		result.put(SQL_REGENERATE_REASON, SqlRetryDto.empty());
+		result.put(SQL_RESULT_LIST_MEMORY, resultSetBO.getData());
+		result.put(PLAN_CURRENT_STEP, currentStep + 1);
+		result.put(SQL_GENERATE_COUNT, 0);
+
+		try {
+			Map<String, String> existingResults = StateUtil.getObjectValue(state, SQL_EXECUTE_NODE_OUTPUT, Map.class,
+					new HashMap<>());
+			Map<String, String> updatedResults = PlanProcessUtil.addStepResult(existingResults, currentStep,
+					strResultSetJson);
+			result.put(SQL_EXECUTE_NODE_OUTPUT, updatedResults);
+
+			ExecutionStep.ToolParameters currentStepParams = PlanProcessUtil.getCurrentExecutionStep(state)
+				.getToolParameters();
+			currentStepParams.setSqlQuery(sqlQuery);
+		}
+		catch (Exception stateEx) {
+			log.warn("State processing after successful SQL execution failed (non-critical): {}", stateEx.getMessage());
+		}
+
+		log.info("SQL execution successful, result count: {}",
+				resultSetBO.getData() != null ? resultSetBO.getData().size() : 0);
+		return new ExecutedSqlResult(resultSetBO);
+	}
+
+	private Flux<ChatResponse> baseResultResponses(ResultSetBO resultSetBO) {
+		return resultPayloadResponses(resultSetBO, tableDisplayStyle())
+			.startWith(ChatResponseUtil.createResponse("执行SQL完成"), ChatResponseUtil.createResponse("SQL查询结果："));
+	}
+
+	private Flux<ChatResponse> chartUpdateResponses(OverAllState state, ResultSetBO resultSetBO) {
+		return enrichResultSetWithChartConfig(state, resultSetBO)
+			.flatMapMany(displayStyle -> resultPayloadResponses(resultSetBO, displayStyle))
+			.onErrorResume(e -> {
+				log.warn("Failed to publish optional chart config, keeping table result: {}", e.getMessage());
+				return Flux.empty();
+			});
+	}
+
+	private Flux<ChatResponse> resultPayloadResponses(ResultSetBO resultSetBO, DisplayStyleBO displayStyle) {
+		return Mono
+			.fromCallable(() -> JsonUtil.getObjectMapper()
+				.writeValueAsString(ResultBO.builder().resultSet(resultSetBO).displayStyle(displayStyle).build()))
+			.flatMapMany(
+					strResultJson -> Flux.just(ChatResponseUtil.createPureResponse(TextType.RESULT_SET.getStartSign()),
+							ChatResponseUtil.createPureResponse(strResultJson),
+							ChatResponseUtil.createPureResponse(TextType.RESULT_SET.getEndSign())));
+	}
+
+	private Mono<DisplayStyleBO> enrichResultSetWithChartConfig(OverAllState state, ResultSetBO resultSetBO) {
 		if (state.value(IS_ONLY_NL2SQL, false)) {
 			log.debug("NL2SQL-only mode skips optional chart generation and uses table display");
-			return defaultDisplayStyle;
+			return Mono.empty();
 		}
 		if (!this.properties.isEnableSqlResultChart()) {
 			log.debug("Sql result chart is disabled, set display style as table default");
-			return defaultDisplayStyle;
+			return Mono.empty();
 		}
 
-		try {
-			// 获取用户查询
-			String userQuery = StateUtil.getCanonicalQuery(state);
+		return Mono.defer(() -> {
+			try {
+				// 获取用户查询
+				String userQuery = StateUtil.getCanonicalQuery(state);
 
-			// 将SQL结果转换为JSON字符串，限制数据量以避免提示词过长
-			String sqlResultJson = JsonUtil.getObjectMapper()
-				.writeValueAsString(resultSetBO.getData() != null
-						? resultSetBO.getData().stream().limit(SAMPLE_DATA_NUMBER).toList() : null);
+				// 将SQL结果转换为JSON字符串，限制数据量以避免提示词过长
+				String sqlResultJson = JsonUtil.getObjectMapper()
+					.writeValueAsString(resultSetBO.getData() != null
+							? resultSetBO.getData().stream().limit(SAMPLE_DATA_NUMBER).toList() : null);
 
-			// 构建用户提示词，包含SQL结果数据
-			String userPrompt = String.format("""
-					# 正式任务
+				// 构建用户提示词，包含SQL结果数据
+				String userPrompt = String.format("""
+						# 正式任务
 
-					<最新>用户输入: %s
-					范例数据: %s
+						<最新>用户输入: %s
+						范例数据: %s
 
-					# 输出
-					""", userQuery != null ? userQuery : "数据可视化", sqlResultJson);
+						# 输出
+						""", userQuery != null ? userQuery : "数据可视化", sqlResultJson);
 
-			// 加载data-view-analyze提示词模板（系统提示词）
-			String fullPrompt = PromptHelper.buildDataViewAnalysisPrompt();
-			// 分割系统提示词和用户提示词模板
-			String[] parts = fullPrompt.split("=== 用户输入 ===", 2);
-			// 渲染系统提示词（当前没有变量，直接使用模板内容）
-			String systemPrompt = parts[0].trim();
+				// 加载data-view-analyze提示词模板（系统提示词）
+				String fullPrompt = PromptHelper.buildDataViewAnalysisPrompt();
+				// 分割系统提示词和用户提示词模板
+				String[] parts = fullPrompt.split("=== 用户输入 ===", 2);
+				// 渲染系统提示词（当前没有变量，直接使用模板内容）
+				String systemPrompt = parts[0].trim();
 
-			log.debug("Built chart config generation system prompt as follows \n {} \n", systemPrompt);
-			log.debug("Built chart config generation user prompt as follows \n {} \n", userPrompt);
+				log.debug("Built chart config generation system prompt as follows \n {} \n", systemPrompt);
+				log.debug("Built chart config generation user prompt as follows \n {} \n", userPrompt);
 
-			// 调用LLM生成图表配置（使用系统提示词和用户提示词）
-			String chartConfigJson = llmService.toStringFlux(llmService.call(systemPrompt, userPrompt))
-				.collect(StringBuilder::new, StringBuilder::append)
-				.map(StringBuilder::toString)
-				.block(Duration.ofMillis(properties.getEnrichSqlResultTimeout()));
-			if (chartConfigJson != null && !chartConfigJson.trim().isEmpty()) {
-				String content = MarkdownParserUtil.extractText(chartConfigJson.trim());
-				DisplayStyleBO displayStyle = jsonParseUtil.tryConvertToObject(content, DisplayStyleBO.class);
-				log.debug("Successfully enriched ResultSetBO with chart config: type={}, title={}, x={}, y={}",
-						displayStyle.getType(), displayStyle.getTitle(), displayStyle.getX(), displayStyle.getY());
-				return displayStyle;
+				// 调用LLM生成图表配置（使用系统提示词和用户提示词）
+				return llmService.toStringFlux(llmService.call(systemPrompt, userPrompt, DisplayStyleBO.class))
+					.collect(StringBuilder::new, StringBuilder::append)
+					.map(StringBuilder::toString)
+					.filter(StringUtils::isNotBlank)
+					.map(DISPLAY_STYLE_CONVERTER::convert)
+					.timeout(Duration.ofMillis(properties.getEnrichSqlResultTimeout()))
+					.doOnNext(displayStyle -> {
+						log.debug("Successfully enriched ResultSetBO with chart config: type={}, title={}, x={}, y={}",
+								displayStyle.getType(), displayStyle.getTitle(), displayStyle.getX(),
+								displayStyle.getY());
+					});
 			}
-			else {
-				log.warn("LLM returned empty chart config, using default settings");
+			catch (Exception e) {
+				return Mono.error(e);
 			}
-		}
-		catch (Exception e) {
-			log.warn("Failed to generate optional chart config, using table display: {}", e.getMessage());
-		}
-		return defaultDisplayStyle;
+		}).onErrorResume(e -> {
+			log.warn("Failed to generate optional chart config, keeping table result: {}", e.getMessage());
+			return Mono.empty();
+		});
 	}
 
 	private DisplayStyleBO tableDisplayStyle() {
 		DisplayStyleBO displayStyle = new DisplayStyleBO();
 		displayStyle.setType("table");
 		return displayStyle;
+	}
+
+	private record ExecutedSqlResult(ResultSetBO resultSet) {
 	}
 
 }

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/integration/TextToSqlWorkflowIntegrationTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/integration/TextToSqlWorkflowIntegrationTest.java
@@ -40,7 +40,6 @@ import com.alibaba.cloud.ai.dataagent.properties.DataAgentProperties;
 import com.alibaba.cloud.ai.dataagent.service.llm.LlmService;
 import com.alibaba.cloud.ai.dataagent.service.nl2sql.Nl2SqlService;
 import com.alibaba.cloud.ai.dataagent.util.DatabaseUtil;
-import com.alibaba.cloud.ai.dataagent.util.JsonParseUtil;
 import com.alibaba.cloud.ai.dataagent.workflow.node.SqlExecuteNode;
 import com.alibaba.cloud.ai.dataagent.workflow.node.SqlGenerateNode;
 import com.alibaba.cloud.ai.graph.OverAllState;
@@ -67,9 +66,6 @@ class TextToSqlWorkflowIntegrationTest {
 	private LlmService llmService;
 
 	@Mock
-	private JsonParseUtil jsonParseUtil;
-
-	@Mock
 	private Accessor accessor;
 
 	private SqlGenerateNode sqlGenerateNode;
@@ -79,7 +75,7 @@ class TextToSqlWorkflowIntegrationTest {
 	@BeforeEach
 	void setUp() {
 		sqlGenerateNode = new SqlGenerateNode(nl2SqlService, properties);
-		sqlExecuteNode = new SqlExecuteNode(databaseUtil, nl2SqlService, llmService, properties, jsonParseUtil);
+		sqlExecuteNode = new SqlExecuteNode(databaseUtil, nl2SqlService, llmService, properties);
 
 		when(properties.getMaxSqlRetryCount()).thenReturn(10);
 		when(properties.isEnableSqlResultChart()).thenReturn(false);

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/mock/MockLlmService.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/mock/MockLlmService.java
@@ -65,6 +65,11 @@ public class MockLlmService implements LlmService {
 	}
 
 	@Override
+	public Flux<ChatResponse> call(String system, String user, Class<?> outputType) {
+		return call(system, user);
+	}
+
+	@Override
 	public Flux<ChatResponse> callSystem(String system) {
 		String response = findResponse(system);
 		return Flux.just(ChatResponseUtil.createPureResponse(response));

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/llm/BlockLlmServiceTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/llm/BlockLlmServiceTest.java
@@ -119,4 +119,16 @@ class BlockLlmServiceTest {
 		verify(requestSpec).advisors(any(Advisor[].class));
 	}
 
+	@Test
+	void call_structuredOutput_preservesSystemRoleAndUsesValidationAdvisor() {
+		Flux<ChatResponse> result = blockLlmService.call("system", "user", FeasibilityAssessmentOutputDTO.class);
+
+		StepVerifier.create(result)
+			.expectNextMatches(r -> ChatResponseUtil.getText(r).equals("test output"))
+			.verifyComplete();
+		verify(requestSpec).system("system");
+		verify(requestSpec).user("user");
+		verify(requestSpec).advisors(any(Advisor[].class));
+	}
+
 }

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/llm/StreamLlmServiceTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/llm/StreamLlmServiceTest.java
@@ -117,4 +117,17 @@ class StreamLlmServiceTest {
 		verify(requestSpec, never()).stream();
 	}
 
+	@Test
+	void call_structuredOutput_preservesSystemRoleAndUsesValidationAdvisor() {
+		Flux<ChatResponse> result = streamLlmService.call("system", "user", FeasibilityAssessmentOutputDTO.class);
+
+		StepVerifier.create(result)
+			.expectNextMatches(r -> ChatResponseUtil.getText(r).equals("streamed output"))
+			.verifyComplete();
+		verify(requestSpec).system("system");
+		verify(requestSpec).user("user");
+		verify(requestSpec).advisors(any(Advisor[].class));
+		verify(requestSpec).call();
+	}
+
 }

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/workflow/node/sql/SqlExecuteNodeTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/workflow/node/sql/SqlExecuteNodeTest.java
@@ -50,7 +50,6 @@ import com.alibaba.cloud.ai.dataagent.service.nl2sql.Nl2SqlService;
 import com.alibaba.cloud.ai.dataagent.util.ChatResponseUtil;
 import com.alibaba.cloud.ai.dataagent.util.DatabaseUtil;
 import com.alibaba.cloud.ai.dataagent.util.JsonUtil;
-import com.alibaba.cloud.ai.dataagent.util.JsonParseUtil;
 import com.alibaba.cloud.ai.dataagent.workflow.node.SqlExecuteNode;
 import com.alibaba.cloud.ai.dataagent.properties.DataAgentProperties;
 import com.alibaba.cloud.ai.graph.GraphResponse;
@@ -100,16 +99,13 @@ class SqlExecuteNodeTest {
 	private DataAgentProperties properties;
 
 	@Mock
-	private JsonParseUtil jsonParseUtil;
-
-	@Mock
 	private Accessor accessor;
 
 	private SqlExecuteNode sqlExecuteNode;
 
 	@BeforeEach
 	void setUp() {
-		sqlExecuteNode = new SqlExecuteNode(databaseUtil, nl2SqlService, llmService, properties, jsonParseUtil);
+		sqlExecuteNode = new SqlExecuteNode(databaseUtil, nl2SqlService, llmService, properties);
 	}
 
 	private OverAllState createTestState() {
@@ -162,13 +158,27 @@ class SqlExecuteNodeTest {
 	}
 
 	private ResultBO extractResultSetPayload(String streamedText) throws Exception {
+		return extractResultSetPayloads(streamedText).get(0);
+	}
+
+	private List<ResultBO> extractResultSetPayloads(String streamedText) throws Exception {
 		String startSign = TextType.RESULT_SET.getStartSign();
-		int start = streamedText.indexOf(startSign);
-		assertTrue(start >= 0, "RESULT_SET start marker must be emitted");
-		start += startSign.length();
-		int end = streamedText.indexOf(TextType.RESULT_SET.getEndSign(), start);
-		assertTrue(end > start, "RESULT_SET end marker must be emitted");
-		return JsonUtil.getObjectMapper().readValue(streamedText.substring(start, end), ResultBO.class);
+		String endSign = TextType.RESULT_SET.getEndSign();
+		List<ResultBO> payloads = new ArrayList<>();
+		int offset = 0;
+		while (true) {
+			int start = streamedText.indexOf(startSign, offset);
+			if (start < 0) {
+				break;
+			}
+			start += startSign.length();
+			int end = streamedText.indexOf(endSign, start);
+			assertTrue(end > start, "RESULT_SET end marker must be emitted");
+			payloads.add(JsonUtil.getObjectMapper().readValue(streamedText.substring(start, end), ResultBO.class));
+			offset = end + endSign.length();
+		}
+		assertFalse(payloads.isEmpty(), "RESULT_SET start marker must be emitted");
+		return payloads;
 	}
 
 	private record SqlExecution(String streamedText, Map<String, Object> finalResult) {
@@ -301,17 +311,16 @@ class SqlExecuteNodeTest {
 		when(accessor.executeSqlAndReturnObject(any(), any())).thenReturn(resultSetBO);
 		when(properties.isEnableSqlResultChart()).thenReturn(true);
 		when(properties.getEnrichSqlResultTimeout()).thenReturn(1000L);
-		when(llmService.call(anyString(), anyString()))
+		when(llmService.call(anyString(), anyString(), eq(DisplayStyleBO.class)))
 			.thenReturn(Flux.just(ChatResponseUtil.createPureResponse("{\"type\":\"bar\"}")));
 		when(llmService.toStringFlux(any())).thenCallRealMethod();
-		DisplayStyleBO displayStyle = DisplayStyleBO.builder().type("bar").title("Users").build();
-		when(jsonParseUtil.tryConvertToObject(anyString(), eq(DisplayStyleBO.class))).thenReturn(displayStyle);
 
 		SqlExecution execution = subscribeToExecution(state);
-		ResultBO payload = extractResultSetPayload(execution.streamedText());
+		List<ResultBO> payloads = extractResultSetPayloads(execution.streamedText());
 
-		assertEquals(resultSetBO, payload.getResultSet());
-		assertEquals("bar", payload.getDisplayStyle().getType());
+		assertEquals(resultSetBO, payloads.get(0).getResultSet());
+		assertEquals("table", payloads.get(0).getDisplayStyle().getType());
+		assertEquals("bar", payloads.get(payloads.size() - 1).getDisplayStyle().getType());
 		assertEquals(SqlRetryDto.empty(), execution.finalResult().get(SQL_REGENERATE_REASON));
 	}
 
@@ -327,7 +336,7 @@ class SqlExecuteNodeTest {
 		when(accessor.executeSqlAndReturnObject(any(), any())).thenReturn(resultSetBO);
 		when(properties.isEnableSqlResultChart()).thenReturn(true);
 		when(properties.getEnrichSqlResultTimeout()).thenReturn(1L);
-		when(llmService.call(anyString(), anyString())).thenReturn(Flux.never());
+		when(llmService.call(anyString(), anyString(), eq(DisplayStyleBO.class))).thenReturn(Flux.never());
 		when(llmService.toStringFlux(any())).thenCallRealMethod();
 
 		SqlExecution execution = subscribeToExecution(state);
@@ -337,6 +346,36 @@ class SqlExecuteNodeTest {
 		assertEquals("table", payload.getDisplayStyle().getType());
 		assertEquals(SqlRetryDto.empty(), execution.finalResult().get(SQL_REGENERATE_REASON));
 		assertFalse(execution.streamedText().contains("SQL执行失败"));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void apply_slowChartGeneration_emitsTableResultBeforeChartCompletes() throws Exception {
+		OverAllState state = createTestState();
+		setupBasicState(state);
+		setupBasicMocks();
+
+		ResultSetBO resultSetBO = new ResultSetBO();
+		resultSetBO.setData(new ArrayList<>(List.of(Map.of("name", "Alice"))));
+		when(accessor.executeSqlAndReturnObject(any(), any())).thenReturn(resultSetBO);
+		when(properties.isEnableSqlResultChart()).thenReturn(true);
+		when(properties.getEnrichSqlResultTimeout()).thenReturn(5000L);
+		when(llmService.call(anyString(), anyString(), eq(DisplayStyleBO.class))).thenReturn(Flux.never());
+		when(llmService.toStringFlux(any())).thenCallRealMethod();
+
+		Map<String, Object> result = sqlExecuteNode.apply(state);
+		Flux<GraphResponse<StreamingOutput>> generator = (Flux<GraphResponse<StreamingOutput>>) result
+			.get(SQL_EXECUTE_NODE_OUTPUT);
+		GraphResponse<StreamingOutput> response = generator
+			.filter(item -> !item.isDone() && !item.isError()
+					&& item.getOutput().join().chunk().contains("\"displayStyle\""))
+			.next()
+			.block(Duration.ofSeconds(1));
+
+		assertNotNull(response);
+		ResultBO payload = JsonUtil.getObjectMapper().readValue(response.getOutput().join().chunk(), ResultBO.class);
+		assertEquals(resultSetBO, payload.getResultSet());
+		assertEquals("table", payload.getDisplayStyle().getType());
 	}
 
 	@Test
@@ -359,7 +398,7 @@ class SqlExecuteNodeTest {
 		assertEquals(resultSetBO, payload.getResultSet());
 		assertEquals("table", payload.getDisplayStyle().getType());
 		assertEquals(SqlRetryDto.empty(), execution.finalResult().get(SQL_REGENERATE_REASON));
-		verifyNoInteractions(llmService, jsonParseUtil);
+		verifyNoInteractions(llmService);
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

- emit the SQL table result immediately after JDBC execution
- generate optional chart metadata asynchronously without blocking the Reactor chain
- execute JDBC work on `boundedElastic`
- use Spring AI `StructuredOutputValidationAdvisor` and typed output conversion for chart configuration
- treat chart timeout/failure as presentation degradation rather than SQL execution failure

## Root cause

`SqlExecuteNode` called `Mono.block(Duration)` while already executing inside the reactive workflow. A slow chart-model call delayed the actual query result and could time out after valid SQL data had already been fetched.

## Behavior

`RESULT_SET` is now progressive: the first event contains the table, and a later event may enrich it with chart configuration. NL2SQL-only requests skip chart generation.

## Validation

- `./mvnw test -q`
- contrast tests cover chart success, timeout, never-completing model calls, and NL2SQL-only mode
- verified as the third commit in the four-PR integration sequence

