### PR TITLE
fix: add typed workflow events and retry-safe timeline

### DIFF
--- a/data-agent-frontend-nuxt/app/components/chat/ChatWorkflowTimeline.vue
+++ b/data-agent-frontend-nuxt/app/components/chat/ChatWorkflowTimeline.vue
@@ -43,13 +43,13 @@
 		<v-timeline density="compact" side="end" truncate-line="both">
 			<v-timeline-item
 				v-for="step in timelineSteps"
-				:key="step.nodeName"
+				:key="step.stepId"
 				:dot-color="dotColor(step.status)"
 				:icon="dotIcon(step.status)"
 				size="small"
 			>
 				<!-- Step header: clickable to toggle -->
-				<div class="step-header" @click="toggleStep(step.nodeName)">
+				<div class="step-header" @click="toggleStep(step)">
 					<div class="step-header-left">
 						<span class="step-label">{{ step.label }}</span>
 						<span v-if="step.status === 'active'" class="step-badge active">
@@ -113,6 +113,7 @@ import { TextType, type GraphNodeResponse } from '~/services/graph/index';
 import type { ResultData } from '~/services/resultSet/index';
 import ChatResultSet from './ChatResultSet.vue';
 import { useChatStore } from '~/stores/chat';
+import { groupWorkflowTimeline } from '~/utils/workflowTimeline';
 
 const store = useChatStore();
 
