### PR TITLE
fix: apply Dameng schema and stop repeated SQL retries

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/connector/SqlExecutor.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/connector/SqlExecutor.java
@@ -67,6 +67,11 @@ public class SqlExecutor {
 					statement.execute("ALTER SESSION SET CURRENT_SCHEMA = " + schema);
 				}
 			}
+			else if (isDameng(dialect)) {
+				if (StringUtils.isNotEmpty(schema)) {
+					statement.execute("SET SCHEMA " + quoteIdentifier(schema));
+				}
+			}
 
 			try (ResultSet rs = statement.executeQuery(sql)) {
 				return ResultSetBuilder.buildFrom(rs, schema);
@@ -122,6 +127,11 @@ public class SqlExecutor {
 					statement.execute("ALTER SESSION SET CURRENT_SCHEMA = " + databaseOrSchema);
 				}
 			}
+			else if (isDameng(dialect)) {
+				if (StringUtils.isNotEmpty(databaseOrSchema)) {
+					statement.execute("SET SCHEMA " + quoteIdentifier(databaseOrSchema));
+				}
+			}
 
 			ResultSet rs = statement.executeQuery(sql);
 
@@ -133,6 +143,15 @@ public class SqlExecutor {
 
 			return result;
 		}
+	}
+
+	private static String quoteIdentifier(String identifier) {
+		return '"' + identifier.replace("\"", "\"\"") + '"';
+	}
+
+	private static boolean isDameng(String databaseProductName) {
+		return "DM DBMS".equalsIgnoreCase(databaseProductName)
+				|| DatabaseDialectEnum.DAMENG.code.equalsIgnoreCase(databaseProductName);
 	}
 
 }

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/SqlGenerateNode.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/SqlGenerateNode.java
@@ -33,6 +33,7 @@ import com.alibaba.cloud.ai.graph.action.NodeAction;
 import com.alibaba.cloud.ai.graph.streaming.StreamingOutput;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
