### PR TITLE
fix: store chat messages with utf8mb4

### DIFF
--- a/data-agent-management/src/main/resources/sql/migration/upgrade-chat-utf8mb4.sql
+++ b/data-agent-management/src/main/resources/sql/migration/upgrade-chat-utf8mb4.sql
@@ -1,0 +1,42 @@
+-- Upgrade existing MySQL installations so chat messages can store 4-byte Unicode
+-- characters such as emoji. Run this script against the DataAgent management
+-- database. It is safe to run again: the current session foreign key is discovered,
+-- replaced, and given a stable name.
+
+SET NAMES utf8mb4;
+
+SET @chat_message_session_fk = NULL;
+SELECT CONSTRAINT_NAME
+INTO @chat_message_session_fk
+FROM information_schema.KEY_COLUMN_USAGE
+WHERE CONSTRAINT_SCHEMA = DATABASE()
+  AND TABLE_NAME = 'chat_message'
+  AND COLUMN_NAME = 'session_id'
+  AND REFERENCED_TABLE_NAME = 'chat_session'
+  AND REFERENCED_COLUMN_NAME = 'id'
+LIMIT 1;
+
+SET @drop_chat_message_session_fk = IF(
+  @chat_message_session_fk IS NULL,
+  'SELECT 1',
+  CONCAT(
+    'ALTER TABLE `chat_message` DROP FOREIGN KEY `',
+    REPLACE(@chat_message_session_fk, '`', '``'),
+    '`'
+  )
+);
+
+PREPARE drop_chat_message_session_fk_stmt FROM @drop_chat_message_session_fk;
+EXECUTE drop_chat_message_session_fk_stmt;
+DEALLOCATE PREPARE drop_chat_message_session_fk_stmt;
+
+ALTER TABLE `chat_session`
+  CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE `chat_message`
+  CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE `chat_message`
+  ADD CONSTRAINT `fk_chat_message_session`
+  FOREIGN KEY (`session_id`) REFERENCES `chat_session` (`id`)
+  ON DELETE CASCADE;

--- a/data-agent-management/src/main/resources/sql/schema.sql
+++ b/data-agent-management/src/main/resources/sql/schema.sql
@@ -187,7 +187,7 @@ CREATE TABLE IF NOT EXISTS chat_session (
   INDEX idx_is_pinned (is_pinned),
   INDEX idx_create_time (create_time),
   FOREIGN KEY (agent_id) REFERENCES agent(id) ON DELETE CASCADE
-) ENGINE = InnoDB COMMENT = '聊天会话表';
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci COMMENT = '聊天会话表';
 
 -- 消息表
 CREATE TABLE IF NOT EXISTS chat_message (
@@ -203,8 +203,8 @@ CREATE TABLE IF NOT EXISTS chat_message (
   INDEX idx_role (role),
   INDEX idx_message_type (message_type),
   INDEX idx_create_time (create_time),
-  FOREIGN KEY (session_id) REFERENCES chat_session(id) ON DELETE CASCADE
-) ENGINE = InnoDB COMMENT = '聊天消息表';
+  CONSTRAINT fk_chat_message_session FOREIGN KEY (session_id) REFERENCES chat_session(id) ON DELETE CASCADE
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci COMMENT = '聊天消息表';
 
 -- 用户Prompt配置表
 CREATE TABLE IF NOT EXISTS user_prompt_config (

--- a/data-agent-management/src/test/resources/sql/schema.sql
+++ b/data-agent-management/src/test/resources/sql/schema.sql
@@ -167,7 +167,7 @@ CREATE TABLE IF NOT EXISTS chat_session (
   INDEX idx_is_pinned (is_pinned),
   INDEX idx_create_time (create_time),
   FOREIGN KEY (agent_id) REFERENCES agent(id) ON DELETE CASCADE
-) ENGINE = InnoDB COMMENT = '聊天会话表';
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci COMMENT = '聊天会话表';
 
 -- 消息表
 CREATE TABLE IF NOT EXISTS chat_message (
@@ -183,8 +183,8 @@ CREATE TABLE IF NOT EXISTS chat_message (
   INDEX idx_role (role),
   INDEX idx_message_type (message_type),
   INDEX idx_create_time (create_time),
-  FOREIGN KEY (session_id) REFERENCES chat_session(id) ON DELETE CASCADE
-) ENGINE = InnoDB COMMENT = '聊天消息表';
+  CONSTRAINT fk_chat_message_session FOREIGN KEY (session_id) REFERENCES chat_session(id) ON DELETE CASCADE
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci COMMENT = '聊天消息表';
 
 -- 用户Prompt配置表
 CREATE TABLE IF NOT EXISTS user_prompt_config (

--- a/docs/QUICK_START-en.md
+++ b/docs/QUICK_START-en.md
@@ -32,6 +32,12 @@ mysql -u root -p your_database < data-agent-management/src/main/resources/sql/pr
 mysql -u root -p your_database < data-agent-management/src/main/resources/sql/product_data.sql
 ```
 
+When upgrading an existing installation, run the charset migration if `chat_message.content` cannot store emoji. The script handles the `chat_message.session_id` foreign key before converting both chat tables to `utf8mb4`:
+
+```bash
+mysql -u root -p your_database < data-agent-management/src/main/resources/sql/migration/upgrade-chat-utf8mb4.sql
+```
+
 ## 2. Configuration
 
 ### 2.1 Configure Management Database

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -32,6 +32,12 @@ mysql -u root -p your_database < data-agent-management/src/main/resources/sql/pr
 mysql -u root -p your_database < data-agent-management/src/main/resources/sql/product_data.sql
 ```
 
+如果是从旧版本升级，并且 `chat_message.content` 无法写入 Emoji，请执行字符集升级脚本。脚本会先处理 `chat_message.session_id` 的外键，再将会话表和消息表一起转换为 `utf8mb4`：
+
+```bash
+mysql -u root -p your_database < data-agent-management/src/main/resources/sql/migration/upgrade-chat-utf8mb4.sql
+```
+
 ## ⚙️ 2. 配置
 
 ### 2.1 配置management数据库


### PR DESCRIPTION
## What changed

- create `chat_session` and `chat_message` with `utf8mb4_unicode_ci`
- give the session-message foreign key a stable name on new installations
- add a rerunnable MySQL migration for existing installations
- document the upgrade command in the Chinese and English quick-start guides

## Root cause

The chat tables inherited the management database's default charset. When that default was MySQL `utf8`/`utf8mb3`, four-byte Unicode characters such as emoji could not be inserted into `chat_message.content`.

Converting only one table also makes the `chat_message.session_id` and `chat_session.id` foreign-key columns temporarily incompatible, causing MySQL Error 3780.

## Migration behavior

`upgrade-chat-utf8mb4.sql` discovers the current session foreign key from `information_schema`, drops it, converts both related tables to the same charset and collation, then recreates the foreign key as `fk_chat_message_session`. Running it again follows the same sequence, so upgrades are repeatable and do not depend on MySQL's generated constraint name.

## Validation

- `.\mvnw.cmd -pl data-agent-management '-Dtest=ChatMessageServiceImplTest,ChatSessionServiceImplTest' test` (14 tests)
- `.\mvnw.cmd -pl data-agent-management spotless:check`
- Checkstyle: 0 violations
- static assertions verify both schema copies use `utf8mb4` and the migration drops/recreates the foreign key around both table conversions

A live MySQL migration run was not available in the local environment because neither a MySQL client nor a running Docker engine was present.

Fixes #464
Fixes #368