@@ -137,14 +138,14 @@ const allExpanded = computed(() => {
 function toggleAll() {
 	const shouldExpand = !allExpanded.value;
 	for (const step of timelineSteps.value) {
-		expandedSteps.value[step.nodeName] = shouldExpand;
+		expandedSteps.value[step.stepId] = shouldExpand;
 	}
 }
 
-function toggleStep(nodeName: string) {
-	const defaultExpanded = getDefaultExpanded(nodeName);
-	expandedSteps.value[nodeName] = !(
-		expandedSteps.value[nodeName] ?? defaultExpanded
+function toggleStep(step: TimelineStep) {
+	const defaultExpanded = getDefaultExpanded(step.nodeName);
+	expandedSteps.value[step.stepId] = !(
+		expandedSteps.value[step.stepId] ?? defaultExpanded
 	);
 }
 
@@ -244,6 +245,8 @@ const NODE_LABEL_MAP: Record<string, NodeDef> = {
 };
 
 interface TimelineStep extends NodeDef {
+	stepId: string;
+	attempt: number;
 	status: 'pending' | 'active' | 'done';
 	contentBlock: GraphNodeResponse[];
 	resultSetText?: string;
@@ -252,32 +255,21 @@ interface TimelineStep extends NodeDef {
 }
 
 const timelineSteps = computed<TimelineStep[]>(() => {
-	const seen = new Set<string>();
-	const orderedNodeNames: string[] = [];
-	for (const block of props.nodeBlocks) {
-		const name = block[0]?.nodeName;
-		if (name && !seen.has(name)) {
-			seen.add(name);
-			orderedNodeNames.push(name);
-		}
-	}
+	const groups = groupWorkflowTimeline(props.nodeBlocks);
+	if (groups.length === 0) return [];
+	const lastIdx = groups.length - 1;
 
-	if (orderedNodeNames.length === 0) return [];
-	const lastIdx = orderedNodeNames.length - 1;
-
-	return orderedNodeNames.map((nodeName, idx) => {
+	return groups.map((group, idx) => {
+		const { nodeName, stepId, attempt, items: block } = group;
 		const def = NODE_LABEL_MAP[nodeName] || {
 			nodeName,
 			label: nodeName,
 			icon: 'mdi-lightning-bolt',
 		};
-		const block = props.nodeBlocks
-			.filter((candidate) => candidate[0]?.nodeName === nodeName)
-			.flat();
 		const contentBlock = block.filter(
 			(item) => item.textType !== TextType.RESULT_SET,
 		);
-		const resultSetText = block.find(
+		const resultSetText = [...block].reverse().find(
 			(item) => item.textType === TextType.RESULT_SET && item.text,
 		)?.text;
 		const isReport = nodeName === 'ReportGeneratorNode';
@@ -291,10 +283,13 @@ const timelineSteps = computed<TimelineStep[]>(() => {
 
 		return {
 			...def,
+			stepId,
+			attempt,
+			label: attempt > 1 ? `${def.label}（第 ${attempt} 次）` : def.label,
 			status,
 			contentBlock,
 			resultSetText,
-			expanded: expandedSteps.value[nodeName] ?? getDefaultExpanded(nodeName),
+			expanded: expandedSteps.value[stepId] ?? getDefaultExpanded(nodeName),
 			isReport,
 		};
 	});

--- a/data-agent-frontend-nuxt/app/services/graph/index.ts
+++ b/data-agent-frontend-nuxt/app/services/graph/index.ts
@@ -46,6 +46,12 @@ export interface GraphNodeResponse {
   agentId: string;
   /** 线程 ID */
   threadId: string;
+  /** 事件语义；历史消息可能不存在 */
+  eventType?: GraphEventType;
+  /** 单次节点执行 ID；历史消息可能不存在 */
+  stepId?: string;
+  /** 同名节点在本次运行中的执行次数 */
+  attempt?: number;
   /** 当前执行的节点名称 */
   nodeName: string;
   /** 文本内容类型 */
@@ -56,6 +62,11 @@ export interface GraphNodeResponse {
   error: boolean;
   /** 是否已完成 */
   complete: boolean;
+}
+
+export enum GraphEventType {
+  NODE_OUTPUT = "NODE_OUTPUT",
+  FINAL_ANSWER = "FINAL_ANSWER",
 }
 
 /**

--- a/data-agent-frontend-nuxt/app/stores/chat.ts
+++ b/data-agent-frontend-nuxt/app/stores/chat.ts
@@ -22,6 +22,7 @@ import chatService, {
 import graphService, {
 	type GraphRequest,
 	type GraphNodeResponse,
+	GraphEventType,
 	TextType,
 } from '~/services/graph/index';
 import agentDatasourceService from '~/services/agentDatasource/index';
@@ -45,31 +46,6 @@ export interface ChatRequestOptions {
 	nl2sqlOnly: boolean;
 	showSqlResults: boolean;
 	pageSize: number;
-}
-
-function extractIntentReply(blocks: GraphNodeResponse[][]): string | null {
-	const json = blocks
-		.flat()
-		.filter(
-			(item) =>
-				item.nodeName === 'IntentRecognitionNode' &&
-				item.textType === TextType.JSON,
-		)
-		.map((item) => item.text)
-		.join('')
-		.trim();
-	if (!json) return null;
-
-	try {
-		const result = JSON.parse(json) as {
-			classification?: string;
-			response?: string;
-		};
-		if (result.classification !== '《闲聊或无关指令》') return null;
-		return result.response?.trim() || null;
-	} catch {
-		return null;
-	}
 }
 
 export const useChatStore = defineStore('chat', () => {
@@ -365,8 +341,9 @@ export const useChatStore = defineStore('chat', () => {
 		streamingReportContent.value = '';
 		isReportStreaming.value = false;
 
-		let currentNodeName: string | null = null;
+		let currentStepId: string | null = null;
 		let currentBlockIndex = -1;
+		let finalReply: string | null = null;
 
 		let viewSyncRafId: number | null = null;
 		function scheduleViewSync() {
@@ -417,71 +394,40 @@ export const useChatStore = defineStore('chat', () => {
 			request,
 			async (response: GraphNodeResponse) => {
 				if (response.error) return;
+				if (response.eventType === GraphEventType.FINAL_ANSWER) {
+					finalReply = response.text?.trim() || null;
+					return;
+				}
 				if (sessionState.lastRequest)
 					sessionState.lastRequest.threadId = response.threadId;
 
+				const responseStepId =
+					response.stepId || `${response.nodeName}:${response.attempt || 1}`;
+				const isNewStep = currentStepId !== responseStepId;
+				if (isNewStep) {
+					sessionState.nodeBlocks.push([{ ...response }]);
+					currentBlockIndex = sessionState.nodeBlocks.length - 1;
+					currentStepId = responseStepId;
+				}
+				const currentBlock = sessionState.nodeBlocks[currentBlockIndex];
+
 				if (response.nodeName === 'ReportGeneratorNode') {
-					const isNewNode =
-						currentNodeName === null || response.nodeName !== currentNodeName;
-					if (isNewNode) {
-						sessionState.nodeBlocks.push([{ ...response }]);
-						currentBlockIndex = sessionState.nodeBlocks.length - 1;
-						currentNodeName = response.nodeName;
-					}
 					if (response.textType === 'HTML') {
 						sessionState.htmlReportContent += response.text;
 						sessionState.htmlReportSize = sessionState.htmlReportContent.length;
-						const rn = sessionState.nodeBlocks.find(
-							(b) =>
-								b.length > 0 &&
-								b[0].nodeName === 'ReportGeneratorNode' &&
-								b[0].textType === 'HTML',
-						);
+						const rn = currentBlock;
 						if (rn)
 							rn[0].text = `正在收集HTML报告... 已收集 ${sessionState.htmlReportSize} 字节`;
-						else
-							sessionState.nodeBlocks.push([
-								{ ...response, text: `正在收集HTML报告...` },
-							]);
 					} else if (response.textType === 'MARK_DOWN') {
 						sessionState.markdownReportContent += response.text;
 						scheduleReportSync();
-						const rn = sessionState.nodeBlocks.find(
-							(b) =>
-								b.length > 0 &&
-								b[0].nodeName === 'ReportGeneratorNode' &&
-								b[0].textType === 'MARK_DOWN',
-						);
+						const rn = currentBlock;
 						if (rn) rn[0].text = sessionState.markdownReportContent;
-						else
-							sessionState.nodeBlocks.push([
-								{ ...response, text: response.text },
-							]);
 					}
 				} else if (response.textType === TextType.RESULT_SET) {
-					currentNodeName = 'result_set';
-					sessionState.nodeBlocks.push([{ ...response }]);
-					currentBlockIndex = sessionState.nodeBlocks.length - 1;
-				} else {
-					const isNewNode =
-						currentNodeName === null || response.nodeName !== currentNodeName;
-					if (isNewNode) {
-						sessionState.nodeBlocks.push([{ ...response }]);
-						currentBlockIndex = sessionState.nodeBlocks.length - 1;
-						currentNodeName = response.nodeName;
-					} else {
-						const currentBlock =
-							currentBlockIndex >= 0
-								? sessionState.nodeBlocks[currentBlockIndex]
-								: undefined;
-						if (currentBlock) {
-							currentBlock.push({ ...response });
-						} else {
-							sessionState.nodeBlocks.push([{ ...response }]);
-							currentBlockIndex = sessionState.nodeBlocks.length - 1;
-							currentNodeName = response.nodeName;
-						}
-					}
+					if (!isNewStep && currentBlock) currentBlock.push({ ...response });
+				} else if (!isNewStep && currentBlock) {
+					currentBlock.push({ ...response });
 				}
 
 				scheduleViewSync();
@@ -515,7 +461,7 @@ export const useChatStore = defineStore('chat', () => {
 
 				sessionState.isStreaming = false;
 				sessionState.closeStream = null;
-				currentNodeName = null;
+				currentStepId = null;
 				if (currentSession.value?.id === sessionId) {
 					isStreaming.value = false;
 					isReportStreaming.value = false;
@@ -526,8 +472,6 @@ export const useChatStore = defineStore('chat', () => {
 			},
 			async () => {
 				flushPendingSync();
-				const intentReply = extractIntentReply(sessionState.nodeBlocks);
-
 				if (sessionState.nodeBlocks.length > 0) {
 					const timelineMsg: ChatMessage = {
 						sessionId,
@@ -545,11 +489,11 @@ export const useChatStore = defineStore('chat', () => {
 						currentMessages.value.push(savedTimeline);
 				}
 
-				if (intentReply) {
+				if (finalReply) {
 					const replyMessage: ChatMessage = {
 						sessionId,
 						role: 'assistant',
-						content: intentReply,
+						content: finalReply,
 						messageType: 'text',
 					};
 					await chatService
@@ -557,7 +501,7 @@ export const useChatStore = defineStore('chat', () => {
 						.catch((e) => console.error(e));
 				}
 
-				if (requestOptions.value.humanFeedback && _rejectedPlan) {
+				if (requestOptions.value.humanFeedback && _rejectedPlan && !finalReply) {
 					showHumanFeedback.value = true;
 				} else {
 					sessionState.isStreaming = false;
@@ -569,7 +513,7 @@ export const useChatStore = defineStore('chat', () => {
 					streamingReportContent.value = '';
 				}
 
-				currentNodeName = null;
+				currentStepId = null;
 				closeStream();
 				if (currentSession.value?.id === sessionId) {
 					currentMessages.value =

--- a/data-agent-frontend-nuxt/app/utils/workflowTimeline.test.ts
+++ b/data-agent-frontend-nuxt/app/utils/workflowTimeline.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	TextType,
+	type GraphNodeResponse,
+} from '../services/graph/index';
+import { groupWorkflowTimeline } from './workflowTimeline';
+
+function event(
+	nodeName: string,
+	text: string,
+	overrides: Partial<GraphNodeResponse> = {},
+): GraphNodeResponse {
+	return {
+		agentId: '1',
+		threadId: 'run-1',
+		nodeName,
+		textType: TextType.TEXT,
+		text,
+		error: false,
+		complete: false,
+		...overrides,
+	};
+}
+
+describe('groupWorkflowTimeline', () => {
+	it('preserves repeated node attempts as separate steps', () => {
+		const groups = groupWorkflowTimeline([
+			[event('SqlExecuteNode', 'first', { stepId: 'sql-1', attempt: 1 })],
+			[event('SqlGenerateNode', 'retry', { stepId: 'generate-2', attempt: 2 })],
+			[event('SqlExecuteNode', 'second', { stepId: 'sql-3', attempt: 2 })],
+		]);
+
+		expect(groups.map((group) => group.stepId)).toEqual([
+			'sql-1',
+			'generate-2',
+			'sql-3',
+		]);
+		expect(groups[2]?.attempt).toBe(2);
+	});
+
+	it('uses the latest result payload from one step', () => {
+		const table = event('SqlExecuteNode', '{"displayStyle":{"type":"table"}}', {
+			stepId: 'sql-1',
+			attempt: 1,
+			textType: TextType.RESULT_SET,
+		});
+		const chart = event('SqlExecuteNode', '{"displayStyle":{"type":"bar"}}', {
+			stepId: 'sql-1',
+			attempt: 1,
+			textType: TextType.RESULT_SET,
+		});
+		const groups = groupWorkflowTimeline([[table], [chart]]);
+		const latest = [...(groups[0]?.items || [])]
+			.reverse()
+			.find((item) => item.textType === TextType.RESULT_SET);
+
+		expect(groups).toHaveLength(1);
+		expect(latest?.text).toContain('"bar"');
+	});
+
+	it('attaches a legacy result-only block to its preceding node', () => {
+		const groups = groupWorkflowTimeline([
+			[event('SqlExecuteNode', '执行SQL')],
+			[
+				event('SqlExecuteNode', '{"rows":1}', {
+					textType: TextType.RESULT_SET,
+				}),
+			],
+		]);
+
+		expect(groups).toHaveLength(1);
+		expect(groups[0]?.items).toHaveLength(2);
+	});
+});

--- a/data-agent-frontend-nuxt/app/utils/workflowTimeline.ts
+++ b/data-agent-frontend-nuxt/app/utils/workflowTimeline.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+	TextType,
+	type GraphNodeResponse,
+} from '../services/graph/index';
+
+export interface WorkflowStepGroup {
+	stepId: string;
+	nodeName: string;
+	attempt: number;
+	items: GraphNodeResponse[];
+}
+
+/**
+ * Groups workflow events by backend step identity. The fallback branch keeps persisted
+ * timelines from older versions readable by attaching a result-only block to the
+ * immediately preceding node execution.
+ */
+export function groupWorkflowTimeline(
+	blocks: GraphNodeResponse[][],
+): WorkflowStepGroup[] {
+	const groups: WorkflowStepGroup[] = [];
+	const groupsByStepId = new Map<string, WorkflowStepGroup>();
+	const legacyAttempts = new Map<string, number>();
+
+	for (const [index, block] of blocks.entries()) {
+		const first = block[0];
+		if (!first?.nodeName) continue;
+
+		if (first.stepId) {
+			let group = groupsByStepId.get(first.stepId);
+			if (!group) {
+				group = {
+					stepId: first.stepId,
+					nodeName: first.nodeName,
+					attempt: first.attempt || 1,
+					items: [],
+				};
+				groupsByStepId.set(first.stepId, group);
+				groups.push(group);
+			}
+			group.items.push(...block);
+			continue;
+		}
+
+		const previous = groups.at(-1);
+		const resultOnly = block.every(
+			(item) => item.textType === TextType.RESULT_SET,
+		);
+		if (resultOnly && previous?.nodeName === first.nodeName) {
+			previous.items.push(...block);
+			continue;
+		}
+
+		const attempt = (legacyAttempts.get(first.nodeName) || 0) + 1;
+		legacyAttempts.set(first.nodeName, attempt);
+		groups.push({
+			stepId: `legacy-${first.nodeName}-${index}`,
+			nodeName: first.nodeName,
+			attempt,
+			items: [...block],
+		});
+	}
+
+	return groups;
+}

--- a/data-agent-frontend-nuxt/package.json
+++ b/data-agent-frontend-nuxt/package.json
@@ -7,6 +7,7 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
+    "test:unit": "nuxt prepare && vitest run",
     "postinstall": "nuxt prepare",
     "gen:ctx": "node scripts/gen-ai-context.mjs"
   },
@@ -38,6 +39,7 @@
     "globby": "^16.1.0",
     "ts-morph": "^27.0.2",
     "typescript": "^5.9.3",
+    "vitest": "^3.2.7",
     "vue-docgen-api": "^4.79.2"
   }
 }

--- a/data-agent-frontend-nuxt/pnpm-lock.yaml
+++ b/data-agent-frontend-nuxt/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.7
+        version: 3.2.7(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.97.3)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vue-docgen-api:
         specifier: ^4.79.2
         version: 4.79.2(vue@3.5.27(typescript@5.9.3))
@@ -883,48 +886,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-arm64-musl@0.110.0':
     resolution: {integrity: sha512-53GjCVY8kvymk9P6qNDh6zyblcehF5QHstq9QgCjv13ONGRnSHjeds0PxIwiihD7h295bxsWs84DN39syLPH4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-linux-ppc64-gnu@0.110.0':
     resolution: {integrity: sha512-li8XcN81dxbJDMBESnTgGhoiAQ+CNIdM0QGscZ4duVPjCry1RpX+5FJySFbGqG3pk4s9ZzlL/vtQtbRzZIZOzg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-riscv64-gnu@0.110.0':
     resolution: {integrity: sha512-SweKfsnLKShu6UFV8mwuj1d1wmlNoL/FlAxPUzwjEBgwiT2HQkY24KnjBH+TIA+//1O83kzmWKvvs4OuEhdIEQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-riscv64-musl@0.110.0':
     resolution: {integrity: sha512-oH8G4aFMP8XyTsEpdANC5PQyHgSeGlopHZuW1rpyYcaErg5YaK0vXjQ4EM5HVvPm+feBV24JjxgakTnZoF3aOQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-linux-s390x-gnu@0.110.0':
     resolution: {integrity: sha512-W9na+Vza7XVUlpf8wMt4QBfH35KeTENEmnpPUq3NSlbQHz8lSlSvhAafvo43NcKvHAXV3ckD/mUf2VkqSdbklg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-gnu@0.110.0':
     resolution: {integrity: sha512-XJdA4mmmXOjJxSRgNJXsDP7Xe8h3gQhmb56hUcCrvq5d+h5UcEi2pR8rxsdIrS8QmkLuBA3eHkGK8E27D7DTgQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-musl@0.110.0':
     resolution: {integrity: sha512-QqzvALuOTtSckI8x467R4GNArzYDb/yEh6aNzLoeaY1O7vfT7SPDwlOEcchaTznutpeS9Dy8gUS/AfqtUHaufw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-openharmony-arm64@0.110.0':
     resolution: {integrity: sha512-gAMssLs2Q3+uhLZxanh1DF+27Kaug3cf4PXb9AB7XK81DR+LVcKySXaoGYoOs20Co0fFSphd6rRzKge2qDK3dA==}
@@ -1002,48 +1013,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.110.0':
     resolution: {integrity: sha512-5xwm1hPrGGvjCVtTWNGJ39MmQGnyipoIDShneGBgSrnDh0XX+COAO7AZKajgNipqgNq5rGEItpzFkMtSDyx0bQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.110.0':
     resolution: {integrity: sha512-I8Xop7z+enuvW1xe0AcRQ9XqFNkUYgeXusyGjCyW6TstRb62P90h+nL1AoGaUMy0E0518DJam5vRYVRgXaAzYg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.110.0':
     resolution: {integrity: sha512-XPM0jpght/AuHnweNaIo0twpId6rWFs8NrTkMijxcsRQMzNBeSQQgYm9ErrutmKQS6gb8XNAEIkYXHgPmhdDPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.110.0':
     resolution: {integrity: sha512-ylJIuJyMzAqR191QeCwZLEkyo4Sx817TNILjNhT0W1EDQusGicOYKSsGXM/2DHCNYGcidV+MQ8pUVzNeVmuM6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.110.0':
     resolution: {integrity: sha512-DL6oR0PfYor9tBX9xlAxMUVwfm6+sKTL4H+KiQ6JKP3xkJTwBIdDCgeN2AjMht1D3N40uUwVq3v8/2fqnZRgLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.110.0':
     resolution: {integrity: sha512-+e6ws5JLpFehdK+wh6q8icx1iM3Ao+9dtItVWFcRiXxSvGcIlS9viWcMvXKrmcsyVDUf81dnvuMSBigNslxhIQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.110.0':
     resolution: {integrity: sha512-6DiYhVdXKOzB01+j/tyrB6/d2o6b4XYFQvcbBRNbVHIimS6nl992y3V3mGG3NaA+uCZAzhT3M3btTdKAxE4A3A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.110.0':
     resolution: {integrity: sha512-U9KEK7tXdHrXl2eZpoHYGWj31ZSvdGiaXwjkJzeRN0elt89PXi+VcryRh6BAFbEz1EQpTteyMDwDXMgJVWM85A==}
@@ -1124,48 +1143,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-arm64-musl@0.110.0':
     resolution: {integrity: sha512-e5JN94/oy+wevk76q+LMr+2klTTcO60uXa+Wkq558Ms7mdF2TvkKFI++d/JeiuIwJLTi/BxQ4qdT5FWcsHM/ug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-linux-ppc64-gnu@0.110.0':
     resolution: {integrity: sha512-Y3/Tnnz1GvDpmv8FXBIKtdZPsdZklOEPdrL6NHrN5i2u54BOkybFaDSptgWF53wOrJlTrcmAVSE6fRKK9XCM2Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-riscv64-gnu@0.110.0':
     resolution: {integrity: sha512-Y0E35iA9/v9jlkNcP6tMJ+ZFOS0rLsWDqG6rU9z+X2R3fBFJBO9UARIK6ngx8upxk81y1TFR2CmBFhupfYdH6Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-riscv64-musl@0.110.0':
     resolution: {integrity: sha512-JOUSYFfHjBUs7xp2FHmZHb8eTYD/oEu0NklS6JgUauqnoXZHiTLPLVW2o2uVCqldnabYHcomuwI2iqVFYJNhTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-linux-s390x-gnu@0.110.0':
     resolution: {integrity: sha512-7blgoXF9D3Ngzb7eun23pNrHJpoV/TtE6LObwlZ3Nmb4oZ6Z+yMvBVaoW68NarbmvNGfZ95zrOjgm6cVETLYBA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-gnu@0.110.0':
     resolution: {integrity: sha512-YQ2joGWCVDZVEU2cD/r/w49hVjDm/Qu1BvC/7zs8LvprzdLS/HyMXGF2oA0puw0b+AqgYaz3bhwKB2xexHyITQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-musl@0.110.0':
     resolution: {integrity: sha512-fkjr5qE632ULmNgvFXWDR/8668WxERz3tU7TQFp6JebPBneColitjSkdx6VKNVXEoMmQnOvBIGeP5tUNT384oA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-openharmony-arm64@0.110.0':
     resolution: {integrity: sha512-HWH9Zj+lMrdSTqFRCZsvDWMz7OnMjbdGsm3xURXWfRZpuaz0bVvyuZNDQXc4FyyhRDsemICaJbU1bgeIpUJDGw==}
@@ -1225,36 +1252,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-wasm@2.5.6':
     resolution: {integrity: sha512-byAiBZ1t3tXQvc8dMD/eoyE7lTXYorhn+6uVW5AC+JGI1KtJC/LvDche5cfUE+qiefH+Ybq0bUCJU0aB1cSHUA==}
@@ -1414,66 +1447,79 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -1531,6 +1577,12 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/dompurify@3.2.0':
     resolution: {integrity: sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==}
@@ -1670,41 +1722,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1744,6 +1804,35 @@ packages:
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
       vue: ^3.2.25
+
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
+
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
+
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
 
   '@volar/language-core@2.4.27':
     resolution: {integrity: sha512-DjmjBWZ4tJKxfNC1F6HyYERNHPYS7L7OPFyCrestykNdUZMFYzI9WTyvwPcaNaHlrEUwESHYsfEw3isInncZxQ==}
@@ -1920,6 +2009,10 @@ packages:
   assert-never@1.4.0:
     resolution: {integrity: sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-kit@2.2.0:
     resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
     engines: {node: '>=20.19.0'}
@@ -1979,6 +2072,7 @@ packages:
 
   baseline-browser-mapping@2.10.43:
     resolution: {integrity: sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==}
+    engines: {node: '>=6.0.0'}
     hasBin: true
 
   bindings@1.5.0:
@@ -2059,6 +2153,10 @@ packages:
   caniuse-lite@1.0.30001806:
     resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -2068,6 +2166,10 @@ packages:
 
   character-parser@2.2.0:
     resolution: {integrity: sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -2297,6 +2399,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -2434,6 +2540,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
@@ -2642,6 +2751,10 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
@@ -2788,6 +2901,7 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@13.0.0:
@@ -3166,24 +3280,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3245,6 +3363,9 @@ packages:
 
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -3618,6 +3739,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
@@ -4098,48 +4223,56 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: glibc
 
   sass-embedded-linux-arm@1.98.0:
     resolution: {integrity: sha512-03baQZCxVyEp8v1NWBRlzGYrmVT/LK7ZrHlF1piscGiGxwfdxoLXVuxsylx3qn/dD/4i/rh7Bzk7reK1br9jvQ==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: glibc
 
   sass-embedded-linux-musl-arm64@1.98.0:
     resolution: {integrity: sha512-LeqNxQA8y4opjhe68CcFvMzCSrBuJqYVFbwElEj9bagHXQHTp9xVPJRn6VcrC+0VLEDq13HVXMv7RslIuU0zmA==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-musl-arm@1.98.0:
     resolution: {integrity: sha512-OBkjTDPYR4hSaueOGIM6FDpl9nt/VZwbSRpbNu9/eEJcxE8G/vynRugW8KRZmCFjPy8j/jkGBvvS+k9iOqKV3g==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-musl-riscv64@1.98.0:
     resolution: {integrity: sha512-7w6hSuOHKt8FZsmjRb3iGSxEzM87fO9+M8nt5JIQYMhHTj5C+JY/vcske0v715HCVj5e1xyTnbGXf8FcASeAIw==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-musl-x64@1.98.0:
     resolution: {integrity: sha512-QikNyDEJOVqPmxyCFkci8ZdCwEssdItfjQFJB+D+Uy5HFqcS5Lv3d3GxWNX/h1dSb23RPyQdQc267ok5SbEyJw==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-riscv64@1.98.0:
     resolution: {integrity: sha512-E7fNytc/v4xFBQKzgzBddV/jretA4ULAPO6XmtBiQu4zZBdBozuSxsQLe2+XXeb0X4S2GIl72V7IPABdqke/vA==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: glibc
 
   sass-embedded-linux-x64@1.98.0:
     resolution: {integrity: sha512-VsvP0t/uw00mMNPv3vwyYKUrFbqzxQHnRMO+bHdAMjvLw4NFf6mscpym9Bzf+NXwi1ZNKnB6DtXjmcpcvqFqYg==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: glibc
 
   sass-embedded-unknown-all@1.98.0:
     resolution: {integrity: sha512-C4MMzcAo3oEDQnW7L8SBgB9F2Fq5qHPnaYTZRMOH3Mp/7kM4OooBInXpCiiFjLnjY95hzP4KyctVx0uYR6MYlQ==}
@@ -4229,6 +4362,9 @@ packages:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -4286,6 +4422,9 @@ packages:
   stable-hash-x@0.2.0:
     resolution: {integrity: sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==}
     engines: {node: '>=12.0.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
@@ -4404,6 +4543,7 @@ packages:
   tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   terser@5.46.0:
     resolution: {integrity: sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==}
@@ -4416,6 +4556,12 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
@@ -4423,6 +4569,18 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -4534,6 +4692,7 @@ packages:
 
   unplugin-vue-router@0.19.2:
     resolution: {integrity: sha512-u5dgLBarxE5cyDK/hzJGfpCTLIAyiTXGlo85COuD4Nssj6G7NxS+i9mhCWz/1p/ud1eMwdcUbTXehQe41jYZUA==}
+    deprecated: 'Merged into vuejs/router. Migrate: https://router.vuejs.org/guide/migration/v4-to-v5.html'
     peerDependencies:
       '@vue/compiler-sfc': ^3.5.17
       vue-router: ^4.6.0
@@ -4653,6 +4812,11 @@ packages:
     peerDependencies:
       vite: ^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite-node@5.3.0:
     resolution: {integrity: sha512-8f20COPYJujc3OKPX6OuyBy3ZIv2det4eRRU4GY1y2MjbeGSUmPjedxg1b72KnTagCofwvZ65ThzjxDW2AtQFQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4759,6 +4923,34 @@ packages:
       yaml:
         optional: true
 
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
@@ -4836,6 +5028,11 @@ packages:
   which@5.0.0:
     resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   with@7.0.2:
@@ -6317,6 +6514,13 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/dompurify@3.2.0':
     dependencies:
       dompurify: 3.3.3
@@ -6544,6 +6748,48 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.2
       vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.97.3)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vue: 3.5.27(typescript@5.9.3)
+
+  '@vitest/expect@3.2.7':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.7(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.97.3)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.97.3)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.7':
+    dependencies:
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.7':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@volar/language-core@2.4.27':
     dependencies:
@@ -6783,6 +7029,8 @@ snapshots:
 
   assert-never@1.4.0: {}
 
+  assertion-error@2.0.1: {}
+
   ast-kit@2.2.0:
     dependencies:
       '@babel/parser': 7.29.0
@@ -6928,6 +7176,14 @@ snapshots:
 
   caniuse-lite@1.0.30001806: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -6938,6 +7194,8 @@ snapshots:
   character-parser@2.2.0:
     dependencies:
       is-regex: 1.2.1
+
+  check-error@2.1.3: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -7151,6 +7409,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
@@ -7255,6 +7515,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.0.0: {}
 
@@ -7566,6 +7828,8 @@ snapshots:
       onetime: 6.0.0
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
+
+  expect-type@1.4.0: {}
 
   exsolve@1.0.8: {}
 
@@ -8144,6 +8408,8 @@ snapshots:
   lodash.uniq@4.5.0: {}
 
   lodash@4.17.23: {}
+
+  loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
 
@@ -8742,6 +9008,8 @@ snapshots:
   pathe@1.1.2: {}
 
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   perfect-debounce@1.0.0: {}
 
@@ -9356,6 +9624,8 @@ snapshots:
 
   shell-quote@1.8.3: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-git@3.30.0:
@@ -9403,6 +9673,8 @@ snapshots:
   srvx@0.10.1: {}
 
   stable-hash-x@0.2.0: {}
+
+  stackback@0.0.2: {}
 
   standard-as-callback@2.1.0: {}
 
@@ -9552,12 +9824,22 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyexec@1.0.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -9797,6 +10079,27 @@ snapshots:
     dependencies:
       vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.97.3)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  vite-node@3.2.4(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.97.3)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.97.3)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@5.3.0(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.97.3)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
@@ -9892,6 +10195,47 @@ snapshots:
       terser: 5.46.0
       tsx: 4.21.0
       yaml: 2.8.2
+
+  vitest@3.2.7(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.97.3)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.97.3)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.97.3)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.98.0)(sass@1.97.3)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.5.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   void-elements@3.1.0: {}
 
@@ -9995,6 +10339,11 @@ snapshots:
   which@5.0.0:
     dependencies:
       isexe: 3.1.1
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   with@7.0.2:
     dependencies:

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/config/DataAgentConfiguration.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/config/DataAgentConfiguration.java
@@ -211,6 +211,7 @@ public class DataAgentConfiguration implements DisposableBean {
 			keyStrategyHashMap.put(TRACE_THREAD_ID, KeyStrategy.REPLACE);
 			// Final result
 			keyStrategyHashMap.put(RESULT, KeyStrategy.REPLACE);
+			keyStrategyHashMap.put(FINAL_ANSWER, KeyStrategy.REPLACE);
 			return keyStrategyHashMap;
 		};
 

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/constant/Constant.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/constant/Constant.java
@@ -36,6 +36,8 @@ public final class Constant {
 
 	public static final String RESULT = "result";
 
+	public static final String FINAL_ANSWER = "final_answer";
+
 	public static final String NL2SQL_GRAPH_NAME = "nl2sqlGraph";
 
 	public static final String INTENT_RECOGNITION_NODE_OUTPUT = "INTENT_RECOGNITION_NODE_OUTPUT";

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/enums/GraphEventType.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/enums/GraphEventType.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.enums;
+
+public enum GraphEventType {
+
+	NODE_OUTPUT,
+
+	FINAL_ANSWER
+
+}

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/Context/StreamContext.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/Context/StreamContext.java
@@ -24,6 +24,9 @@ import reactor.core.Disposable;
 import reactor.core.publisher.Sinks;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * 流式处理上下文，封装每个 threadId 的所有相关状态
@@ -41,6 +44,27 @@ public class StreamContext {
 	private Span span;
 
 	private TextType textType;
+
+	private String finalAnswer;
+
+	private final Map<String, Integer> nodeAttempts = new HashMap<>();
+
+	private String activeNode;
+
+	private String activeStepId;
+
+	private int activeAttempt;
+
+	private int stepSequence;
+
+	public synchronized StepIdentity resolveStep(String nodeName) {
+		if (!Objects.equals(activeNode, nodeName)) {
+			activeNode = nodeName;
+			activeAttempt = nodeAttempts.merge(nodeName, 1, Integer::sum);
+			activeStepId = nodeName + "-" + (++stepSequence);
+		}
+		return new StepIdentity(activeStepId, activeAttempt);
+	}
 
 	/**
 	 * 收集流式输出内容，用于 Langfuse 上报
@@ -97,6 +121,9 @@ public class StreamContext {
 	 */
 	public boolean isCleaned() {
 		return cleaned.get();
+	}
+
+	public record StepIdentity(String stepId, int attempt) {
 	}
 
 }

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphServiceImpl.java
@@ -264,6 +264,12 @@ public class GraphServiceImpl implements GraphService {
 				langfuseReporter.endSpanSuccess(context.getSpan(), threadId, context.getCollectedOutput());
 			}
 			if (context.getSink() != null && context.getSink().currentSubscriberCount() > 0) {
+				if (StringUtils.hasText(context.getFinalAnswer())) {
+					context.getSink()
+						.tryEmitNext(ServerSentEvent
+							.builder(GraphNodeResponse.finalAnswer(agentId, threadId, context.getFinalAnswer()))
+							.build());
+				}
 				context.getSink()
 					.tryEmitNext(ServerSentEvent.builder(GraphNodeResponse.complete(agentId, threadId))
 						.event(STREAM_EVENT_COMPLETE)
@@ -279,6 +285,14 @@ public class GraphServiceImpl implements GraphService {
 	 */
 	private void handleNodeOutput(GraphRequest request, NodeOutput output) {
 		log.debug("Received output: {}", output.getClass().getSimpleName());
+		StreamContext context = streamContextMap.get(request.getThreadId());
+		if (context != null) {
+			output.state()
+				.value(FINAL_ANSWER)
+				.map(Object::toString)
+				.filter(StringUtils::hasText)
+				.ifPresent(context::setFinalAnswer);
+		}
 		if (output instanceof StreamingOutput streamingOutput) {
 			handleStreamNodeOutput(request, streamingOutput);
 		}
@@ -321,12 +335,15 @@ public class GraphServiceImpl implements GraphService {
 		// 文本标记符号不返回给前端
 		if (!isTypeSign) {
 			context.appendOutput(chunk);
+			StreamContext.StepIdentity stepIdentity = context.resolveStep(node);
 			if (PlannerNode.class.getSimpleName().equals(node)) {
 				multiTurnContextManager.appendPlannerChunk(threadId, chunk);
 			}
 			GraphNodeResponse response = GraphNodeResponse.builder()
 				.agentId(request.getAgentId())
 				.threadId(threadId)
+				.stepId(stepIdentity.stepId())
+				.attempt(stepIdentity.attempt())
 				.nodeName(node)
 				.text(chunk)
 				.textType(textType)

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/vo/GraphNodeResponse.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/vo/GraphNodeResponse.java
@@ -16,6 +16,7 @@
 package com.alibaba.cloud.ai.dataagent.vo;
 
 import com.alibaba.cloud.ai.dataagent.enums.TextType;
+import com.alibaba.cloud.ai.dataagent.enums.GraphEventType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -30,6 +31,13 @@ public class GraphNodeResponse {
 	private String agentId;
 
 	private String threadId;
+
+	@Builder.Default
+	private GraphEventType eventType = GraphEventType.NODE_OUTPUT;
+
+	private String stepId;
+
+	private Integer attempt;
 
 	// 使用Constant常量
 	private String nodeName;
@@ -60,6 +68,16 @@ public class GraphNodeResponse {
 			.threadId(threadId)
 			.complete(true)
 			.textType(TextType.TEXT)
+			.build();
+	}
+
+	public static GraphNodeResponse finalAnswer(String agentId, String threadId, String text) {
+		return GraphNodeResponse.builder()
+			.agentId(agentId)
+			.threadId(threadId)
+			.eventType(GraphEventType.FINAL_ANSWER)
+			.textType(TextType.TEXT)
+			.text(text)
 			.build();
 	}
 

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/FeasibilityAssessmentNode.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/FeasibilityAssessmentNode.java
@@ -33,6 +33,7 @@ import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 
 import java.util.Map;
+import java.util.HashMap;
 
 import static com.alibaba.cloud.ai.dataagent.constant.Constant.*;
 
@@ -72,7 +73,14 @@ public class FeasibilityAssessmentNode implements NodeAction {
 				state, "正在进行可行性评估...", "可行性评估完成！", llmOutput -> {
 					FeasibilityAssessmentOutputDTO assessmentResult = OUTPUT_CONVERTER.convert(llmOutput);
 					log.info("Feasibility assessment result: {}", assessmentResult);
-					return Map.of(FEASIBILITY_ASSESSMENT_NODE_OUTPUT, assessmentResult);
+					Map<String, Object> output = new HashMap<>();
+					output.put(FEASIBILITY_ASSESSMENT_NODE_OUTPUT, assessmentResult);
+					if (assessmentResult
+						.getRequirementType() != FeasibilityAssessmentOutputDTO.RequirementType.DATA_ANALYSIS
+							&& org.springframework.util.StringUtils.hasText(assessmentResult.getContent())) {
+						output.put(FINAL_ANSWER, assessmentResult.getContent().trim());
+					}
+					return output;
 				}, responseFlux);
 		return Map.of(FEASIBILITY_ASSESSMENT_NODE_OUTPUT, generator);
 	}

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/IntentRecognitionNode.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/IntentRecognitionNode.java
@@ -34,6 +34,7 @@ import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 
 import java.util.Map;
+import java.util.HashMap;
 
 import static com.alibaba.cloud.ai.dataagent.constant.Constant.*;
 
@@ -72,7 +73,16 @@ public class IntentRecognitionNode implements NodeAction {
 						ChatResponseUtil.createPureResponse(TextType.JSON.getStartSign())),
 				Flux.just(ChatResponseUtil.createPureResponse(TextType.JSON.getEndSign()),
 						ChatResponseUtil.createResponse("\n意图识别完成！")),
-				result -> Map.of(INTENT_RECOGNITION_NODE_OUTPUT, OUTPUT_CONVERTER.convert(result)));
+				result -> {
+					IntentRecognitionOutputDTO intent = OUTPUT_CONVERTER.convert(result);
+					Map<String, Object> output = new HashMap<>();
+					output.put(INTENT_RECOGNITION_NODE_OUTPUT, intent);
+					if ("《闲聊或无关指令》".equals(intent.getClassification())
+							&& org.springframework.util.StringUtils.hasText(intent.getResponse())) {
+						output.put(FINAL_ANSWER, intent.getResponse().trim());
+					}
+					return output;
+				});
 		return Map.of(INTENT_RECOGNITION_NODE_OUTPUT, generator);
 	}
 

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphServiceImplTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/graph/GraphServiceImplTest.java
@@ -16,6 +16,7 @@
 package com.alibaba.cloud.ai.dataagent.service.graph;
 
 import com.alibaba.cloud.ai.dataagent.dto.GraphRequest;
+import com.alibaba.cloud.ai.dataagent.enums.GraphEventType;
 import com.alibaba.cloud.ai.dataagent.service.graph.Context.MultiTurnContextManager;
 import com.alibaba.cloud.ai.dataagent.service.langfuse.LangfuseService;
 import com.alibaba.cloud.ai.dataagent.vo.GraphNodeResponse;
@@ -25,6 +26,8 @@ import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.StateGraph;
 import com.alibaba.cloud.ai.graph.exception.GraphRunnerException;
+import com.alibaba.cloud.ai.graph.streaming.StreamingOutput;
+import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
 import io.opentelemetry.api.trace.Span;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +41,8 @@ import org.springframework.http.codec.ServerSentEvent;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
 
+import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -139,6 +144,52 @@ class GraphServiceImplTest {
 		graphService.graphStreamProcess(sink, request);
 
 		assertEquals("existing-thread", request.getThreadId());
+	}
+
+	@Test
+	void graphStreamProcess_emitsStepIdentityAndTypedFinalAnswer() throws Exception {
+		OverAllState regularState = new OverAllState();
+		regularState.registerKeyAndStrategy("final_answer", new ReplaceStrategy());
+		OverAllState finalState = new OverAllState();
+		finalState.registerKeyAndStrategy("final_answer", new ReplaceStrategy());
+		finalState.updateState(java.util.Map.of("final_answer", "请补充时间范围"));
+
+		StreamingOutput<?> first = streamingOutput("IntentRecognitionNode", "first", regularState);
+		StreamingOutput<?> second = streamingOutput("IntentRecognitionNode", "second", regularState);
+		StreamingOutput<?> other = streamingOutput("QueryEnhanceNode", "other", regularState);
+		StreamingOutput<?> retry = streamingOutput("IntentRecognitionNode", "retry", finalState);
+		when(compiledGraph.stream(anyMap(), any(RunnableConfig.class)))
+			.thenReturn(Flux.just(first, second, other, retry));
+
+		Sinks.Many<ServerSentEvent<GraphNodeResponse>> sink = Sinks.many().unicast().onBackpressureBuffer();
+		var responsesFuture = sink.asFlux().map(ServerSentEvent::data).collectList().toFuture();
+		GraphRequest request = GraphRequest.builder().agentId("1").threadId("run-1").query("test query").build();
+
+		graphService.graphStreamProcess(sink, request);
+		List<GraphNodeResponse> responses = responsesFuture.get(Duration.ofSeconds(2).toMillis(),
+				java.util.concurrent.TimeUnit.MILLISECONDS);
+
+		List<GraphNodeResponse> nodeEvents = responses.stream()
+			.filter(response -> response.getEventType() == GraphEventType.NODE_OUTPUT && !response.isComplete())
+			.toList();
+		assertEquals(nodeEvents.get(0).getStepId(), nodeEvents.get(1).getStepId());
+		assertNotEquals(nodeEvents.get(1).getStepId(), nodeEvents.get(2).getStepId());
+		assertNotEquals(nodeEvents.get(0).getStepId(), nodeEvents.get(3).getStepId());
+		assertEquals(1, nodeEvents.get(0).getAttempt());
+		assertEquals(2, nodeEvents.get(3).getAttempt());
+		assertTrue(responses.stream()
+			.anyMatch(response -> response.getEventType() == GraphEventType.FINAL_ANSWER
+					&& "请补充时间范围".equals(response.getText())),
+				responses.toString());
+	}
+
+	@SuppressWarnings("unchecked")
+	private StreamingOutput<?> streamingOutput(String node, String chunk, OverAllState state) {
+		StreamingOutput<Object> output = mock(StreamingOutput.class);
+		when(output.node()).thenReturn(node);
+		when(output.chunk()).thenReturn(chunk);
+		when(output.state()).thenReturn(state);
+		return output;
 	}
 
 	@Test

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/workflow/node/FeasibilityAssessmentNodeTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/workflow/node/FeasibilityAssessmentNodeTest.java
@@ -23,6 +23,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 
 import com.alibaba.cloud.ai.dataagent.common.TestFixtures;
@@ -31,7 +33,9 @@ import com.alibaba.cloud.ai.dataagent.dto.schema.SchemaDTO;
 import com.alibaba.cloud.ai.dataagent.service.llm.LlmService;
 import com.alibaba.cloud.ai.dataagent.util.ChatResponseUtil;
 import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.GraphResponse;
 import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
+import com.alibaba.cloud.ai.graph.streaming.StreamingOutput;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,7 +66,22 @@ class FeasibilityAssessmentNodeTest {
 		state.registerKeyAndStrategy(EVIDENCE, new ReplaceStrategy());
 		state.registerKeyAndStrategy(MULTI_TURN_CONTEXT, new ReplaceStrategy());
 		state.registerKeyAndStrategy(FEASIBILITY_ASSESSMENT_NODE_OUTPUT, new ReplaceStrategy());
+		state.registerKeyAndStrategy(FINAL_ANSWER, new ReplaceStrategy());
 		return state;
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, Object> execute(Map<String, Object> nodeResult) {
+		Flux<GraphResponse<StreamingOutput>> generator = (Flux<GraphResponse<StreamingOutput>>) nodeResult
+			.get(FEASIBILITY_ASSESSMENT_NODE_OUTPUT);
+		List<GraphResponse<StreamingOutput>> responses = generator.collectList().block(Duration.ofSeconds(2));
+		assertNotNull(responses);
+		return responses.stream()
+			.filter(GraphResponse::isDone)
+			.findFirst()
+			.flatMap(GraphResponse::resultValue)
+			.map(value -> (Map<String, Object>) value)
+			.orElseThrow();
 	}
 
 	private SchemaDTO createSimpleSchema() {
@@ -87,6 +106,7 @@ class FeasibilityAssessmentNodeTest {
 
 		assertNotNull(result);
 		assertTrue(result.containsKey(FEASIBILITY_ASSESSMENT_NODE_OUTPUT));
+		assertFalse(execute(result).containsKey(FINAL_ANSWER));
 		verify(llmService).callUser(anyString(), any());
 	}
 
@@ -104,6 +124,7 @@ class FeasibilityAssessmentNodeTest {
 
 		assertNotNull(result);
 		assertTrue(result.containsKey(FEASIBILITY_ASSESSMENT_NODE_OUTPUT));
+		assertEquals("查询与数据库无关", execute(result).get(FINAL_ANSWER));
 	}
 
 	@Test

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/workflow/node/IntentRecognitionNodeTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/workflow/node/IntentRecognitionNodeTest.java
@@ -22,6 +22,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -36,7 +38,9 @@ import com.alibaba.cloud.ai.dataagent.enums.TextType;
 import com.alibaba.cloud.ai.dataagent.service.llm.LlmService;
 import com.alibaba.cloud.ai.dataagent.util.ChatResponseUtil;
 import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.GraphResponse;
 import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
+import com.alibaba.cloud.ai.graph.streaming.StreamingOutput;
 
 import reactor.core.publisher.Flux;
 
@@ -68,7 +72,22 @@ class IntentRecognitionNodeTest {
 		state.registerKeyAndStrategy(INTENT_RECOGNITION_NODE_OUTPUT, new ReplaceStrategy());
 		state.registerKeyAndStrategy(INPUT_KEY, new ReplaceStrategy());
 		state.registerKeyAndStrategy(MULTI_TURN_CONTEXT, new ReplaceStrategy());
+		state.registerKeyAndStrategy(FINAL_ANSWER, new ReplaceStrategy());
 		return state;
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, Object> execute(Map<String, Object> nodeResult) {
+		Flux<GraphResponse<StreamingOutput>> generator = (Flux<GraphResponse<StreamingOutput>>) nodeResult
+			.get(INTENT_RECOGNITION_NODE_OUTPUT);
+		List<GraphResponse<StreamingOutput>> responses = generator.collectList().block(Duration.ofSeconds(2));
+		assertNotNull(responses);
+		return responses.stream()
+			.filter(GraphResponse::isDone)
+			.findFirst()
+			.flatMap(GraphResponse::resultValue)
+			.map(value -> (Map<String, Object>) value)
+			.orElseThrow();
 	}
 
 	@Test
@@ -77,16 +96,13 @@ class IntentRecognitionNodeTest {
 		state.updateState(Map.of(INPUT_KEY, CHAT_QUERY, MULTI_TURN_CONTEXT, "(无)"));
 
 		when(llmService.callUser(anyString(), any()))
-			.thenReturn(Flux.just(ChatResponseUtil.createResponse("正在进行意图识别..."),
-					ChatResponseUtil.createPureResponse(TextType.JSON.getStartSign()),
-					ChatResponseUtil.createPureResponse(JSON_ANALYSIS),
-					ChatResponseUtil.createPureResponse(TextType.JSON.getEndSign()),
-					ChatResponseUtil.createResponse("\n意图识别完成！")));
+			.thenReturn(Flux.just(ChatResponseUtil.createPureResponse(JSON_ANALYSIS)));
 
 		Map<String, Object> result = intentRecognitionNode.apply(state);
 
 		assertNotNull(result);
 		assertTrue(result.containsKey(INTENT_RECOGNITION_NODE_OUTPUT));
+		assertFalse(execute(result).containsKey(FINAL_ANSWER));
 	}
 
 	@Test
@@ -94,21 +110,18 @@ class IntentRecognitionNodeTest {
 		OverAllState state = createTestState();
 		state.updateState(Map.of(INPUT_KEY, "你好", MULTI_TURN_CONTEXT, "(无)"));
 
-		when(llmService.callUser(anyString(), any()))
-			.thenReturn(Flux.just(ChatResponseUtil.createResponse("正在进行意图识别..."),
-					ChatResponseUtil.createPureResponse(TextType.JSON.getStartSign()),
-					ChatResponseUtil.createPureResponse("""
-							{
-								"classification": "《闲聊或无关指令》",
-								"response": "你好！我可以帮你分析已连接的数据。"
-							}
-							"""), ChatResponseUtil.createPureResponse(TextType.JSON.getEndSign()),
-					ChatResponseUtil.createResponse("\n意图识别完成！")));
+		when(llmService.callUser(anyString(), any())).thenReturn(Flux.just(ChatResponseUtil.createPureResponse("""
+				{
+					"classification": "《闲聊或无关指令》",
+					"response": "你好！我可以帮你分析已连接的数据。"
+				}
+				""")));
 
 		Map<String, Object> result = intentRecognitionNode.apply(state);
 
 		assertNotNull(result);
 		assertTrue(result.containsKey(INTENT_RECOGNITION_NODE_OUTPUT));
+		assertEquals("你好！我可以帮你分析已连接的数据。", execute(result).get(FINAL_ANSWER));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

- add typed `NODE_OUTPUT` and `FINAL_ANSWER` workflow events
- add stable `stepId` and `attempt` metadata for repeated node executions
- stop parsing localized intent JSON in the frontend
- group timeline entries by execution step and use the latest progressive result
- add focused Vitest coverage for retries, result enrichment, and legacy grouping

## Root cause

The frontend inferred terminal answers from Chinese node content and grouped the timeline only by `nodeName`. Re-entering a node collapsed retries, while progressive result updates could render stale data.

## Compatibility

Existing node payload fields remain available. The frontend grouping utility includes a legacy fallback for events that do not yet contain `stepId`.

## Validation

- `./mvnw test -q`
- `pnpm test:unit` (3 tests)
- `pnpm build`
- verified as the fourth commit in the four-PR integration sequence