@@ -89,16 +90,15 @@ public class SqlGenerateNode implements NodeAction {
 		Flux<String> sqlFlux;
 		SqlRetryDto retryDto = StateUtil.getObjectValue(state, SQL_REGENERATE_REASON, SqlRetryDto.class,
 				SqlRetryDto.empty());
+		String failedSql = StateUtil.getStringValue(state, SQL_GENERATE_OUTPUT, "");
 
 		if (retryDto.sqlExecuteFail()) {
 			displayMessage = "检测到SQL执行异常，开始重新生成SQL...";
-			sqlFlux = handleRetryGenerateSql(state, StateUtil.getStringValue(state, SQL_GENERATE_OUTPUT, ""),
-					retryDto.reason(), promptForSql);
+			sqlFlux = handleRetryGenerateSql(state, failedSql, retryDto.reason(), promptForSql);
 		}
 		else if (retryDto.semanticFail()) {
 			displayMessage = "语义一致性校验未通过，开始重新生成SQL...";
-			sqlFlux = handleRetryGenerateSql(state, StateUtil.getStringValue(state, SQL_GENERATE_OUTPUT, ""),
-					retryDto.reason(), promptForSql);
+			sqlFlux = handleRetryGenerateSql(state, failedSql, retryDto.reason(), promptForSql);
 		}
 		else {
 			displayMessage = "开始生成SQL...";
@@ -115,17 +115,41 @@ public class SqlGenerateNode implements NodeAction {
 				ChatResponseUtil.createPureResponse(TextType.SQL.getStartSign()));
 		Flux<ChatResponse> displayFlux = preFlux
 			.concatWith(sqlFlux.doOnNext(sqlCollector::append).map(ChatResponseUtil::createPureResponse))
-			.concatWith(Flux.just(ChatResponseUtil.createPureResponse(TextType.SQL.getEndSign()),
-					ChatResponseUtil.createResponse("SQL生成完成，准备执行")));
+			.concatWith(Flux.defer(() -> {
+				String generatedSql = nl2SqlService.sqlTrim(sqlCollector.toString());
+				String completionMessage = isUnchangedExecutionRetry(retryDto, failedSql, generatedSql)
+						? "SQL 修复结果与失败 SQL 相同，已停止重试，避免重复执行。" : "SQL生成完成，准备执行";
+				return Flux.just(ChatResponseUtil.createPureResponse(TextType.SQL.getEndSign()),
+						ChatResponseUtil.createResponse(completionMessage));
+			}));
 
 		Flux<GraphResponse<StreamingOutput>> generator = FluxUtil.createStreamingGeneratorWithMessages(this.getClass(),
 				state, v -> {
 					String sql = nl2SqlService.sqlTrim(sqlCollector.toString());
-					result.put(SQL_GENERATE_OUTPUT, sql);
+					if (isUnchangedExecutionRetry(retryDto, failedSql, sql)) {
+						log.warn("Regenerated SQL is unchanged after execution failure; stopping retry loop");
+						result.put(SQL_GENERATE_OUTPUT, StateGraph.END);
+					}
+					else {
+						result.put(SQL_GENERATE_OUTPUT, sql);
+					}
 					return result;
 				}, displayFlux);
 
 		return Map.of(SQL_GENERATE_OUTPUT, generator);
+	}
+
+	private boolean isUnchangedExecutionRetry(SqlRetryDto retryDto, String failedSql, String generatedSql) {
+		return retryDto.sqlExecuteFail() && StringUtils.isNotBlank(failedSql) && StringUtils.isNotBlank(generatedSql)
+				&& normalizeSql(failedSql).equals(normalizeSql(generatedSql));
+	}
+
+	private String normalizeSql(String sql) {
+		String normalized = StringUtils.defaultString(sql).strip();
+		while (normalized.endsWith(";")) {
+			normalized = normalized.substring(0, normalized.length() - 1).stripTrailing();
+		}
+		return normalized;
 	}
 
 	private Flux<String> handleRetryGenerateSql(OverAllState state, String originalSql, String errorMsg,

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/connector/SqlExecutorTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/connector/SqlExecutorTest.java
@@ -173,6 +173,23 @@ class SqlExecutorTest {
 	}
 
 	@Test
+	void executeSqlAndReturnObject_withDamengSchema_setsSchema() throws SQLException {
+		when(connection.createStatement()).thenReturn(statement);
+		when(connection.getMetaData()).thenReturn(databaseMetaData);
+		when(databaseMetaData.getDatabaseProductName()).thenReturn("DM DBMS");
+		when(statement.executeQuery("SELECT 1")).thenReturn(resultSet);
+		when(resultSet.getMetaData()).thenReturn(resultSetMetaData);
+		when(resultSetMetaData.getColumnCount()).thenReturn(1);
+		when(resultSetMetaData.getColumnLabel(1)).thenReturn("1");
+		when(resultSet.next()).thenReturn(false);
+
+		ResultSetBO result = SqlExecutor.executeSqlAndReturnObject(connection, "ACT", "SELECT 1");
+
+		assertNotNull(result);
+		verify(statement).execute("SET SCHEMA \"ACT\"");
+	}
+
+	@Test
 	void executeSqlAndReturnObject_withNullSchema_skipsSchemaSwitch() throws SQLException {
 		when(connection.createStatement()).thenReturn(statement);
 		when(connection.getMetaData()).thenReturn(databaseMetaData);
@@ -259,6 +276,24 @@ class SqlExecutorTest {
 
 		assertNotNull(result);
 		verify(statement).execute("ALTER SESSION SET CURRENT_SCHEMA = HR");
+	}
+
+	@Test
+	void executeSqlAndReturnArr_withDamengSchema_setsSchema() throws SQLException {
+		when(connection.createStatement()).thenReturn(statement);
+		when(connection.getCatalog()).thenReturn("DAMENG");
+		when(connection.getMetaData()).thenReturn(databaseMetaData);
+		when(databaseMetaData.getDatabaseProductName()).thenReturn("DM DBMS");
+		when(statement.executeQuery("SELECT 1")).thenReturn(resultSet);
+		when(resultSet.getMetaData()).thenReturn(resultSetMetaData);
+		when(resultSetMetaData.getColumnCount()).thenReturn(1);
+		when(resultSetMetaData.getColumnLabel(1)).thenReturn("1");
+		when(resultSet.next()).thenReturn(false);
+
+		String[][] result = SqlExecutor.executeSqlAndReturnArr(connection, "ACT", "SELECT 1");
+
+		assertNotNull(result);
+		verify(statement).execute("SET SCHEMA \"ACT\"");
 	}
 
 	@Test

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/workflow/node/sql/SqlGenerateNodeTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/workflow/node/sql/SqlGenerateNodeTest.java
@@ -19,8 +19,11 @@ import com.alibaba.cloud.ai.dataagent.dto.datasource.SqlRetryDto;
 import com.alibaba.cloud.ai.dataagent.workflow.node.SqlGenerateNode;
 import com.alibaba.cloud.ai.dataagent.properties.DataAgentProperties;
 import com.alibaba.cloud.ai.dataagent.service.nl2sql.Nl2SqlService;
+import com.alibaba.cloud.ai.graph.GraphResponse;
 import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.StateGraph;
 import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
+import com.alibaba.cloud.ai.graph.streaming.StreamingOutput;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,6 +33,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import reactor.core.publisher.Flux;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -220,6 +224,33 @@ class SqlGenerateNodeTest {
 		Map<String, Object> result = sqlGenerateNode.apply(state);
 		assertNotNull(result);
 		assertTrue(result.containsKey(SQL_GENERATE_OUTPUT));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void apply_executionRetryReturnsSameSql_stopsRetryLoop() throws Exception {
+		OverAllState state = createTestState();
+		setupBasicState(state);
+		state.updateState(Map.of(SQL_REGENERATE_REASON, SqlRetryDto.sqlExecute("same database error"),
+				SQL_GENERATE_OUTPUT, "SELECT * FROM users;"));
+
+		when(properties.getMaxSqlRetryCount()).thenReturn(10);
+		when(nl2SqlService.generateSql(any())).thenReturn(Flux.just("SELECT * FROM users"));
+		when(nl2SqlService.sqlTrim(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+		Map<String, Object> result = sqlGenerateNode.apply(state);
+		Flux<GraphResponse<StreamingOutput>> generator = (Flux<GraphResponse<StreamingOutput>>) result
+			.get(SQL_GENERATE_OUTPUT);
+		List<GraphResponse<StreamingOutput>> responses = generator.collectList().block(Duration.ofSeconds(2));
+
+		assertNotNull(responses);
+		Map<String, Object> finalResult = responses.stream()
+			.filter(GraphResponse::isDone)
+			.findFirst()
+			.flatMap(GraphResponse::resultValue)
+			.map(value -> (Map<String, Object>) value)
+			.orElseThrow();
+		assertEquals(StateGraph.END, finalResult.get(SQL_GENERATE_OUTPUT));
 	}
 
 	@Test


### PR DESCRIPTION
## What changed

- set the configured schema on Dameng sessions before executing SQL
- recognize the real Dameng JDBC product name (`DM DBMS`) while retaining the existing dialect alias
- stop SQL repair when the model returns the same failed SQL again (ignoring only trailing semicolons)
- tell the user why retrying stopped instead of executing the same statement repeatedly

## Root cause

`SqlExecutor` switches schemas for PostgreSQL, H2, and Oracle, but did not do so for Dameng. The datasource configuration therefore reported a schema such as `ACT`, while unqualified queries still ran against the login user's default schema and failed with `Invalid table or view name`.

Dameng documents `SET SCHEMA <schema>` as the session-level way to select the current schema. The bundled JDBC driver reports `DM DBMS` from `DatabaseMetaData#getDatabaseProductName`, so the implementation handles that actual value.

Separately, SQL execution errors always routed back to model-based repair until the global retry limit. If the model returned the unchanged SQL, the same statement and error could repeat many times. The new guard ends that branch immediately when repair made no change.

## Impact

Dameng queries now execute in the configured schema, and unrecoverable unchanged SQL no longer produces a long repeated retry loop.

## Validation

- `.\mvnw.cmd -pl data-agent-management '-Dtest=SqlExecutorTest,SqlGenerateNodeTest' test` (31 tests)
- `.\mvnw.cmd -pl data-agent-management spotless:check`
- Checkstyle: 0 violations

Fixes #555
Fixes #549
