### PR TITLE
fix: harden vector store reliability

### DIFF
--- a/data-agent-frontend-nuxt/app/components/chat/ChatMessageList.vue
+++ b/data-agent-frontend-nuxt/app/components/chat/ChatMessageList.vue
@@ -201,6 +201,7 @@ import DOMPurify from 'dompurify';
 import { renderMarkdownContent } from '~/utils/markdown';
 import { useEchartsRenderer } from '~/composables/useEchartsRenderer';
 import { useChatStore } from '~/stores/chat';
+import { extractReportContent } from '~/utils/reportTimeline';
 import type { ResultData } from '~/services/resultSet/index';
 import type { ChatMessage } from '~/services/chat/index';
 import ChatWelcome from './ChatWelcome.vue';
@@ -280,26 +281,6 @@ function safeParseBlocks(content: string) {
 	} catch {
 		return [];
 	}
-}
-
-function extractReportContent(timelineJson: string): string | null {
-	try {
-		const blocks = JSON.parse(
-			timelineJson,
-		) as import('~/services/graph/index').GraphNodeResponse[][];
-		for (const block of blocks) {
-			if (
-				block[0]?.nodeName === 'ReportGeneratorNode' &&
-				block[0]?.textType === 'MARK_DOWN' &&
-				block[0]?.text
-			) {
-				return block[0].text;
-			}
-		}
-	} catch {
-		/* ignore */
-	}
-	return null;
 }
 
 function escapeHtml(text: string): string {

--- a/data-agent-frontend-nuxt/app/error.vue
+++ b/data-agent-frontend-nuxt/app/error.vue
@@ -17,9 +17,7 @@
 <script setup lang="ts">
 import type { NuxtError } from '#app';
 
-const props = defineProps({
-	error: Object as () => NuxtError,
-});
+const props = defineProps<{ error: NuxtError }>();
 
 const statusCode = computed(() => props.error?.statusCode || 500);
 const statusText = computed(() => {

--- a/data-agent-frontend-nuxt/app/pages/system/agents.vue
+++ b/data-agent-frontend-nuxt/app/pages/system/agents.vue
@@ -29,9 +29,9 @@
 					variant="outlined"
 					prepend-icon="mdi-refresh"
 					:loading="loading"
-					@click="loadAgents"
 					class="text-none"
 					style="border-color: #e2e8f0"
+					@click="loadAgents"
 				>
 					刷新
 				</v-btn>

--- a/data-agent-frontend-nuxt/app/pages/system/model-config.vue
+++ b/data-agent-frontend-nuxt/app/pages/system/model-config.vue
@@ -29,9 +29,9 @@
 					variant="outlined"
 					prepend-icon="mdi-refresh"
 					:loading="loading"
-					@click="fetchConfigs"
 					class="text-none"
 					style="border-color: #e2e8f0"
+					@click="fetchConfigs"
 				>
 					刷新
 				</v-btn>
@@ -184,8 +184,8 @@
 											size="small"
 											class="text-none"
 											style="border-color: #e2e8f0"
-											@click="handleTestConnection(model)"
 											:loading="testingId === model.id"
+											@click="handleTestConnection(model)"
 										>
 											测试连接
 										</v-btn>
@@ -287,11 +287,11 @@
 									v-model="form.apiKey"
 									:type="showApiKey ? 'text' : 'password'"
 									:append-inner-icon="showApiKey ? 'mdi-eye-off' : 'mdi-eye'"
-									@click:append-inner="showApiKey = !showApiKey"
 									placeholder="sk-..."
 									variant="outlined"
 									density="compact"
 									:rules="form.provider === 'custom' ? [] : [rules.required]"
+									@click:append-inner="showApiKey = !showApiKey"
 								/>
 							</v-col>
 							<v-col cols="12">
@@ -306,7 +306,7 @@
 							</v-col>
 
 							<!-- Extra fields from original but styled like new -->
-							<v-col cols="12" v-if="form.modelType === 'CHAT'">
+							<v-col v-if="form.modelType === 'CHAT'" cols="12">
 								<span class="custom-label">Completions 路径</span>
 								<v-text-field
 									v-model="form.completionsPath"
@@ -316,7 +316,7 @@
 								/>
 							</v-col>
 
-							<v-col cols="12" v-if="form.modelType === 'EMBEDDING'">
+							<v-col v-if="form.modelType === 'EMBEDDING'" cols="12">
 								<span class="custom-label">Embeddings 路径</span>
 								<v-text-field
 									v-model="form.embeddingsPath"

--- a/data-agent-frontend-nuxt/app/pages/system/model-config.vue
+++ b/data-agent-frontend-nuxt/app/pages/system/model-config.vue
@@ -286,12 +286,34 @@
 								<v-text-field
 									v-model="form.apiKey"
 									:type="showApiKey ? 'text' : 'password'"
-									:append-inner-icon="showApiKey ? 'mdi-eye-off' : 'mdi-eye'"
-									placeholder="sk-..."
+									:append-inner-icon="
+										form.apiKey
+											? showApiKey
+												? 'mdi-eye-off'
+												: 'mdi-eye'
+											: undefined
+									"
+									:placeholder="
+										dialog.mode === 'edit'
+											? `${storedApiKeyMask} 已保存，留空表示不修改`
+											: 'sk-...'
+									"
+									:hint="
+										dialog.mode === 'edit'
+											? '出于安全考虑，已保存的完整密钥不会回显；输入新密钥可进行替换。'
+											: undefined
+									"
+									:persistent-hint="dialog.mode === 'edit'"
 									variant="outlined"
 									density="compact"
-									:rules="form.provider === 'custom' ? [] : [rules.required]"
-									@click:append-inner="showApiKey = !showApiKey"
+									:rules="
+										form.provider === 'custom' || dialog.mode === 'edit'
+											? []
+											: [rules.required]
+									"
+									@click:append-inner="
+										form.apiKey && (showApiKey = !showApiKey)
+									"
 								/>
 							</v-col>
 							<v-col cols="12">
@@ -407,6 +429,7 @@ const activatingId = ref<number | null>(null);
 const deletingId = ref<number | null>(null);
 const saving = ref(false);
 const showApiKey = ref(false);
+const storedApiKeyMask = ref('');
 
 const formRef = ref<VForm | null>(null);
 const formValid = ref(false);
@@ -457,6 +480,8 @@ const providerLabel = (value: string) => {
 };
 
 const resetForm = (type: ModelType) => {
+	storedApiKeyMask.value = '';
+	showApiKey.value = false;
 	form.provider = providerOptions[0]?.value || 'deepseek';
 	form.apiKey = '';
 	form.baseUrl = providerBaseUrlMap[form.provider] || '';
@@ -497,12 +522,15 @@ const handleEdit = (model: ModelConfig) => {
 	dialog.mode = 'edit';
 	dialog.visible = true;
 	dialog.presetTab = model.modelType;
-	Object.assign(form, model);
+	storedApiKeyMask.value = model.apiKey || '';
+	showApiKey.value = false;
+	Object.assign(form, model, { apiKey: '' });
 };
 
 const closeDialog = () => {
 	dialog.visible = false;
 	showApiKey.value = false;
+	storedApiKeyMask.value = '';
 };
 
 const submitConfig = async (isUpdate: boolean) => {
@@ -596,9 +624,13 @@ const handleActivate = async (model: ModelConfig) => {
 };
 
 const handleTestConnection = async (model: ModelConfig) => {
-	testingId.value = model.id ?? null;
+	if (!model.id) {
+		$tip('模型ID不存在', { icon: 'mdi-alert-circle', color: 'error' });
+		return;
+	}
+	testingId.value = model.id;
 	try {
-		const result = await modelConfigService.testConnection(model);
+		const result = await modelConfigService.testConnection(model.id);
 		if (result.success) {
 			$tip(result.message || '连接测试成功');
 		} else {

--- a/data-agent-frontend-nuxt/app/services/agentDatasource.ts
+++ b/data-agent-frontend-nuxt/app/services/agentDatasource.ts
@@ -15,6 +15,7 @@
  */
 
 import { $fetch } from 'ofetch';
+import type { Datasource } from './datasource';
 
 export interface ApiResponse<T> {
 	success: boolean;
@@ -28,7 +29,7 @@ export interface AgentDatasource {
 	datasourceId?: number;
 	isActive?: number;
 	selectTables?: string[];
-	datasource?: any;
+	datasource?: Datasource;
 }
 
 export interface UpdateDatasourceTablesDto {

--- a/data-agent-frontend-nuxt/app/services/modelConfig/index.test.ts
+++ b/data-agent-frontend-nuxt/app/services/modelConfig/index.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import axios from 'axios';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import modelConfigService from './index';
+
+vi.mock('axios', () => ({
+	default: {
+		post: vi.fn(),
+	},
+}));
+
+describe('ModelConfigService.testConnection', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('submits only the saved config ID so masked credentials are never reused', async () => {
+		vi.mocked(axios.post).mockResolvedValue({
+			data: { success: true, message: 'ok' },
+		});
+
+		await modelConfigService.testConnection(42);
+
+		expect(axios.post).toHaveBeenCalledWith('/api/model-config/test/42');
+	});
+});

--- a/data-agent-frontend-nuxt/app/services/modelConfig/index.ts
+++ b/data-agent-frontend-nuxt/app/services/modelConfig/index.ts
@@ -135,15 +135,12 @@ class ModelConfigService {
 
   /**
    * @description 测试模型配置的连接有效性
-   * @param {Omit<ModelConfig, "id">} config - 配置信息
+   * @param {number} id - 已保存的模型配置 ID
    * @returns {Promise<ApiResponse<string>>} 测试结果消息
    */
-  async testConnection(
-    config: Omit<ModelConfig, "id">,
-  ): Promise<ApiResponse<string>> {
+  async testConnection(id: number): Promise<ApiResponse<string>> {
     const response = await axios.post<ApiResponse<string>>(
-      `${API_BASE_URL}/test`,
-      config,
+      `${API_BASE_URL}/test/${id}`,
     );
     return response.data;
   }

--- a/data-agent-frontend-nuxt/app/stores/chat.ts
+++ b/data-agent-frontend-nuxt/app/stores/chat.ts
@@ -33,6 +33,7 @@ import modelConfigService, {
 import datasourceService, {
 	type Datasource as BaseDatasource,
 } from '~/services/datasource/index';
+import { resolveActiveDatasource } from '~/utils/datasourceSelection';
 
 export type Datasource = BaseDatasource & { isActive?: boolean };
 
@@ -164,13 +165,23 @@ export const useChatStore = defineStore('chat', () => {
 		} else {
 			await createNewSession(agentId);
 		}
-		// Load global datasources (active)
+		// Load active global datasources, then resolve the binding for this agent.
 		try {
 			const list = await datasourceService.getAllDatasource('active');
-			allDatasources.value = list;
-			activeDatasource.value = list[0] || null;
+			let activeDatasourceId: number | undefined;
+			try {
+				const agentDatasource =
+					await agentDatasourceService.getActiveAgentDatasource(agentId);
+				activeDatasourceId = agentDatasource.datasourceId;
+			} catch {
+				// An unbound agent can still select from the global datasource list.
+			}
+			const resolved = resolveActiveDatasource(list, activeDatasourceId);
+			allDatasources.value = resolved.datasources;
+			activeDatasource.value = resolved.activeDatasource;
 		} catch {
-			/* ignore */
+			allDatasources.value = [];
+			activeDatasource.value = null;
 		}
 		// Load chat models
 		try {

--- a/data-agent-frontend-nuxt/app/stores/chat.ts
+++ b/data-agent-frontend-nuxt/app/stores/chat.ts
@@ -34,6 +34,7 @@ import datasourceService, {
 	type Datasource as BaseDatasource,
 } from '~/services/datasource/index';
 import { resolveActiveDatasource } from '~/utils/datasourceSelection';
+import { applyReportContent } from '~/utils/reportTimeline';
 
 export type Datasource = BaseDatasource & { isActive?: boolean };
 
@@ -434,8 +435,11 @@ export const useChatStore = defineStore('chat', () => {
 					} else if (response.textType === 'MARK_DOWN') {
 						sessionState.markdownReportContent += response.text;
 						scheduleReportSync();
-						const rn = currentBlock;
-						if (rn) rn[0].text = sessionState.markdownReportContent;
+						applyReportContent(
+							currentBlock,
+							sessionState.markdownReportContent,
+							TextType.MARK_DOWN,
+						);
 					}
 				} else if (response.textType === TextType.RESULT_SET) {
 					if (!isNewStep && currentBlock) currentBlock.push({ ...response });

--- a/data-agent-frontend-nuxt/app/utils/datasourceSelection.test.ts
+++ b/data-agent-frontend-nuxt/app/utils/datasourceSelection.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { resolveActiveDatasource } from './datasourceSelection';
+
+describe('resolveActiveDatasource', () => {
+	it('uses the datasource bound to the current agent instead of the first global datasource', () => {
+		const result = resolveActiveDatasource(
+			[
+				{ id: 5, name: 'newest global datasource' },
+				{ id: 3, name: 'agent datasource' },
+			],
+			3,
+		);
+
+		expect(result.activeDatasource?.name).toBe('agent datasource');
+		expect(result.datasources).toEqual([
+			{ id: 5, name: 'newest global datasource', isActive: false },
+			{ id: 3, name: 'agent datasource', isActive: true },
+		]);
+	});
+
+	it('does not mislabel a global datasource when the agent has no active binding', () => {
+		const result = resolveActiveDatasource([{ id: 5, name: 'global datasource' }]);
+
+		expect(result.activeDatasource).toBeNull();
+		expect(result.datasources[0]?.isActive).toBe(false);
+	});
+});

--- a/data-agent-frontend-nuxt/app/utils/datasourceSelection.ts
+++ b/data-agent-frontend-nuxt/app/utils/datasourceSelection.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface SelectableDatasource {
+	id?: number;
+	isActive?: boolean;
+}
+
+export function resolveActiveDatasource<T extends SelectableDatasource>(
+	datasources: T[],
+	activeDatasourceId?: number,
+): { datasources: T[]; activeDatasource: T | null } {
+	const resolvedDatasources = datasources.map((datasource) => ({
+		...datasource,
+		isActive: datasource.id === activeDatasourceId,
+	}));
+
+	return {
+		datasources: resolvedDatasources,
+		activeDatasource:
+			resolvedDatasources.find((datasource) => datasource.isActive) || null,
+	};
+}

--- a/data-agent-frontend-nuxt/app/utils/report-html-template.ts
+++ b/data-agent-frontend-nuxt/app/utils/report-html-template.ts
@@ -34,8 +34,8 @@ export function buildReportHtml(markdownContent: string): string {
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>分析报告</title>
-<script src="${MARKED_URL}"><\/script>
-<script src="${ECHARTS_URL}"><\/script>
+<script src="${MARKED_URL}"></script>
+<script src="${ECHARTS_URL}"></script>
 <style>
 * { box-sizing: border-box; }
 body { margin: 0; padding: 20px; background-color: #f3f4f6; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; color: #374151; line-height: 1.6; }
@@ -94,7 +94,7 @@ window.onload = function() {
     });
   }
 };
-<\/script>
+</script>
 </body>
 </html>`;
 }

--- a/data-agent-frontend-nuxt/app/utils/reportTimeline.test.ts
+++ b/data-agent-frontend-nuxt/app/utils/reportTimeline.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { TextType, type GraphNodeResponse } from '../services/graph/index';
+import { applyReportContent, extractReportContent } from './reportTimeline';
+
+function reportEvent(
+	text: string,
+	textType: TextType = TextType.TEXT,
+): GraphNodeResponse {
+	return {
+		agentId: '1',
+		threadId: 'run-1',
+		stepId: 'ReportGeneratorNode-11',
+		attempt: 1,
+		nodeName: 'ReportGeneratorNode',
+		textType,
+		text,
+		error: false,
+		complete: false,
+	};
+}
+
+describe('report timeline', () => {
+	it('promotes the report summary event to markdown while aggregating chunks', () => {
+		const block = [reportEvent('开始生成报告...')];
+
+		applyReportContent(block, '# 已完成订单报告', TextType.MARK_DOWN);
+
+		expect(block[0]?.text).toBe('# 已完成订单报告');
+		expect(block[0]?.textType).toBe(TextType.MARK_DOWN);
+	});
+
+	it('extracts reports persisted before the text type fix', () => {
+		const timeline = JSON.stringify([
+			[reportEvent('# 历史数据分析报告', TextType.TEXT)],
+		]);
+
+		expect(extractReportContent(timeline)).toBe('# 历史数据分析报告');
+	});
+
+	it('does not mistake report lifecycle messages for report content', () => {
+		for (const status of ['开始生成报告...', '报告生成完成！']) {
+			const timeline = JSON.stringify([[reportEvent(status, TextType.TEXT)]]);
+			expect(extractReportContent(timeline)).toBeNull();
+		}
+	});
+
+	it('extracts a correctly typed markdown report', () => {
+		const timeline = JSON.stringify([
+			[reportEvent('# 新数据分析报告', TextType.MARK_DOWN)],
+		]);
+
+		expect(extractReportContent(timeline)).toBe('# 新数据分析报告');
+	});
+});

--- a/data-agent-frontend-nuxt/app/utils/reportTimeline.ts
+++ b/data-agent-frontend-nuxt/app/utils/reportTimeline.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TextType, type GraphNodeResponse } from '../services/graph/index';
+
+const REPORT_NODE_NAME = 'ReportGeneratorNode';
+const REPORT_LIFECYCLE_MESSAGES = new Set([
+	'开始生成报告...',
+	'报告生成完成！',
+]);
+const HTML_REPORT_PROGRESS_PREFIX = '正在收集HTML报告...';
+
+export function applyReportContent(
+	block: GraphNodeResponse[] | undefined,
+	content: string,
+	textType: TextType,
+): void {
+	const reportEvent = block?.[0];
+	if (!reportEvent) return;
+	reportEvent.text = content;
+	reportEvent.textType = textType;
+}
+
+export function extractReportContent(timelineJson: string): string | null {
+	try {
+		const blocks = JSON.parse(timelineJson) as GraphNodeResponse[][];
+		for (const block of blocks) {
+			const reportEvent = block[0];
+			if (reportEvent?.nodeName !== REPORT_NODE_NAME || !reportEvent.text)
+				continue;
+			if (reportEvent.textType === TextType.MARK_DOWN) return reportEvent.text;
+
+			const legacyText = reportEvent.text.trim();
+			if (
+				reportEvent.textType === TextType.TEXT &&
+				!REPORT_LIFECYCLE_MESSAGES.has(legacyText) &&
+				!legacyText.startsWith(HTML_REPORT_PROGRESS_PREFIX)
+			)
+				return reportEvent.text;
+		}
+	} catch {
+		/* ignore malformed historical messages */
+	}
+	return null;
+}

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/bo/schema/DisplayStyleBO.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/bo/schema/DisplayStyleBO.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.cloud.ai.dataagent.bo.schema;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -37,24 +38,28 @@ public class DisplayStyleBO {
 	/**
 	 * 图表类型，如：table, bar, line, pie等
 	 */
+	@JsonProperty(required = true)
 	@JsonPropertyDescription("图表类型，取值范围：table、 bar、 line、 pie等")
 	private String type;
 
 	/**
 	 * 图表标题
 	 */
+	@JsonProperty(required = true)
 	@JsonPropertyDescription("图表标题")
 	private String title;
 
 	/**
 	 * X轴字段名
 	 */
+	@JsonProperty(required = false)
 	@JsonPropertyDescription("X轴字段名")
 	private String x;
 
 	/**
 	 * Y轴字段名列表
 	 */
+	@JsonProperty(required = false)
 	@JsonPropertyDescription("Y轴字段名列表")
 	private List<String> y;
 

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/config/DataAgentConfiguration.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/config/DataAgentConfiguration.java
@@ -35,6 +35,7 @@ import com.alibaba.cloud.ai.dataagent.splitter.ParagraphTextSplitter;
 import com.alibaba.cloud.ai.dataagent.util.McpServerToolUtil;
 import com.alibaba.cloud.ai.dataagent.util.NodeBeanUtil;
 import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.AiModelRegistry;
+import com.alibaba.cloud.ai.dataagent.service.aimodelconfig.EmbeddingModelCompatibilityValidator;
 import com.alibaba.cloud.ai.dataagent.strategy.EnhancedTokenCountBatchingStrategy;
 import com.alibaba.cloud.ai.dataagent.workflow.dispatcher.*;
 import com.alibaba.cloud.ai.dataagent.workflow.node.*;
@@ -405,7 +406,8 @@ public class DataAgentConfiguration implements DisposableBean {
 	 */
 	@Bean
 	@Primary
-	public EmbeddingModel embeddingModel(AiModelRegistry registry) {
+	public EmbeddingModel embeddingModel(AiModelRegistry registry,
+			EmbeddingModelCompatibilityValidator embeddingModelCompatibilityValidator) {
 
 		// 1. 定义目标源 (TargetSource)
 		TargetSource targetSource = new TargetSource() {
@@ -423,7 +425,9 @@ public class DataAgentConfiguration implements DisposableBean {
 			@Override
 			public Object getTarget() {
 				// 每次方法调用，都去注册表拿最新的
-				return registry.getEmbeddingModel();
+				EmbeddingModel model = registry.getEmbeddingModel();
+				embeddingModelCompatibilityValidator.validateModel(model);
+				return model;
 			}
 
 			@Override

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/config/HybridRetrievalConfiguration.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/config/HybridRetrievalConfiguration.java
@@ -47,7 +47,7 @@ public class HybridRetrievalConfiguration {
 			FusionStrategy fusionStrategy, DataAgentProperties properties,
 			@Value("${spring.ai.vectorstore.elasticsearch.index-name:spring-ai-document-index}") String indexName) {
 		ElasticsearchHybridRetrievalStrategy strategy = new ElasticsearchHybridRetrievalStrategy(executorService,
-				vectorStore, fusionStrategy);
+				vectorStore, fusionStrategy, properties.getVectorStore().getHybridSearchTimeoutMs());
 		strategy.setIndexName(indexName);
 		strategy.setMinScore(properties.getVectorStore().getElasticsearchMinScore());
 		return strategy;

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/controller/ChatController.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/controller/ChatController.java
@@ -71,10 +71,14 @@ public class ChatController {
 	public ResponseEntity<ChatSession> createSession(@PathVariable(value = "id") Integer id,
 			@RequestBody(required = false) Map<String, Object> request) {
 		String title = request != null ? (String) request.get("title") : null;
-		Long userId = request != null ? (Long) request.get("userId") : null;
+		Long userId = request != null ? toUserId(request.get("userId")) : null;
 
 		ChatSession session = chatSessionService.createSession(id, title, userId);
 		return ResponseEntity.ok(session);
+	}
+
+	static Long toUserId(Object value) {
+		return value instanceof Number number ? number.longValue() : null;
 	}
 
 	/**

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/controller/ModelConfigController.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/controller/ModelConfigController.java
@@ -96,12 +96,12 @@ public class ModelConfigController {
 	}
 
 	/**
-	 * 6. 连通性测试 接收前端表单里的配置参数，尝试发起一次真实调用
+	 * 6. 连通性测试 根据配置 ID 从服务端读取完整配置，避免前端回传脱敏凭据
 	 */
-	@PostMapping("/test")
-	public ApiResponse<String> testConnection(@Valid @RequestBody ModelConfigDTO config) {
+	@PostMapping("/test/{id}")
+	public ApiResponse<String> testConnection(@PathVariable Integer id) {
 		try {
-			modelConfigOpsService.testConnection(config);
+			modelConfigOpsService.testConnection(id);
 			return ApiResponse.success("连接测试成功！模型可用。");
 		}
 		catch (Exception e) {

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/mapper/AgentDatasourceTablesMapper.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/mapper/AgentDatasourceTablesMapper.java
@@ -30,6 +30,18 @@ public interface AgentDatasourceTablesMapper {
 	@Select("select table_name from agent_datasource_tables where agent_datasource_id = #{agentDatasourceId}")
 	List<String> getAgentDatasourceTables(@Param("agentDatasourceId") int agentDatasourceId);
 
+	/**
+	 * Get the union of tables selected by every agent that shares a datasource.
+	 */
+	@Select("""
+			SELECT DISTINCT adt.table_name
+			FROM agent_datasource_tables adt
+			JOIN agent_datasource ad ON ad.id = adt.agent_datasource_id
+			WHERE ad.datasource_id = #{datasourceId}
+			ORDER BY adt.table_name
+			""")
+	List<String> getSelectedTablesByDatasourceId(@Param("datasourceId") int datasourceId);
+
 	// 删除当前列表中不存在的表
 	@Delete("<script>" + "DELETE FROM agent_datasource_tables WHERE agent_datasource_id = #{agentDatasourceId}"
 			+ "<if test='tables != null and tables.size() > 0'>" + " AND table_name NOT IN ("

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/mapper/AgentKnowledgeMapper.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/mapper/AgentKnowledgeMapper.java
@@ -131,6 +131,15 @@ public interface AgentKnowledgeMapper {
 			""")
 	List<AgentKnowledge> selectPendingAndRecalled();
 
+	@Update("""
+			UPDATE agent_knowledge
+			SET embedding_status = 'PENDING', error_msg = 'Recovered stale PROCESSING job', updated_time = NOW()
+			WHERE embedding_status = 'PROCESSING'
+			  AND is_deleted = 0
+			  AND updated_time < #{beforeTime}
+			""")
+	int resetStaleProcessing(@Param("beforeTime") LocalDateTime beforeTime);
+
 	/**
 	 * 查询待清理的“僵尸”记录 条件：is_deleted = 1 AND is_resource_cleaned = 0 AND updated_time <(当前时间
 	 * - N分钟)

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/mapper/BusinessKnowledgeMapper.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/mapper/BusinessKnowledgeMapper.java
@@ -18,6 +18,7 @@ package com.alibaba.cloud.ai.dataagent.mapper;
 import com.alibaba.cloud.ai.dataagent.entity.BusinessKnowledge;
 import org.apache.ibatis.annotations.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Mapper
@@ -95,6 +96,15 @@ public interface BusinessKnowledgeMapper {
 			WHERE agent_id = #{agentId} AND is_recall = 1 AND is_deleted = 0
 			""")
 	List<Long> selectRecalledKnowledgeIds(@Param("agentId") Long agentId);
+
+	@Update("""
+			UPDATE business_knowledge
+			SET embedding_status = 'PENDING', error_msg = 'Recovered stale PROCESSING job', updated_time = NOW()
+			WHERE embedding_status = 'PROCESSING'
+			  AND is_deleted = 0
+			  AND updated_time < #{beforeTime}
+			""")
+	int resetStaleProcessing(@Param("beforeTime") LocalDateTime beforeTime);
 
 	@Update("""
 			UPDATE business_knowledge

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/properties/DataAgentProperties.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/properties/DataAgentProperties.java
@@ -278,9 +278,21 @@ public class DataAgentProperties {
 		private int batchDelTopkLimit = 5000;
 
 		/**
+		 * Expected embedding dimension for the configured persistent vector store. A
+		 * value of 0 disables the check, which is useful for the development-only simple
+		 * store.
+		 */
+		private int embeddingDimension = 0;
+
+		/**
 		 * 是否启用混合搜索
 		 */
 		private boolean enableHybridSearch = false;
+
+		/**
+		 * Maximum wait for each hybrid retrieval branch.
+		 */
+		private long hybridSearchTimeoutMs = 3000;
 
 		/**
 		 * Elasticsearch最小分数阈值，用于es执行关键词搜索时过滤相关性较低的文档

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/agent/AgentStartupInitialization.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/agent/AgentStartupInitialization.java
@@ -26,6 +26,7 @@ import com.alibaba.cloud.ai.dataagent.service.business.BusinessKnowledgeService;
 import com.alibaba.cloud.ai.dataagent.service.datasource.AgentDatasourceService;
 import com.alibaba.cloud.ai.dataagent.service.knowledge.AgentKnowledgeService;
 import com.alibaba.cloud.ai.dataagent.service.vectorstore.AgentVectorStoreService;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -34,6 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -67,12 +69,7 @@ public class AgentStartupInitialization implements ApplicationRunner, Disposable
 			// 因为异步可以让初始化过程在后台运行，不会阻塞Spring启动主线程，提高启动速度和响应性；即使初始化很耗时也不会影响主程序正常启动。
 			CompletableFuture.runAsync(() -> {
 				initializePublishedAgents();
-				if (!hasActiveEmbeddingModel()) {
-					log.warn("No active EMBEDDING model configured; pending knowledge will remain pending");
-					return;
-				}
-				embedPendingBusinessKnowledge();
-				embedPendingAgentKnowledge();
+				recoverPendingEmbeddings();
 			}, executorService).exceptionally(throwable -> {
 				log.error("Error during agent initialization: {}", throwable.getMessage());
 				return null;
@@ -82,6 +79,28 @@ public class AgentStartupInitialization implements ApplicationRunner, Disposable
 		catch (Exception e) {
 			log.error("Failed to start agent initialization process", e);
 		}
+	}
+
+	/**
+	 * Recover events lost after transaction commit and jobs left in PROCESSING by a
+	 * process crash. The age guard prevents competing with healthy in-flight work.
+	 */
+	@Scheduled(initialDelayString = "${spring.ai.alibaba.data-agent.embedding-recovery.initial-delay-ms:300000}",
+			fixedDelayString = "${spring.ai.alibaba.data-agent.embedding-recovery.fixed-delay-ms:300000}")
+	public void recoverPendingEmbeddings() {
+		if (!hasActiveEmbeddingModel()) {
+			log.warn("No active EMBEDDING model configured; pending knowledge will remain pending");
+			return;
+		}
+		LocalDateTime staleBefore = LocalDateTime.now().minusMinutes(10);
+		int recoveredBusinessJobs = businessKnowledgeMapper.resetStaleProcessing(staleBefore);
+		int recoveredAgentJobs = agentKnowledgeMapper.resetStaleProcessing(staleBefore);
+		if (recoveredBusinessJobs + recoveredAgentJobs > 0) {
+			log.warn("Recovered {} stale business and {} stale agent embedding jobs", recoveredBusinessJobs,
+					recoveredAgentJobs);
+		}
+		embedPendingBusinessKnowledge();
+		embedPendingAgentKnowledge();
 	}
 
 	private boolean hasActiveEmbeddingModel() {
@@ -155,17 +174,16 @@ public class AgentStartupInitialization implements ApplicationRunner, Disposable
 			}
 
 			Integer datasourceId = activeDatasource.getDatasourceId();
-			if (isAlreadyInitialized(datasourceId)) {
-				log.info("Datasource {} already has schema vector data, skipping initialization for agent {}",
-						datasourceId, agentId);
-				return true;
-			}
-
 			List<String> tables = activeDatasource.getSelectTables();
 
 			if (tables.isEmpty()) {
 				log.warn("Datasource {} has no tables available for agent {}", datasourceId, agentId);
 				return false;
+			}
+
+			if (isAlreadyInitialized(datasourceId, tables)) {
+				log.info("Datasource {} already has all selected schema vectors, skipping initialization", datasourceId);
+				return true;
 			}
 
 			log.info("Initializing agent {} with datasource {} and {} tables", agentId, datasourceId, tables.size());
@@ -189,12 +207,12 @@ public class AgentStartupInitialization implements ApplicationRunner, Disposable
 		}
 	}
 
-	private boolean isAlreadyInitialized(Integer datasourceId) {
+	private boolean isAlreadyInitialized(Integer datasourceId, List<String> tableNames) {
 		try {
-			return agentVectorStoreService.hasSchemaDocuments(String.valueOf(datasourceId));
+			return agentVectorStoreService.hasTableDocuments(datasourceId, tableNames);
 		}
 		catch (Exception e) {
-			log.error("Failed to check initialization status for datasource: {}, assuming not initialized",
+			log.error("Failed to check schema vector initialization for datasource: {}, assuming not initialized",
 					datasourceId, e);
 			return false;
 		}

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/agent/AgentStartupInitialization.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/agent/AgentStartupInitialization.java
@@ -182,7 +182,8 @@ public class AgentStartupInitialization implements ApplicationRunner, Disposable
 			}
 
 			if (isAlreadyInitialized(datasourceId, tables)) {
-				log.info("Datasource {} already has all selected schema vectors, skipping initialization", datasourceId);
+				log.info("Datasource {} already has all selected schema vectors, skipping initialization",
+						datasourceId);
 				return true;
 			}
 

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/EmbeddingModelCompatibilityValidator.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/EmbeddingModelCompatibilityValidator.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.service.aimodelconfig;
+
+import com.alibaba.cloud.ai.dataagent.dto.ModelConfigDTO;
+import com.alibaba.cloud.ai.dataagent.properties.DataAgentProperties;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.stereotype.Component;
+
+/**
+ * Prevents a vector collection from silently mixing embeddings produced by different
+ * model spaces.
+ */
+@Component
+@RequiredArgsConstructor
+public class EmbeddingModelCompatibilityValidator {
+
+	private final DataAgentProperties properties;
+
+	private volatile EmbeddingModel validatedModel;
+
+	public void validateDimension(int actualDimension) {
+		int expectedDimension = properties.getVectorStore().getEmbeddingDimension();
+		if (expectedDimension > 0 && expectedDimension != actualDimension) {
+			throw new IllegalStateException("Embedding dimension " + actualDimension
+					+ " does not match vector-store dimension " + expectedDimension
+					+ ". Use a new collection and rebuild vectors before activating this model.");
+		}
+	}
+
+	public void validateModel(EmbeddingModel model) {
+		if (properties.getVectorStore().getEmbeddingDimension() <= 0 || validatedModel == model) {
+			return;
+		}
+		synchronized (this) {
+			if (validatedModel != model) {
+				validateDimension(model.dimensions());
+				validatedModel = model;
+			}
+		}
+	}
+
+	public void validateModelChange(ModelConfigDTO current, ModelConfigDTO target) {
+		if (current == null || target == null || sameEmbeddingSpace(current, target)) {
+			return;
+		}
+		throw new IllegalStateException("Embedding model hot switch is unsafe for existing vectors. "
+				+ "Create a new versioned collection, rebuild all schema and knowledge vectors, then switch traffic.");
+	}
+
+	private boolean sameEmbeddingSpace(ModelConfigDTO left, ModelConfigDTO right) {
+		return Objects.equals(left.getProvider(), right.getProvider())
+				&& Objects.equals(left.getBaseUrl(), right.getBaseUrl())
+				&& Objects.equals(left.getModelName(), right.getModelName())
+				&& Objects.equals(left.getEmbeddingsPath(), right.getEmbeddingsPath());
+	}
+
+}

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigDataServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigDataServiceImpl.java
@@ -24,6 +24,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -130,7 +131,7 @@ public class ModelConfigDataServiceImpl implements ModelConfigDataService {
 		}
 
 		// 只有当前端传来的 Key 不包含 "****" 时，才说明用户真的改了 Key，否则保持原样
-		if (dto.getApiKey() != null && !dto.getApiKey().contains("****")) {
+		if (StringUtils.hasText(dto.getApiKey()) && !dto.getApiKey().contains("****")) {
 			oldEntity.setApiKey(dto.getApiKey());
 		}
 	}

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigOpsService.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigOpsService.java
@@ -16,6 +16,7 @@
 package com.alibaba.cloud.ai.dataagent.service.aimodelconfig;
 
 import com.alibaba.cloud.ai.dataagent.enums.ModelType;
+import com.alibaba.cloud.ai.dataagent.converter.ModelConfigConverter;
 import com.alibaba.cloud.ai.dataagent.dto.ModelConfigDTO;
 import com.alibaba.cloud.ai.dataagent.entity.ModelConfig;
 import lombok.AllArgsConstructor;
@@ -25,6 +26,8 @@ import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -37,11 +40,19 @@ public class ModelConfigOpsService {
 
 	private final AiModelRegistry aiModelRegistry;
 
+	private final EmbeddingModelCompatibilityValidator embeddingModelCompatibilityValidator;
 	/**
 	 * 专门处理：更新配置并热刷新的聚合逻辑
 	 */
 	@Transactional(rollbackFor = Exception.class)
 	public void updateAndRefresh(ModelConfigDTO dto) {
+		ModelConfigDTO currentEmbedding = null;
+		if (ModelType.EMBEDDING.getCode().equalsIgnoreCase(dto.getModelType())) {
+			currentEmbedding = modelConfigDataService.getActiveConfigByType(ModelType.EMBEDDING);
+			if (currentEmbedding != null && Objects.equals(currentEmbedding.getId(), dto.getId())) {
+				embeddingModelCompatibilityValidator.validateModelChange(currentEmbedding, dto);
+			}
+		}
 		// 1. 更新数据库
 		ModelConfig entity = modelConfigDataService.updateConfigInDb(dto);
 
@@ -68,6 +79,11 @@ public class ModelConfigOpsService {
 		ModelConfig entity = modelConfigDataService.findById(id);
 		if (entity == null) {
 			throw new RuntimeException("配置不存在");
+		}
+		if (ModelType.EMBEDDING.equals(entity.getModelType())) {
+			ModelConfigDTO current = modelConfigDataService.getActiveConfigByType(ModelType.EMBEDDING);
+			ModelConfigDTO target = ModelConfigConverter.toDTO(entity);
+			embeddingModelCompatibilityValidator.validateModelChange(current, target);
 		}
 
 		// 2. 先更新数据库状态，避免缓存清空后并发请求重新加载旧配置
@@ -154,6 +170,7 @@ public class ModelConfigOpsService {
 		if (embedding == null || embedding.length == 0) {
 			throw new RuntimeException("模型生成的向量为空");
 		}
+		embeddingModelCompatibilityValidator.validateDimension(embedding.length);
 		log.info("Embedding Model test passed. Dimension: {}", embedding.length);
 	}
 

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigOpsService.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigOpsService.java
@@ -41,6 +41,7 @@ public class ModelConfigOpsService {
 	private final AiModelRegistry aiModelRegistry;
 
 	private final EmbeddingModelCompatibilityValidator embeddingModelCompatibilityValidator;
+
 	/**
 	 * 专门处理：更新配置并热刷新的聚合逻辑
 	 */

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigOpsService.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigOpsService.java
@@ -115,7 +115,15 @@ public class ModelConfigOpsService {
 	/**
 	 * 测试连接逻辑 注意：这里创建的模型是“临时”的，用完即丢，不会影响当前系统正在运行的模型
 	 */
-	public void testConnection(ModelConfigDTO config) {
+	public void testConnection(Integer id) {
+		ModelConfig entity = modelConfigDataService.findById(id);
+		if (entity == null) {
+			throw new IllegalArgumentException("配置不存在");
+		}
+		testConnection(ModelConfigConverter.toDTO(entity));
+	}
+
+	private void testConnection(ModelConfigDTO config) {
 		String modelType = config.getModelType();
 
 		try {

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/business/BusinessKnowledgeServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/business/BusinessKnowledgeServiceImpl.java
@@ -157,12 +157,8 @@ public class BusinessKnowledgeServiceImpl implements BusinessKnowledgeService {
 	 * 更新向量库中的知识向量
 	 */
 	private void syncToVectorStore(BusinessKnowledge knowledge) {
-		// 先删除旧的向量数据
-		this.doDelVector(knowledge);
-
-		// 添加新的向量数据
 		Document newDocument = DocumentConverterUtil.convertBusinessKnowledgeToDocument(knowledge);
-		agentVectorStoreService.addDocuments(knowledge.getAgentId().toString(), List.of(newDocument));
+		agentVectorStoreService.replaceDocumentsByMetadata(vectorMetadata(knowledge), List.of(newDocument));
 
 		log.info("Successfully updated vector store for knowledge id: {}", knowledge.getId());
 	}
@@ -188,15 +184,15 @@ public class BusinessKnowledgeServiceImpl implements BusinessKnowledgeService {
 	}
 
 	private void doDelVector(BusinessKnowledge knowledge) {
+		agentVectorStoreService.deleteDocumentsByMetadata(knowledge.getAgentId().toString(), vectorMetadata(knowledge));
+	}
+
+	private Map<String, Object> vectorMetadata(BusinessKnowledge knowledge) {
 		Map<String, Object> metadata = new HashMap<>();
 		metadata.put(Constant.AGENT_ID, knowledge.getAgentId().toString());
 		metadata.put(DocumentMetadataConstant.DB_BUSINESS_TERM_ID, knowledge.getId());
 		metadata.put(DocumentMetadataConstant.VECTOR_TYPE, DocumentMetadataConstant.BUSINESS_TERM);
-		if (!Boolean.TRUE
-			.equals(agentVectorStoreService.deleteDocumentsByMetadata(knowledge.getAgentId().toString(), metadata))) {
-			throw new IllegalStateException(
-					"Failed to delete business knowledge from vector store: " + knowledge.getId());
-		}
+		return metadata;
 	}
 
 	@Override
@@ -216,8 +212,6 @@ public class BusinessKnowledgeServiceImpl implements BusinessKnowledgeService {
 
 	@Override
 	public void refreshAllKnowledgeToVectorStore(String agentId) throws Exception {
-		agentVectorStoreService.deleteDocumentsByVectorType(agentId, DocumentMetadataConstant.BUSINESS_TERM);
-
 		// 获取所有 isRecall 等于 1 且未逻辑删除的 BusinessKnowledge
 		List<BusinessKnowledge> allKnowledge = businessKnowledgeMapper.selectAll();
 		List<BusinessKnowledge> recalledKnowledge = allKnowledge.stream()
@@ -231,7 +225,10 @@ public class BusinessKnowledgeServiceImpl implements BusinessKnowledgeService {
 			List<Document> documents = recalledKnowledge.stream()
 				.map(DocumentConverterUtil::convertBusinessKnowledgeToDocument)
 				.toList();
-			agentVectorStoreService.addDocuments(agentId, documents);
+			agentVectorStoreService.replaceDocumentsByMetadata(
+					Map.of(Constant.AGENT_ID, agentId, DocumentMetadataConstant.VECTOR_TYPE,
+							DocumentMetadataConstant.BUSINESS_TERM),
+					documents);
 
 			// 批量更新 embedding_status 为 COMPLETED，避免前端一直显示"等待中"
 			for (BusinessKnowledge knowledge : recalledKnowledge) {
@@ -240,6 +237,9 @@ public class BusinessKnowledgeServiceImpl implements BusinessKnowledgeService {
 				businessKnowledgeMapper.updateById(knowledge);
 			}
 			log.info("Updated {} business knowledge records to COMPLETED status", recalledKnowledge.size());
+		}
+		else {
+			agentVectorStoreService.deleteDocumentsByVectorType(agentId, DocumentMetadataConstant.BUSINESS_TERM);
 		}
 	}
 

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/business/BusinessKnowledgeServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/business/BusinessKnowledgeServiceImpl.java
@@ -225,10 +225,8 @@ public class BusinessKnowledgeServiceImpl implements BusinessKnowledgeService {
 			List<Document> documents = recalledKnowledge.stream()
 				.map(DocumentConverterUtil::convertBusinessKnowledgeToDocument)
 				.toList();
-			agentVectorStoreService.replaceDocumentsByMetadata(
-					Map.of(Constant.AGENT_ID, agentId, DocumentMetadataConstant.VECTOR_TYPE,
-							DocumentMetadataConstant.BUSINESS_TERM),
-					documents);
+			agentVectorStoreService.replaceDocumentsByMetadata(Map.of(Constant.AGENT_ID, agentId,
+					DocumentMetadataConstant.VECTOR_TYPE, DocumentMetadataConstant.BUSINESS_TERM), documents);
 
 			// 批量更新 embedding_status 为 COMPLETED，避免前端一直显示"等待中"
 			for (BusinessKnowledge knowledge : recalledKnowledge) {

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/impl/AgentDatasourceServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/datasource/impl/AgentDatasourceServiceImpl.java
@@ -67,10 +67,12 @@ public class AgentDatasourceServiceImpl implements AgentDatasourceService {
 			// Create SchemaInitRequest
 			SchemaInitRequest schemaInitRequest = new SchemaInitRequest();
 			schemaInitRequest.setDbConfig(dbConfig);
-			schemaInitRequest.setTables(tables);
+			List<String> sharedTables = tablesMapper.getSelectedTablesByDatasourceId(datasourceId);
+			List<String> tablesToInitialize = sharedTables.isEmpty() ? tables : sharedTables;
+			schemaInitRequest.setTables(tablesToInitialize);
 
 			log.info("Created SchemaInitRequest for agent: {}, datasource: {}, tableCount: {}", agentIdStr,
-					datasourceId, tables.size());
+					datasourceId, tablesToInitialize.size());
 
 			// Call the original initialization method
 			return schemaService.schema(datasourceId, schemaInitRequest);

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/hybrid/retrieval/AbstractHybridRetrievalStrategy.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/hybrid/retrieval/AbstractHybridRetrievalStrategy.java
@@ -36,11 +36,19 @@ public abstract class AbstractHybridRetrievalStrategy implements HybridRetrieval
 
 	protected final FusionStrategy fusionStrategy;
 
+	private final long timeoutMs;
+
 	protected AbstractHybridRetrievalStrategy(ExecutorService executorService, VectorStore vectorStore,
 			FusionStrategy fusionStrategy) {
+		this(executorService, vectorStore, fusionStrategy, 3000L);
+	}
+
+	protected AbstractHybridRetrievalStrategy(ExecutorService executorService, VectorStore vectorStore,
+			FusionStrategy fusionStrategy, long timeoutMs) {
 		this.executorService = executorService;
 		this.vectorStore = vectorStore;
 		this.fusionStrategy = fusionStrategy;
+		this.timeoutMs = timeoutMs;
 		log.info(
 				"Initialized AbstractHybridRetrievalStrategy with executorService: {}, vectorStore: {}, fusionStrategy: {}",
 				executorService, vectorStore, fusionStrategy);
@@ -60,7 +68,7 @@ public abstract class AbstractHybridRetrievalStrategy implements HybridRetrieval
 			log.debug("Vector Search completed. Found {} documents for SearchRequest: {}", vectorResults.size(),
 					vectorSearchRequest);
 			return vectorResults;
-		}, executorService);
+		}, executorService).orTimeout(timeoutMs, java.util.concurrent.TimeUnit.MILLISECONDS);
 
 		// 异步执行关键词搜索
 		CompletableFuture<List<Document>> keywordSearchFuture = CompletableFuture.supplyAsync(() -> {
@@ -68,7 +76,12 @@ public abstract class AbstractHybridRetrievalStrategy implements HybridRetrieval
 			log.debug("Keyword Search completed. Found {} documents, with query: {}", results.size(),
 					request.getQuery());
 			return results;
-		}, executorService);
+		}, executorService)
+			.completeOnTimeout(List.of(), timeoutMs, java.util.concurrent.TimeUnit.MILLISECONDS)
+			.exceptionally(error -> {
+				log.warn("Keyword search failed; falling back to vector results: {}", error.getMessage());
+				return List.of();
+			});
 
 		try {
 			List<Document> vectorResults = vectorSearchFuture.get();

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/hybrid/retrieval/impl/ElasticsearchHybridRetrievalStrategy.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/hybrid/retrieval/impl/ElasticsearchHybridRetrievalStrategy.java
@@ -67,6 +67,12 @@ public class ElasticsearchHybridRetrievalStrategy extends AbstractHybridRetrieva
 		this.indexName = "spring-ai-document-index"; // 默认索引名称
 	}
 
+	public ElasticsearchHybridRetrievalStrategy(ExecutorService executorService, VectorStore vectorStore,
+			FusionStrategy fusionStrategy, long timeoutMs) {
+		super(executorService, vectorStore, fusionStrategy, timeoutMs);
+		this.indexName = "spring-ai-document-index";
+	}
+
 	@Override
 	public List<Document> getDocumentsByKeywords(HybridSearchRequest request) {
 		if (!StringUtils.hasText(request.getQuery())) {

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/knowledge/AgentKnowledgeResourceManager.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/knowledge/AgentKnowledgeResourceManager.java
@@ -53,9 +53,6 @@ public class AgentKnowledgeResourceManager {
 	}
 
 	public void doEmbedingToVectorStore(AgentKnowledge agentKnowledge) throws Exception {
-		// delete old data
-		this.deleteFromVectorStore(agentKnowledge.getAgentId(), agentKnowledge.getId());
-
 		if (KnowledgeType.QA.equals(agentKnowledge.getType()) || KnowledgeType.FAQ.equals(agentKnowledge.getType())) {
 			processQaKnowledge(agentKnowledge);
 		}
@@ -69,7 +66,7 @@ public class AgentKnowledgeResourceManager {
 
 	private void processQaKnowledge(AgentKnowledge knowledge) {
 		Document document = DocumentConverterUtil.convertQaFaqKnowledgeToDocument(knowledge);
-		agentVectorStoreService.addDocuments(knowledge.getAgentId().toString(), List.of(document));
+		agentVectorStoreService.replaceDocumentsByMetadata(replacementMetadata(knowledge), List.of(document));
 		log.info("Successfully vectorized AgentKnowledge: id={}, type={}", knowledge.getId(), knowledge.getType());
 	}
 
@@ -88,10 +85,18 @@ public class AgentKnowledgeResourceManager {
 			.convertAgentKnowledgeDocumentsWithMetadata(documents, knowledge);
 
 		// 添加到向量存储
-		agentVectorStoreService.addDocuments(knowledge.getAgentId().toString(), documentsWithMetadata);
+		agentVectorStoreService.replaceDocumentsByMetadata(replacementMetadata(knowledge), documentsWithMetadata);
 		log.info("Successfully vectorized DOCUMENT knowledge: id={}, filePath={}, documentCount={}, splitterType={}",
 				knowledge.getId(), knowledge.getFilePath(), documentsWithMetadata.size(), knowledge.getSplitterType());
 
+	}
+
+	private Map<String, Object> replacementMetadata(AgentKnowledge knowledge) {
+		Map<String, Object> metadata = new HashMap<>();
+		metadata.put(Constant.AGENT_ID, knowledge.getAgentId().toString());
+		metadata.put(DocumentMetadataConstant.DB_AGENT_KNOWLEDGE_ID, knowledge.getId());
+		metadata.put(DocumentMetadataConstant.VECTOR_TYPE, DocumentMetadataConstant.AGENT_KNOWLEDGE);
+		return metadata;
 	}
 
 	private List<Document> getAndSplitDocument(String filePath, String splitterType) {
@@ -121,7 +126,6 @@ public class AgentKnowledgeResourceManager {
 			Map<String, Object> metadata = new HashMap<>();
 			metadata.put(Constant.AGENT_ID, agentId.toString());
 			metadata.put(DocumentMetadataConstant.DB_AGENT_KNOWLEDGE_ID, knowledgeId);
-
 			if (!Boolean.TRUE.equals(agentVectorStoreService.deleteDocumentsByMetadata(agentId.toString(), metadata))) {
 				return false;
 			}

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/schema/SchemaServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/schema/SchemaServiceImpl.java
@@ -39,7 +39,6 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.embedding.BatchingStrategy;
-import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.filter.Filter;
 import org.springframework.ai.vectorstore.filter.FilterExpressionBuilder;
 import org.springframework.stereotype.Service;
@@ -138,11 +137,6 @@ public class SchemaServiceImpl implements SchemaService {
 			// 根据当前DbConfig获取Accessor
 			Accessor dbAccessor = accessorFactory.getAccessorByDbConfig(config);
 
-			// 清理旧数据
-			log.info("Clearing existing schema data for datasource: {}", datasourceId);
-			clearSchemaDataForDatasource(datasourceId);
-			log.debug("Successfully cleared existing schema data for datasource: {}", datasourceId);
-
 			// 处理外键
 			log.debug("Fetching foreign keys for datasource: {}", datasourceId);
 			List<ForeignKeyInfoBO> foreignKeys = dbAccessor.showForeignKeys(config, dqp);
@@ -176,7 +170,7 @@ public class SchemaServiceImpl implements SchemaService {
 			// 存储文档
 			log.info("Storing  columns and {} tables for datasource: {}", columnDocs.size(), tableDocs.size(),
 					datasourceId);
-			storeSchemaDocuments(datasourceId, columnDocs, tableDocs);
+			replaceSchemaDocuments(datasourceId, columnDocs, tableDocs);
 			log.info("Successfully stored all documents for datasource: {}", datasourceId);
 			return true;
 		}
@@ -259,6 +253,17 @@ public class SchemaServiceImpl implements SchemaService {
 
 	}
 
+	protected void replaceSchemaDocuments(Integer datasourceId, List<Document> columns, List<Document> tables) {
+		List<Document> replacementDocuments = new ArrayList<>(columns.size() + tables.size());
+		replacementDocuments.addAll(columns);
+		replacementDocuments.addAll(tables);
+		if (replacementDocuments.isEmpty()) {
+			throw new IllegalStateException("Refusing to replace existing schema vectors with an empty schema");
+		}
+		agentVectorStoreService.replaceDocumentsByMetadata(
+				Map.of(Constant.DATASOURCE_ID, datasourceId.toString()), replacementDocuments);
+	}
+
 	protected Map<String, List<String>> buildForeignKeyMap(List<ForeignKeyInfoBO> foreignKeys) {
 		Map<String, List<String>> map = new HashMap<>();
 		for (ForeignKeyInfoBO fk : foreignKeys) {
@@ -298,15 +303,7 @@ public class SchemaServiceImpl implements SchemaService {
 
 		Filter.Expression filterExpression = DynamicFilterService.combineWithAnd(conditions);
 
-		// 执行向量检索
-		SearchRequest searchRequest = SearchRequest.builder()
-			.query(query)
-			.topK(tableTopK)
-			.similarityThreshold(tableThreshold)
-			.filterExpression(filterExpression)
-			.build();
-
-		return agentVectorStoreService.getDocumentsOnlyByFilter(filterExpression, tableTopK);
+		return agentVectorStoreService.similaritySearch(query, filterExpression, tableTopK, tableThreshold);
 	}
 
 	private List<String> getMissingTableNamesWithForeignKeySet(List<Document> tableDocuments,

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/schema/SchemaServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/schema/SchemaServiceImpl.java
@@ -260,8 +260,8 @@ public class SchemaServiceImpl implements SchemaService {
 		if (replacementDocuments.isEmpty()) {
 			throw new IllegalStateException("Refusing to replace existing schema vectors with an empty schema");
 		}
-		agentVectorStoreService.replaceDocumentsByMetadata(
-				Map.of(Constant.DATASOURCE_ID, datasourceId.toString()), replacementDocuments);
+		agentVectorStoreService.replaceDocumentsByMetadata(Map.of(Constant.DATASOURCE_ID, datasourceId.toString()),
+				replacementDocuments);
 	}
 
 	protected Map<String, List<String>> buildForeignKeyMap(List<ForeignKeyInfoBO> foreignKeys) {

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/vector/MetadataDocumentRetriever.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/vector/MetadataDocumentRetriever.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.service.vector;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
+import io.milvus.client.MilvusServiceClient;
+import io.milvus.common.clientenum.ConsistencyLevelEnum;
+import io.milvus.grpc.QueryResults;
+import io.milvus.param.R;
+import io.milvus.param.dml.QueryParam;
+import io.milvus.response.QueryResultsWrapper;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.ai.vectorstore.elasticsearch.ElasticsearchAiSearchFilterExpressionConverter;
+import org.springframework.ai.vectorstore.elasticsearch.ElasticsearchVectorStore;
+import org.springframework.ai.vectorstore.filter.Filter;
+import org.springframework.ai.vectorstore.milvus.MilvusVectorStore;
+import org.springframework.ai.vectorstore.observation.VectorStoreObservationContext;
+import com.alibaba.cloud.ai.dataagent.service.vectorstore.MetadataAwareSimpleVectorStore;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+/** Provider-specific exact metadata retrieval without creating a query embedding. */
+@Component
+public class MetadataDocumentRetriever {
+
+	private final Environment environment;
+
+	public MetadataDocumentRetriever(Environment environment) {
+		this.environment = environment;
+	}
+
+	public List<Document> find(VectorStore vectorStore, Filter.Expression filterExpression, int limit) {
+		if (vectorStore instanceof MetadataAwareSimpleVectorStore simpleVectorStore) {
+			return simpleVectorStore.findByFilter(filterExpression, limit);
+		}
+		if (vectorStore instanceof MilvusVectorStore milvusVectorStore) {
+			return findInMilvus(milvusVectorStore, filterExpression, limit);
+		}
+		if (vectorStore instanceof ElasticsearchVectorStore elasticsearchVectorStore) {
+			return findInElasticsearch(elasticsearchVectorStore, filterExpression, limit);
+		}
+		throw new IllegalArgumentException("Exact metadata retrieval is not supported for "
+				+ vectorStore.getClass().getName());
+	}
+
+	private List<Document> findInMilvus(MilvusVectorStore vectorStore, Filter.Expression filterExpression,
+			int limit) {
+		VectorStoreObservationContext context = vectorStore.createObservationContextBuilder("metadata-query").build();
+		String idField = environment.getProperty("spring.ai.vectorstore.milvus.id-field-name",
+				MilvusVectorStore.DOC_ID_FIELD_NAME);
+		String contentField = environment.getProperty("spring.ai.vectorstore.milvus.content-field-name",
+				MilvusVectorStore.CONTENT_FIELD_NAME);
+		String metadataField = environment.getProperty("spring.ai.vectorstore.milvus.metadata-field-name",
+				MilvusVectorStore.METADATA_FIELD_NAME);
+		MilvusServiceClient client = vectorStore.<MilvusServiceClient>getNativeClient()
+			.orElseThrow(() -> new IllegalStateException("Milvus native client is unavailable"));
+		QueryParam query = QueryParam.newBuilder()
+			.withDatabaseName(context.getNamespace())
+			.withCollectionName(context.getCollectionName())
+			.withConsistencyLevel(ConsistencyLevelEnum.STRONG)
+			.withOutFields(List.of(idField, contentField, metadataField))
+			.withExpr(vectorStore.filterExpressionConverter.convertExpression(filterExpression))
+			.withLimit((long) limit)
+			.build();
+		R<QueryResults> response = client.query(query);
+		if (response.getException() != null) {
+			throw new IllegalStateException("Milvus metadata query failed", response.getException());
+		}
+		Gson gson = new Gson();
+		Type metadataType = new TypeToken<Map<String, Object>>() {
+		}.getType();
+		return new QueryResultsWrapper(response.getData()).getRowRecords().stream().map(row -> {
+			JsonObject metadata = (JsonObject) row.get(metadataField);
+			return Document.builder()
+				.id(String.valueOf(row.get(idField)))
+				.text((String) row.get(contentField))
+				.metadata(metadata == null ? Map.of() : gson.fromJson(metadata, metadataType))
+				.build();
+		}).toList();
+	}
+
+	private List<Document> findInElasticsearch(ElasticsearchVectorStore vectorStore,
+			Filter.Expression filterExpression, int limit) {
+		var client = vectorStore.<co.elastic.clients.elasticsearch.ElasticsearchClient>getNativeClient()
+			.orElseThrow(() -> new IllegalStateException("Elasticsearch native client is unavailable"));
+		String indexName = vectorStore.createObservationContextBuilder("metadata-query").build().getCollectionName();
+		String query = new ElasticsearchAiSearchFilterExpressionConverter().convertExpression(filterExpression);
+		try {
+			return client.search(search -> search.index(indexName)
+				.query(q -> q.queryString(qs -> qs.query(query)))
+				.size(limit), Document.class).hits().hits().stream().map(hit -> hit.source()).filter(Objects::nonNull)
+				.toList();
+		}
+		catch (IOException ex) {
+			throw new IllegalStateException("Elasticsearch metadata query failed", ex);
+		}
+	}
+
+}

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/vector/MetadataDocumentRetriever.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/vector/MetadataDocumentRetriever.java
@@ -61,12 +61,11 @@ public class MetadataDocumentRetriever {
 		if (vectorStore instanceof ElasticsearchVectorStore elasticsearchVectorStore) {
 			return findInElasticsearch(elasticsearchVectorStore, filterExpression, limit);
 		}
-		throw new IllegalArgumentException("Exact metadata retrieval is not supported for "
-				+ vectorStore.getClass().getName());
+		throw new IllegalArgumentException(
+				"Exact metadata retrieval is not supported for " + vectorStore.getClass().getName());
 	}
 
-	private List<Document> findInMilvus(MilvusVectorStore vectorStore, Filter.Expression filterExpression,
-			int limit) {
+	private List<Document> findInMilvus(MilvusVectorStore vectorStore, Filter.Expression filterExpression, int limit) {
 		VectorStoreObservationContext context = vectorStore.createObservationContextBuilder("metadata-query").build();
 		String idField = environment.getProperty("spring.ai.vectorstore.milvus.id-field-name",
 				MilvusVectorStore.DOC_ID_FIELD_NAME);
@@ -101,16 +100,21 @@ public class MetadataDocumentRetriever {
 		}).toList();
 	}
 
-	private List<Document> findInElasticsearch(ElasticsearchVectorStore vectorStore,
-			Filter.Expression filterExpression, int limit) {
+	private List<Document> findInElasticsearch(ElasticsearchVectorStore vectorStore, Filter.Expression filterExpression,
+			int limit) {
 		var client = vectorStore.<co.elastic.clients.elasticsearch.ElasticsearchClient>getNativeClient()
 			.orElseThrow(() -> new IllegalStateException("Elasticsearch native client is unavailable"));
 		String indexName = vectorStore.createObservationContextBuilder("metadata-query").build().getCollectionName();
 		String query = new ElasticsearchAiSearchFilterExpressionConverter().convertExpression(filterExpression);
 		try {
-			return client.search(search -> search.index(indexName)
-				.query(q -> q.queryString(qs -> qs.query(query)))
-				.size(limit), Document.class).hits().hits().stream().map(hit -> hit.source()).filter(Objects::nonNull)
+			return client
+				.search(search -> search.index(indexName).query(q -> q.queryString(qs -> qs.query(query))).size(limit),
+						Document.class)
+				.hits()
+				.hits()
+				.stream()
+				.map(hit -> hit.source())
+				.filter(Objects::nonNull)
 				.toList();
 		}
 		catch (IOException ex) {

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/AgentVectorStoreService.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/AgentVectorStoreService.java
@@ -33,6 +33,14 @@ public interface AgentVectorStoreService {
 
 	Boolean deleteDocumentsByMetadata(String agentId, Map<String, Object> metadata);
 
+	/**
+	 * @deprecated use {@link #deleteDocumentsByMetadata(String, Map)}.
+	 */
+	@Deprecated
+	default Boolean deleteDocumentsByMetedata(String agentId, Map<String, Object> metadata) {
+		return deleteDocumentsByMetadata(agentId, metadata);
+	}
+
 	Boolean deleteDocumentsByMetadata(Map<String, Object> metadata);
 
 	/**
@@ -42,10 +50,28 @@ public interface AgentVectorStoreService {
 
 	List<Document> getDocumentsForAgent(String agentId, String query, String vectorType, int topK, double threshold);
 
+	/**
+	 * Execute a semantic search with an already-built metadata filter.
+	 */
+	List<Document> similaritySearch(String query, Filter.Expression filterExpression, int topK, double threshold);
+
 	// 通过元数据过滤精确查找
 	List<Document> getDocumentsOnlyByFilter(Filter.Expression filterExpression, Integer topK);
 
+	/** @deprecated use {@link #hasTableDocuments(Integer, List)}. */
+	@Deprecated
 	boolean hasSchemaDocuments(String datasourceId);
+
+	/**
+	 * Check whether all selected tables have schema vectors for the datasource.
+	 */
+	boolean hasTableDocuments(Integer datasourceId, List<String> tableNames);
+
+	/**
+	 * Replace all documents selected by metadata without deleting the currently usable
+	 * documents before the new vectors have been written successfully.
+	 */
+	void replaceDocumentsByMetadata(Map<String, Object> metadata, List<Document> documents);
 
 	void addDocuments(String agentId, List<Document> documents);
 

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/AgentVectorStoreService.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/AgentVectorStoreService.java
@@ -58,7 +58,9 @@ public interface AgentVectorStoreService {
 	// 通过元数据过滤精确查找
 	List<Document> getDocumentsOnlyByFilter(Filter.Expression filterExpression, Integer topK);
 
-	/** @deprecated use {@link #hasTableDocuments(Integer, List)}. */
+	/**
+	 * @deprecated use {@link #hasTableDocuments(Integer, List)}.
+	 */
 	@Deprecated
 	boolean hasSchemaDocuments(String datasourceId);
 

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/AgentVectorStoreServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/AgentVectorStoreServiceImpl.java
@@ -21,12 +21,16 @@ import com.alibaba.cloud.ai.dataagent.properties.DataAgentProperties;
 import com.alibaba.cloud.ai.dataagent.dto.search.AgentSearchRequest;
 import com.alibaba.cloud.ai.dataagent.dto.search.HybridSearchRequest;
 import com.alibaba.cloud.ai.dataagent.service.hybrid.retrieval.HybridRetrievalStrategy;
+import com.alibaba.cloud.ai.dataagent.service.vector.MetadataDocumentRetriever;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.SimpleVectorStore;
 import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.ai.vectorstore.filter.Filter;
+import org.springframework.ai.vectorstore.filter.FilterExpressionTextParser;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
@@ -38,8 +42,6 @@ import static com.alibaba.cloud.ai.dataagent.service.vectorstore.DynamicFilterSe
 @Service
 public class AgentVectorStoreServiceImpl implements AgentVectorStoreService {
 
-	private static final String DEFAULT = "default";
-
 	private final VectorStore vectorStore;
 
 	private final Optional<HybridRetrievalStrategy> hybridRetrievalStrategy;
@@ -48,14 +50,24 @@ public class AgentVectorStoreServiceImpl implements AgentVectorStoreService {
 
 	private final DynamicFilterService dynamicFilterService;
 
+	private final MetadataDocumentRetriever metadataDocumentRetriever;
+
+	@Autowired
 	public AgentVectorStoreServiceImpl(VectorStore vectorStore,
 			Optional<HybridRetrievalStrategy> hybridRetrievalStrategy, DataAgentProperties dataAgentProperties,
-			DynamicFilterService dynamicFilterService) {
+			DynamicFilterService dynamicFilterService, MetadataDocumentRetriever metadataDocumentRetriever) {
 		this.vectorStore = vectorStore;
 		this.hybridRetrievalStrategy = hybridRetrievalStrategy;
 		this.dataAgentProperties = dataAgentProperties;
 		this.dynamicFilterService = dynamicFilterService;
+		this.metadataDocumentRetriever = metadataDocumentRetriever;
 		log.info("VectorStore type: {}", vectorStore.getClass().getSimpleName());
+	}
+
+	AgentVectorStoreServiceImpl(VectorStore vectorStore, Optional<HybridRetrievalStrategy> hybridRetrievalStrategy,
+			DataAgentProperties dataAgentProperties, DynamicFilterService dynamicFilterService) {
+		this(vectorStore, hybridRetrievalStrategy, dataAgentProperties, dynamicFilterService,
+				new MetadataDocumentRetriever(new StandardEnvironment()));
 	}
 
 	@Override
@@ -106,7 +118,11 @@ public class AgentVectorStoreServiceImpl implements AgentVectorStoreService {
 	public void addDocuments(String agentId, List<Document> documents) {
 		Assert.notNull(agentId, "AgentId cannot be null.");
 		Assert.notEmpty(documents, "Documents cannot be empty.");
+		validateDocumentMetadata(agentId, documents);
+		vectorStore.add(documents);
+	}
 
+	private void validateDocumentMetadata(String ownerId, List<Document> documents) {
 		// 验证文档中 metadata 的一致性
 		for (Document document : documents) {
 			Assert.notNull(document.getMetadata(), "Document metadata cannot be null.");
@@ -119,16 +135,17 @@ public class AgentVectorStoreServiceImpl implements AgentVectorStoreService {
 				// 表和列必须包含 datasourceId
 				Assert.isTrue(document.getMetadata().containsKey(Constant.DATASOURCE_ID),
 						"Document metadata must contain datasourceId for TABLE/COLUMN type.");
+				Assert.isTrue(ownerId.equals(document.getMetadata().get(Constant.DATASOURCE_ID).toString()),
+						"Document metadata datasourceId does not match.");
 			}
 			else {
 				// 知识库和业务术语必须包含 agentId
 				Assert.isTrue(document.getMetadata().containsKey(Constant.AGENT_ID),
 						"Document metadata must contain agentId.");
-				Assert.isTrue(document.getMetadata().get(Constant.AGENT_ID).equals(agentId),
+				Assert.isTrue(document.getMetadata().get(Constant.AGENT_ID).equals(ownerId),
 						"Document metadata agentId does not match.");
 			}
 		}
-		vectorStore.add(documents);
 	}
 
 	@Override
@@ -205,12 +222,8 @@ public class AgentVectorStoreServiceImpl implements AgentVectorStoreService {
 		int totalDeleted = 0;
 
 		do {
-			batch = vectorStore.similaritySearch(org.springframework.ai.vectorstore.SearchRequest.builder()
-				.query(DEFAULT)// 使用默认的查询字符串，因为有的嵌入模型不支持空字符串
-				.filterExpression(filterExpression)
-				.similarityThreshold(0.0)// 设置最低相似度阈值以获取元数据匹配的所有文档
-				.topK(dataAgentProperties.getVectorStore().getBatchDelTopkLimit())
-				.build());
+			batch = metadataDocumentRetriever.find(vectorStore, new FilterExpressionTextParser().parse(filterExpression),
+					dataAgentProperties.getVectorStore().getBatchDelTopkLimit());
 
 			// 过滤掉已经处理过的文档，只删除未处理的文档
 			List<String> idsToDelete = new ArrayList<>();
@@ -259,29 +272,118 @@ public class AgentVectorStoreServiceImpl implements AgentVectorStoreService {
 	}
 
 	@Override
-	public List<Document> getDocumentsOnlyByFilter(Filter.Expression filterExpression, Integer topK) {
-		Assert.notNull(filterExpression, "filterExpression cannot be null.");
-		if (topK == null)
-			topK = dataAgentProperties.getVectorStore().getDefaultTopkLimit();
+	public List<Document> similaritySearch(String query, Filter.Expression filterExpression, int topK,
+			double threshold) {
+		Assert.hasText(query, "Query cannot be empty.");
+		Assert.notNull(filterExpression, "Filter expression cannot be null.");
+		Assert.isTrue(topK > 0, "TopK must be greater than zero.");
+		Assert.isTrue(threshold >= 0.0 && threshold <= 1.0, "Similarity threshold must be between 0 and 1.");
+
 		SearchRequest searchRequest = SearchRequest.builder()
-			.query(DEFAULT)
+			.query(query)
 			.topK(topK)
 			.filterExpression(filterExpression)
-			.similarityThreshold(0.0)
+			.similarityThreshold(threshold)
 			.build();
 		return vectorStore.similaritySearch(searchRequest);
 	}
 
 	@Override
+	public List<Document> getDocumentsOnlyByFilter(Filter.Expression filterExpression, Integer topK) {
+		Assert.notNull(filterExpression, "filterExpression cannot be null.");
+		if (topK == null)
+			topK = dataAgentProperties.getVectorStore().getDefaultTopkLimit();
+		return metadataDocumentRetriever.find(vectorStore, filterExpression, topK);
+	}
+
+	@Override
 	public boolean hasSchemaDocuments(String datasourceId) {
-		// 类似 MySQL 的 LIMIT 1,只检查是否存在文档
-		List<Document> docs = vectorStore.similaritySearch(org.springframework.ai.vectorstore.SearchRequest.builder()
-			.query(DEFAULT)// 使用默认的查询字符串，因为有的嵌入模型不支持空字符串
-			.filterExpression(buildFilterExpressionString(Map.of(Constant.DATASOURCE_ID, datasourceId)))
-			.topK(1) // 只获取1个文档
-			.similarityThreshold(0.0)
-			.build());
-		return !docs.isEmpty();
+		Filter.Expression filter = new FilterExpressionTextParser()
+			.parse(buildFilterExpressionString(Map.of(Constant.DATASOURCE_ID, datasourceId)));
+		return !getDocumentsOnlyByFilter(filter, 1).isEmpty();
+	}
+
+	@Override
+	public boolean hasTableDocuments(Integer datasourceId, List<String> tableNames) {
+		Assert.notNull(datasourceId, "DatasourceId cannot be null.");
+		Assert.notEmpty(tableNames, "Table names cannot be empty.");
+		Filter.Expression filter = DynamicFilterService.buildFilterExpressionForSearchTables(datasourceId, tableNames);
+		List<Document> documents = getDocumentsOnlyByFilter(filter, tableNames.size() + 5);
+		Set<String> storedTableNames = documents.stream()
+			.map(document -> document.getMetadata().get(DocumentMetadataConstant.NAME))
+			.filter(Objects::nonNull)
+			.map(Object::toString)
+			.collect(java.util.stream.Collectors.toSet());
+		return storedTableNames.containsAll(tableNames);
+	}
+
+	@Override
+	public void replaceDocumentsByMetadata(Map<String, Object> metadata, List<Document> documents) {
+		Assert.notEmpty(metadata, "Metadata cannot be empty.");
+		Assert.notEmpty(documents, "Replacement documents cannot be empty.");
+		String filterExpression = buildFilterExpressionString(metadata);
+		List<Document> oldDocuments = getDocumentsOnlyByFilter(new FilterExpressionTextParser().parse(filterExpression),
+				dataAgentProperties.getVectorStore().getBatchDelTopkLimit());
+		if (oldDocuments.size() >= dataAgentProperties.getVectorStore().getBatchDelTopkLimit()) {
+			throw new IllegalStateException("Too many existing vector documents to replace safely; increase batch-del-topk-limit");
+		}
+
+		Object ownerId = metadata.getOrDefault(Constant.AGENT_ID, metadata.get(Constant.DATASOURCE_ID));
+		Assert.notNull(ownerId, "Replacement metadata must contain agentId or datasourceId.");
+		validateReplacementMetadata(metadata, documents);
+		validateDocumentMetadata(ownerId.toString(), documents);
+		Set<String> oldDocumentIdSet = oldDocuments.stream()
+			.map(Document::getId)
+			.collect(java.util.stream.Collectors.toSet());
+		List<Document> replacementDocuments = ensureFreshDocumentIds(documents, oldDocumentIdSet);
+		List<String> newDocumentIds = replacementDocuments.stream().map(Document::getId).toList();
+		Set<String> newDocumentIdSet = new HashSet<>(newDocumentIds);
+		try {
+			vectorStore.add(replacementDocuments);
+			List<String> oldDocumentIds = oldDocuments.stream()
+				.map(Document::getId)
+				.filter(id -> !newDocumentIdSet.contains(id))
+				.toList();
+			if (!oldDocumentIds.isEmpty()) {
+				vectorStore.delete(oldDocumentIds);
+			}
+		}
+		catch (Exception replacementFailure) {
+			try {
+				if (!newDocumentIds.isEmpty()) {
+					vectorStore.delete(newDocumentIds);
+				}
+			}
+			catch (Exception rollbackFailure) {
+				replacementFailure.addSuppressed(rollbackFailure);
+			}
+			throw replacementFailure;
+		}
+	}
+
+	private void validateReplacementMetadata(Map<String, Object> identityMetadata, List<Document> documents) {
+		for (Document document : documents) {
+			for (Map.Entry<String, Object> identity : identityMetadata.entrySet()) {
+				Assert.isTrue(Objects.equals(identity.getValue(), document.getMetadata().get(identity.getKey())),
+						"Replacement document metadata does not match identity key: " + identity.getKey());
+			}
+		}
+	}
+
+	private List<Document> ensureFreshDocumentIds(List<Document> documents, Set<String> oldDocumentIds) {
+		Set<String> assignedIds = new HashSet<>();
+		return documents.stream().map(document -> {
+			String id = document.getId();
+			if (oldDocumentIds.contains(id) || !assignedIds.add(id)) {
+				String freshId;
+				do {
+					freshId = UUID.randomUUID().toString();
+				}
+				while (oldDocumentIds.contains(freshId) || !assignedIds.add(freshId));
+				return document.mutate().id(freshId).build();
+			}
+			return document;
+		}).toList();
 	}
 
 }

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/AgentVectorStoreServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/AgentVectorStoreServiceImpl.java
@@ -222,7 +222,8 @@ public class AgentVectorStoreServiceImpl implements AgentVectorStoreService {
 		int totalDeleted = 0;
 
 		do {
-			batch = metadataDocumentRetriever.find(vectorStore, new FilterExpressionTextParser().parse(filterExpression),
+			batch = metadataDocumentRetriever.find(vectorStore,
+					new FilterExpressionTextParser().parse(filterExpression),
 					dataAgentProperties.getVectorStore().getBatchDelTopkLimit());
 
 			// 过滤掉已经处理过的文档，只删除未处理的文档
@@ -325,7 +326,8 @@ public class AgentVectorStoreServiceImpl implements AgentVectorStoreService {
 		List<Document> oldDocuments = getDocumentsOnlyByFilter(new FilterExpressionTextParser().parse(filterExpression),
 				dataAgentProperties.getVectorStore().getBatchDelTopkLimit());
 		if (oldDocuments.size() >= dataAgentProperties.getVectorStore().getBatchDelTopkLimit()) {
-			throw new IllegalStateException("Too many existing vector documents to replace safely; increase batch-del-topk-limit");
+			throw new IllegalStateException(
+					"Too many existing vector documents to replace safely; increase batch-del-topk-limit");
 		}
 
 		Object ownerId = metadata.getOrDefault(Constant.AGENT_ID, metadata.get(Constant.DATASOURCE_ID));

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/MetadataAwareSimpleVectorStore.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/MetadataAwareSimpleVectorStore.java
@@ -16,7 +16,12 @@
 package com.alibaba.cloud.ai.dataagent.service.vectorstore;
 
 import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.document.Document;
 import org.springframework.ai.vectorstore.SimpleVectorStore;
+import org.springframework.ai.vectorstore.filter.Filter;
+import org.springframework.ai.vectorstore.filter.converter.SimpleVectorStoreFilterExpressionConverter;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
 
 import java.util.List;
 import java.util.Map;
@@ -32,6 +37,11 @@ import java.util.Map;
  */
 public final class MetadataAwareSimpleVectorStore extends SimpleVectorStore {
 
+	private final SpelExpressionParser expressionParser = new SpelExpressionParser();
+
+	private final SimpleVectorStoreFilterExpressionConverter filterConverter =
+			new SimpleVectorStoreFilterExpressionConverter();
+
 	public MetadataAwareSimpleVectorStore(EmbeddingModel embeddingModel) {
 		super(SimpleVectorStore.builder(embeddingModel));
 	}
@@ -44,6 +54,21 @@ public final class MetadataAwareSimpleVectorStore extends SimpleVectorStore {
 			.toList();
 		doDelete(ids);
 		return ids.size();
+	}
+
+	public List<Document> findByFilter(Filter.Expression filterExpression, int limit) {
+		var expression = expressionParser.parseExpression(filterConverter.convertExpression(filterExpression));
+		return store.values().stream().filter(content -> {
+			StandardEvaluationContext context = new StandardEvaluationContext();
+			context.setVariable("metadata", content.getMetadata());
+			return Boolean.TRUE.equals(expression.getValue(context, Boolean.class));
+		}).limit(limit)
+			.map(content -> Document.builder()
+				.id(content.getId())
+				.text(content.getText())
+				.metadata(content.getMetadata())
+				.build())
+			.toList();
 	}
 
 	private boolean matches(Map<String, Object> documentMetadata, Map<String, Object> expectedMetadata) {

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/MetadataAwareSimpleVectorStore.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/MetadataAwareSimpleVectorStore.java
@@ -39,8 +39,7 @@ public final class MetadataAwareSimpleVectorStore extends SimpleVectorStore {
 
 	private final SpelExpressionParser expressionParser = new SpelExpressionParser();
 
-	private final SimpleVectorStoreFilterExpressionConverter filterConverter =
-			new SimpleVectorStoreFilterExpressionConverter();
+	private final SimpleVectorStoreFilterExpressionConverter filterConverter = new SimpleVectorStoreFilterExpressionConverter();
 
 	public MetadataAwareSimpleVectorStore(EmbeddingModel embeddingModel) {
 		super(SimpleVectorStore.builder(embeddingModel));
@@ -62,7 +61,8 @@ public final class MetadataAwareSimpleVectorStore extends SimpleVectorStore {
 			StandardEvaluationContext context = new StandardEvaluationContext();
 			context.setVariable("metadata", content.getMetadata());
 			return Boolean.TRUE.equals(expression.getValue(context, Boolean.class));
-		}).limit(limit)
+		})
+			.limit(limit)
 			.map(content -> Document.builder()
 				.id(content.getId())
 				.text(content.getText())

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/SimpleVectorStoreInitialization.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/SimpleVectorStoreInitialization.java
@@ -27,6 +27,8 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.AtomicMoveNotSupportedException;
 
 /**
  * @author David Yu
@@ -58,18 +60,32 @@ public class SimpleVectorStoreInitialization implements ApplicationRunner, Dispo
 	public void save() {
 		log.info("Serialize the vector database to a local file.");
 		Path path = Paths.get(properties.getVectorStore().getFilePath());
+		Path temporaryFile = null;
 
 		try {
-			Files.createDirectories(path.getParent());
-
-			if (!Files.exists(path)) {
-				Files.createFile(path);
+			Path parent = path.toAbsolutePath().getParent();
+			Files.createDirectories(parent);
+			temporaryFile = Files.createTempFile(parent, "vectorstore-", ".tmp");
+			vectorStore.save(temporaryFile.toFile());
+			try {
+				Files.move(temporaryFile, path, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
 			}
-
-			vectorStore.save(path.toFile());
+			catch (AtomicMoveNotSupportedException unsupported) {
+				Files.move(temporaryFile, path, StandardCopyOption.REPLACE_EXISTING);
+			}
 		}
 		catch (Throwable t) {
 			log.error("An exception occurred while serializing the vector database to a local file.", t);
+		}
+		finally {
+			if (temporaryFile != null) {
+				try {
+					Files.deleteIfExists(temporaryFile);
+				}
+				catch (Exception cleanupError) {
+					log.warn("Failed to remove temporary vector-store file: {}", temporaryFile, cleanupError);
+				}
+			}
 		}
 	}
 

--- a/data-agent-management/src/main/resources/application-elasticsearch.yml
+++ b/data-agent-management/src/main/resources/application-elasticsearch.yml
@@ -10,3 +10,7 @@ spring:
         index-name: ${ELASTICSEARCH_INDEX_NAME:spring-ai-document-index}
         dimensions: ${ELASTICSEARCH_DIMENSIONS:1024}
         initialize-schema: ${ELASTICSEARCH_INITIALIZE_SCHEMA:true}
+    alibaba:
+      data-agent:
+        vector-store:
+          embedding-dimension: ${ELASTICSEARCH_DIMENSIONS:1024}

--- a/data-agent-management/src/main/resources/application-milvus.yml
+++ b/data-agent-management/src/main/resources/application-milvus.yml
@@ -10,3 +10,7 @@ spring:
         collection-name: ${MILVUS_COLLECTION:vector_store}
         embedding-dimension: ${MILVUS_DIMENSION:1024}
         initialize-schema: true
+    alibaba:
+      data-agent:
+        vector-store:
+          embedding-dimension: ${MILVUS_DIMENSION:1024}

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/bo/schema/DisplayStyleBOTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/bo/schema/DisplayStyleBOTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.bo.schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.converter.BeanOutputConverter;
+import org.springframework.ai.util.json.schema.JsonSchemaGenerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DisplayStyleBOTest {
+
+	private final BeanOutputConverter<DisplayStyleBO> converter = new BeanOutputConverter<>(DisplayStyleBO.class);
+
+	@Test
+	void tableOutputDoesNotRequireChartAxes() throws Exception {
+		JsonNode schema = new ObjectMapper().readTree(JsonSchemaGenerator.generateForType(DisplayStyleBO.class));
+
+		assertThat(schema.path("required").isArray()).isTrue();
+		assertThat(schema.path("required").toString()).contains("type", "title").doesNotContain("\"x\"", "\"y\"");
+
+		DisplayStyleBO displayStyle = converter.convert("""
+				{"type":"table","title":"订单统计"}
+				""");
+
+		assertThat(displayStyle).isNotNull();
+		assertThat(displayStyle.getType()).isEqualTo("table");
+		assertThat(displayStyle.getTitle()).isEqualTo("订单统计");
+		assertThat(displayStyle.getX()).isNull();
+		assertThat(displayStyle.getY()).isNull();
+	}
+
+}

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/config/VectorStoreConfigurationTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/config/VectorStoreConfigurationTest.java
@@ -23,9 +23,12 @@ import com.alibaba.cloud.ai.dataagent.service.code.docker.DockerExecutorFactory;
 import com.alibaba.cloud.ai.dataagent.service.llm.LlmService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.env.YamlPropertySourceLoader;
 import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.ai.vectorstore.milvus.autoconfigure.MilvusServiceClientProperties;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -41,6 +44,23 @@ class VectorStoreConfigurationTest {
 		assertThat(property("application.yml", "spring.ai.vectorstore.type")).isEqualTo("simple");
 		assertThat(property("application-milvus.yml", "spring.ai.vectorstore.type")).isEqualTo("milvus");
 		assertThat(property("application-elasticsearch.yml", "spring.ai.vectorstore.type")).isEqualTo("elasticsearch");
+	}
+
+	@Test
+	void milvusProfile_bindsConnectionPropertiesUsedBySpringAi() throws Exception {
+		StandardEnvironment environment = new StandardEnvironment();
+		List<PropertySource<?>> sources = loader.load("application-milvus.yml",
+				new ClassPathResource("application-milvus.yml"));
+		for (PropertySource<?> source : sources) {
+			environment.getPropertySources().addFirst(source);
+		}
+
+		MilvusServiceClientProperties properties = Binder.get(environment)
+			.bind("spring.ai.vectorstore.milvus.client", MilvusServiceClientProperties.class)
+			.orElseThrow(() -> new IllegalStateException("Milvus client properties did not bind"));
+
+		assertThat(properties.getHost()).isEqualTo("127.0.0.1");
+		assertThat(properties.getPort()).isEqualTo(19530);
 	}
 
 	@Test

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/controller/ChatControllerUserIdTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/controller/ChatControllerUserIdTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.controller;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ChatControllerUserIdTest {
+
+	@Test
+	void integerJsonNumberConvertsToLong() {
+		assertThat(ChatController.toUserId(Integer.valueOf(123))).isEqualTo(123L);
+	}
+
+	@Test
+	void longJsonNumberRemainsLong() {
+		assertThat(ChatController.toUserId(Long.MAX_VALUE)).isEqualTo(Long.MAX_VALUE);
+	}
+
+	@Test
+	void absentUserIdRemainsNull() {
+		assertThat(ChatController.toUserId(null)).isNull();
+	}
+
+}

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/controller/ModelConfigControllerTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/controller/ModelConfigControllerTest.java
@@ -84,18 +84,13 @@ class ModelConfigControllerTest {
 	}
 
 	@Test
-	void testConnection_validConfig_returnsSuccess() {
-		ModelConfigDTO config = ModelConfigDTO.builder()
-			.provider("openai")
-			.baseUrl("https://api.openai.com")
-			.modelName("gpt-4")
-			.modelType("CHAT")
-			.build();
-		doNothing().when(modelConfigOpsService).testConnection(any(ModelConfigDTO.class));
+	void testConnection_validId_returnsSuccess() {
+		doNothing().when(modelConfigOpsService).testConnection(1);
 
-		ApiResponse<String> result = modelConfigController.testConnection(config);
+		ApiResponse<String> result = modelConfigController.testConnection(1);
 
 		assertTrue(result.isSuccess());
+		verify(modelConfigOpsService).testConnection(1);
 	}
 
 	@Test

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/mapper/AgentDatasourceTablesMapperIntegrationTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/mapper/AgentDatasourceTablesMapperIntegrationTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.mapper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MybatisTest
+class AgentDatasourceTablesMapperIntegrationTest {
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private AgentDatasourceTablesMapper mapper;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.execute("DROP TABLE IF EXISTS agent_datasource_tables");
+		jdbcTemplate.execute("DROP TABLE IF EXISTS agent_datasource");
+		jdbcTemplate.execute("""
+				CREATE TABLE agent_datasource (
+				  id INT PRIMARY KEY,
+				  agent_id BIGINT NOT NULL,
+				  datasource_id INT NOT NULL,
+				  is_active INT NOT NULL
+				)
+				""");
+		jdbcTemplate.execute("""
+				CREATE TABLE agent_datasource_tables (
+				  agent_datasource_id INT NOT NULL,
+				  table_name VARCHAR(255) NOT NULL,
+				  UNIQUE (agent_datasource_id, table_name)
+				)
+				""");
+	}
+
+	@Test
+	void selectedTablesAreUnionedAcrossAgentsSharingDatasource() {
+		jdbcTemplate.update("INSERT INTO agent_datasource VALUES (1, 10, 3, 1), (2, 11, 3, 1), (3, 12, 4, 1)");
+		jdbcTemplate.update("""
+				INSERT INTO agent_datasource_tables VALUES
+				  (1, 'orders'), (1, 'users'),
+				  (2, 'orders'), (2, 'products'),
+				  (3, 'unrelated_table')
+				""");
+
+		assertThat(mapper.getSelectedTablesByDatasourceId(3)).containsExactly("orders", "products", "users");
+	}
+
+}

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/mapper/EmbeddingRecoveryMapperIntegrationTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/mapper/EmbeddingRecoveryMapperIntegrationTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.mapper;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MybatisTest
+class EmbeddingRecoveryMapperIntegrationTest {
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private AgentKnowledgeMapper agentKnowledgeMapper;
+
+	@Autowired
+	private BusinessKnowledgeMapper businessKnowledgeMapper;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.execute("DROP TABLE IF EXISTS agent_knowledge");
+		jdbcTemplate.execute("DROP TABLE IF EXISTS business_knowledge");
+		jdbcTemplate.execute("""
+				CREATE TABLE agent_knowledge (
+				  id INT PRIMARY KEY,
+				  embedding_status VARCHAR(20),
+				  error_msg VARCHAR(255),
+				  updated_time TIMESTAMP,
+				  is_deleted INT
+				)
+				""");
+		jdbcTemplate.execute("""
+				CREATE TABLE business_knowledge (
+				  id INT PRIMARY KEY,
+				  embedding_status VARCHAR(20),
+				  error_msg VARCHAR(255),
+				  updated_time TIMESTAMP,
+				  is_deleted INT
+				)
+				""");
+	}
+
+	@Test
+	void staleProcessingRowsAreRecoveredButRecentAndDeletedRowsAreNot() {
+		LocalDateTime now = LocalDateTime.now();
+		insertRecoveryFixtures("agent_knowledge", now);
+		insertRecoveryFixtures("business_knowledge", now);
+
+		assertThat(agentKnowledgeMapper.resetStaleProcessing(now.minusMinutes(10))).isEqualTo(1);
+		assertThat(businessKnowledgeMapper.resetStaleProcessing(now.minusMinutes(10))).isEqualTo(1);
+		assertRecoveryResult("agent_knowledge");
+		assertRecoveryResult("business_knowledge");
+	}
+
+	private void insertRecoveryFixtures(String table, LocalDateTime now) {
+		jdbcTemplate.update("INSERT INTO " + table
+				+ " (id, embedding_status, updated_time, is_deleted) VALUES (?, 'PROCESSING', ?, 0)", 1,
+				now.minusMinutes(20));
+		jdbcTemplate.update("INSERT INTO " + table
+				+ " (id, embedding_status, updated_time, is_deleted) VALUES (?, 'PROCESSING', ?, 0)", 2,
+				now.minusMinutes(2));
+		jdbcTemplate.update("INSERT INTO " + table
+				+ " (id, embedding_status, updated_time, is_deleted) VALUES (?, 'PROCESSING', ?, 1)", 3,
+				now.minusMinutes(20));
+	}
+
+	private void assertRecoveryResult(String table) {
+		assertThat(jdbcTemplate.queryForObject("SELECT embedding_status FROM " + table + " WHERE id = 1",
+				String.class)).isEqualTo("PENDING");
+		assertThat(jdbcTemplate.queryForObject("SELECT error_msg FROM " + table + " WHERE id = 1", String.class))
+			.isEqualTo("Recovered stale PROCESSING job");
+		assertThat(jdbcTemplate.queryForObject("SELECT embedding_status FROM " + table + " WHERE id = 2",
+				String.class)).isEqualTo("PROCESSING");
+		assertThat(jdbcTemplate.queryForObject("SELECT embedding_status FROM " + table + " WHERE id = 3",
+				String.class)).isEqualTo("PROCESSING");
+	}
+
+}

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/mapper/EmbeddingRecoveryMapperIntegrationTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/mapper/EmbeddingRecoveryMapperIntegrationTest.java
@@ -74,26 +74,29 @@ class EmbeddingRecoveryMapperIntegrationTest {
 	}
 
 	private void insertRecoveryFixtures(String table, LocalDateTime now) {
-		jdbcTemplate.update("INSERT INTO " + table
-				+ " (id, embedding_status, updated_time, is_deleted) VALUES (?, 'PROCESSING', ?, 0)", 1,
-				now.minusMinutes(20));
-		jdbcTemplate.update("INSERT INTO " + table
-				+ " (id, embedding_status, updated_time, is_deleted) VALUES (?, 'PROCESSING', ?, 0)", 2,
-				now.minusMinutes(2));
-		jdbcTemplate.update("INSERT INTO " + table
-				+ " (id, embedding_status, updated_time, is_deleted) VALUES (?, 'PROCESSING', ?, 1)", 3,
-				now.minusMinutes(20));
+		jdbcTemplate.update(
+				"INSERT INTO " + table
+						+ " (id, embedding_status, updated_time, is_deleted) VALUES (?, 'PROCESSING', ?, 0)",
+				1, now.minusMinutes(20));
+		jdbcTemplate.update(
+				"INSERT INTO " + table
+						+ " (id, embedding_status, updated_time, is_deleted) VALUES (?, 'PROCESSING', ?, 0)",
+				2, now.minusMinutes(2));
+		jdbcTemplate.update(
+				"INSERT INTO " + table
+						+ " (id, embedding_status, updated_time, is_deleted) VALUES (?, 'PROCESSING', ?, 1)",
+				3, now.minusMinutes(20));
 	}
 
 	private void assertRecoveryResult(String table) {
-		assertThat(jdbcTemplate.queryForObject("SELECT embedding_status FROM " + table + " WHERE id = 1",
-				String.class)).isEqualTo("PENDING");
+		assertThat(jdbcTemplate.queryForObject("SELECT embedding_status FROM " + table + " WHERE id = 1", String.class))
+			.isEqualTo("PENDING");
 		assertThat(jdbcTemplate.queryForObject("SELECT error_msg FROM " + table + " WHERE id = 1", String.class))
 			.isEqualTo("Recovered stale PROCESSING job");
-		assertThat(jdbcTemplate.queryForObject("SELECT embedding_status FROM " + table + " WHERE id = 2",
-				String.class)).isEqualTo("PROCESSING");
-		assertThat(jdbcTemplate.queryForObject("SELECT embedding_status FROM " + table + " WHERE id = 3",
-				String.class)).isEqualTo("PROCESSING");
+		assertThat(jdbcTemplate.queryForObject("SELECT embedding_status FROM " + table + " WHERE id = 2", String.class))
+			.isEqualTo("PROCESSING");
+		assertThat(jdbcTemplate.queryForObject("SELECT embedding_status FROM " + table + " WHERE id = 3", String.class))
+			.isEqualTo("PROCESSING");
 	}
 
 }

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/agent/AgentStartupInitializationTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/agent/AgentStartupInitializationTest.java
@@ -118,7 +118,7 @@ class AgentStartupInitializationTest {
 		datasource.setSelectTables(List.of("orders"));
 		when(agentService.findByStatus("published")).thenReturn(List.of(agent));
 		when(agentDatasourceService.getCurrentAgentDatasource(1L)).thenReturn(datasource);
-		when(agentVectorStoreService.hasSchemaDocuments("3")).thenReturn(true);
+		when(agentVectorStoreService.hasTableDocuments(3, List.of("orders"))).thenReturn(true);
 		when(modelConfigDataService.getActiveConfigByType(ModelType.EMBEDDING)).thenReturn(null);
 
 		initialization.run(applicationArguments);
@@ -134,7 +134,7 @@ class AgentStartupInitializationTest {
 		datasource.setSelectTables(List.of("orders"));
 		when(agentService.findByStatus("published")).thenReturn(List.of(agent));
 		when(agentDatasourceService.getCurrentAgentDatasource(1L)).thenReturn(datasource);
-		when(agentVectorStoreService.hasSchemaDocuments("3")).thenReturn(false);
+		when(agentVectorStoreService.hasTableDocuments(3, List.of("orders"))).thenReturn(false);
 		when(agentDatasourceService.initializeSchemaForAgentWithDatasource(1L, 3, List.of("orders"))).thenReturn(true);
 		when(modelConfigDataService.getActiveConfigByType(ModelType.EMBEDDING)).thenReturn(null);
 

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/EmbeddingModelCompatibilityValidatorTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/EmbeddingModelCompatibilityValidatorTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.service.aimodelconfig;
+
+import com.alibaba.cloud.ai.dataagent.dto.ModelConfigDTO;
+import com.alibaba.cloud.ai.dataagent.properties.DataAgentProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class EmbeddingModelCompatibilityValidatorTest {
+
+	private EmbeddingModelCompatibilityValidator validator;
+
+	@BeforeEach
+	void setUp() {
+		DataAgentProperties properties = new DataAgentProperties();
+		properties.getVectorStore().setEmbeddingDimension(1024);
+		validator = new EmbeddingModelCompatibilityValidator(properties);
+	}
+
+	@Test
+	void matchingDimensionIsAccepted() {
+		assertThatCode(() -> validator.validateDimension(1024)).doesNotThrowAnyException();
+	}
+
+	@Test
+	void mismatchedDimensionIsRejectedBeforeVectorsAreMixed() {
+		assertThatThrownBy(() -> validator.validateDimension(1536)).isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("new collection");
+	}
+
+	@Test
+	void changingEmbeddingSpaceIsRejected() {
+		ModelConfigDTO current = embeddingConfig("provider", "https://one", "embedding-a");
+		ModelConfigDTO target = embeddingConfig("provider", "https://one", "embedding-b");
+
+		assertThatThrownBy(() -> validator.validateModelChange(current, target))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("rebuild all schema and knowledge vectors");
+	}
+
+	@Test
+	void credentialRotationForTheSameEmbeddingSpaceIsAccepted() {
+		ModelConfigDTO current = embeddingConfig("provider", "https://one", "embedding-a");
+		current.setApiKey("old-key");
+		ModelConfigDTO target = embeddingConfig("provider", "https://one", "embedding-a");
+		target.setApiKey("new-key");
+
+		assertThatCode(() -> validator.validateModelChange(current, target)).doesNotThrowAnyException();
+	}
+
+	private ModelConfigDTO embeddingConfig(String provider, String baseUrl, String modelName) {
+		return ModelConfigDTO.builder()
+			.provider(provider)
+			.baseUrl(baseUrl)
+			.modelName(modelName)
+			.embeddingsPath("/v1/embeddings")
+			.modelType("EMBEDDING")
+			.build();
+	}
+
+}

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/EmbeddingModelCompatibilityValidatorTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/EmbeddingModelCompatibilityValidatorTest.java
@@ -17,6 +17,7 @@ package com.alibaba.cloud.ai.dataagent.service.aimodelconfig;
 
 import com.alibaba.cloud.ai.dataagent.dto.ModelConfigDTO;
 import com.alibaba.cloud.ai.dataagent.properties.DataAgentProperties;
+import com.alibaba.cloud.ai.dataagent.support.KeywordEmbeddingModel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -63,6 +64,36 @@ class EmbeddingModelCompatibilityValidatorTest {
 		target.setApiKey("new-key");
 
 		assertThatCode(() -> validator.validateModelChange(current, target)).doesNotThrowAnyException();
+	}
+
+	@Test
+	void embeddingModelIsValidatedOnceAgainstTheConfiguredDimension() {
+		DataAgentProperties properties = new DataAgentProperties();
+		properties.getVectorStore().setEmbeddingDimension(3);
+		EmbeddingModelCompatibilityValidator dimensionValidator = new EmbeddingModelCompatibilityValidator(properties);
+		KeywordEmbeddingModel model = new KeywordEmbeddingModel();
+
+		assertThatCode(() -> {
+			dimensionValidator.validateModel(model);
+			dimensionValidator.validateModel(model);
+		}).doesNotThrowAnyException();
+	}
+
+	@Test
+	void disabledDimensionValidationDoesNotInspectTheModel() {
+		DataAgentProperties properties = new DataAgentProperties();
+		properties.getVectorStore().setEmbeddingDimension(0);
+		EmbeddingModelCompatibilityValidator dimensionValidator = new EmbeddingModelCompatibilityValidator(properties);
+
+		assertThatCode(() -> dimensionValidator.validateModel(null)).doesNotThrowAnyException();
+	}
+
+	@Test
+	void missingEmbeddingConfigurationsDoNotTriggerAHotSwitchFailure() {
+		ModelConfigDTO target = embeddingConfig("provider", "https://one", "embedding-a");
+
+		assertThatCode(() -> validator.validateModelChange(null, target)).doesNotThrowAnyException();
+		assertThatCode(() -> validator.validateModelChange(target, null)).doesNotThrowAnyException();
 	}
 
 	private ModelConfigDTO embeddingConfig(String provider, String baseUrl, String modelName) {

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigDataServiceImplTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigDataServiceImplTest.java
@@ -182,6 +182,27 @@ class ModelConfigDataServiceImplTest {
 	}
 
 	@Test
+	void updateConfigInDb_blankApiKey_preservesOldKey() {
+		ModelConfig existing = new ModelConfig();
+		existing.setId(1);
+		existing.setModelType(ModelType.CHAT);
+		existing.setApiKey("real-secret-key");
+		when(modelConfigMapper.findById(1)).thenReturn(existing);
+
+		ModelConfigDTO dto = new ModelConfigDTO();
+		dto.setId(1);
+		dto.setModelType("CHAT");
+		dto.setModelName("model");
+		dto.setBaseUrl("http://example.com");
+		dto.setApiKey("  ");
+		dto.setProvider("openai");
+
+		ModelConfig result = service.updateConfigInDb(dto);
+
+		assertEquals("real-secret-key", result.getApiKey());
+	}
+
+	@Test
 	void updateConfigInDb_maskedProxyPassword_preservesOldPassword() {
 		ModelConfig existing = new ModelConfig();
 		existing.setId(1);

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigOpsServiceTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigOpsServiceTest.java
@@ -18,6 +18,7 @@ package com.alibaba.cloud.ai.dataagent.service.aimodelconfig;
 import com.alibaba.cloud.ai.dataagent.dto.ModelConfigDTO;
 import com.alibaba.cloud.ai.dataagent.entity.ModelConfig;
 import com.alibaba.cloud.ai.dataagent.enums.ModelType;
+import com.alibaba.cloud.ai.dataagent.properties.DataAgentProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,7 +47,8 @@ class ModelConfigOpsServiceTest {
 
 	@BeforeEach
 	void setUp() {
-		service = new ModelConfigOpsService(modelConfigDataService, modelFactory, aiModelRegistry);
+		service = new ModelConfigOpsService(modelConfigDataService, modelFactory, aiModelRegistry,
+				new EmbeddingModelCompatibilityValidator(new DataAgentProperties()));
 	}
 
 	@Test

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigOpsServiceTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/aimodelconfig/ModelConfigOpsServiceTest.java
@@ -111,63 +111,84 @@ class ModelConfigOpsServiceTest {
 	}
 
 	@Test
-	void testTestConnection_chat() {
-		ModelConfigDTO dto = new ModelConfigDTO();
-		dto.setModelType("CHAT");
-		dto.setProvider("openai");
-		dto.setModelName("gpt-4");
+	void testTestConnection_chat_usesStoredApiKey() {
+		ModelConfig entity = new ModelConfig();
+		entity.setId(1);
+		entity.setModelType(ModelType.CHAT);
+		entity.setProvider("openai");
+		entity.setModelName("gpt-4");
+		entity.setApiKey("stored-api-key");
+		when(modelConfigDataService.findById(1)).thenReturn(entity);
 
 		ChatModel chatModel = mock(ChatModel.class);
-		when(modelFactory.createChatModel(dto)).thenReturn(chatModel);
+		when(modelFactory.createChatModel(argThat(config -> "stored-api-key".equals(config.getApiKey()))))
+			.thenReturn(chatModel);
 		when(chatModel.call("Hello")).thenReturn("Hi there");
 
-		assertDoesNotThrow(() -> service.testConnection(dto));
+		assertDoesNotThrow(() -> service.testConnection(1));
 	}
 
 	@Test
 	void testTestConnection_embedding() {
-		ModelConfigDTO dto = new ModelConfigDTO();
-		dto.setModelType("EMBEDDING");
-		dto.setProvider("openai");
-		dto.setModelName("text-embedding");
+		ModelConfig entity = new ModelConfig();
+		entity.setId(2);
+		entity.setModelType(ModelType.EMBEDDING);
+		entity.setProvider("openai");
+		entity.setModelName("text-embedding");
+		when(modelConfigDataService.findById(2)).thenReturn(entity);
 
 		EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
-		when(modelFactory.createEmbeddingModel(dto)).thenReturn(embeddingModel);
+		when(modelFactory.createEmbeddingModel(any(ModelConfigDTO.class))).thenReturn(embeddingModel);
 		when(embeddingModel.embed("Test")).thenReturn(new float[] { 0.1f, 0.2f });
 
-		assertDoesNotThrow(() -> service.testConnection(dto));
+		assertDoesNotThrow(() -> service.testConnection(2));
 	}
 
 	@Test
 	void testTestConnection_unknownType() {
-		ModelConfigDTO dto = new ModelConfigDTO();
-		dto.setModelType("UNKNOWN");
+		ModelConfig entity = new ModelConfig();
+		entity.setId(3);
+		entity.setModelType(null);
+		when(modelConfigDataService.findById(3)).thenReturn(entity);
 
-		assertThrows(RuntimeException.class, () -> service.testConnection(dto));
+		assertThrows(RuntimeException.class, () -> service.testConnection(3));
+	}
+
+	@Test
+	void testTestConnection_notFound() {
+		when(modelConfigDataService.findById(99)).thenReturn(null);
+
+		RuntimeException exception = assertThrows(RuntimeException.class, () -> service.testConnection(99));
+
+		assertEquals("配置不存在", exception.getMessage());
 	}
 
 	@Test
 	void testTestConnection_chatReturnsEmpty() {
-		ModelConfigDTO dto = new ModelConfigDTO();
-		dto.setModelType("CHAT");
+		ModelConfig entity = new ModelConfig();
+		entity.setId(4);
+		entity.setModelType(ModelType.CHAT);
+		when(modelConfigDataService.findById(4)).thenReturn(entity);
 
 		ChatModel chatModel = mock(ChatModel.class);
-		when(modelFactory.createChatModel(dto)).thenReturn(chatModel);
+		when(modelFactory.createChatModel(any(ModelConfigDTO.class))).thenReturn(chatModel);
 		when(chatModel.call("Hello")).thenReturn("");
 
-		assertThrows(RuntimeException.class, () -> service.testConnection(dto));
+		assertThrows(RuntimeException.class, () -> service.testConnection(4));
 	}
 
 	@Test
 	void testTestConnection_embeddingReturnsEmpty() {
-		ModelConfigDTO dto = new ModelConfigDTO();
-		dto.setModelType("EMBEDDING");
+		ModelConfig entity = new ModelConfig();
+		entity.setId(5);
+		entity.setModelType(ModelType.EMBEDDING);
+		when(modelConfigDataService.findById(5)).thenReturn(entity);
 
 		EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
-		when(modelFactory.createEmbeddingModel(dto)).thenReturn(embeddingModel);
+		when(modelFactory.createEmbeddingModel(any(ModelConfigDTO.class))).thenReturn(embeddingModel);
 		when(embeddingModel.embed("Test")).thenReturn(new float[0]);
 
-		assertThrows(RuntimeException.class, () -> service.testConnection(dto));
+		assertThrows(RuntimeException.class, () -> service.testConnection(5));
 	}
 
 }

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/integration/MilvusVectorStoreIntegrationTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/integration/MilvusVectorStoreIntegrationTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.service.integration;
+
+import com.alibaba.cloud.ai.dataagent.constant.Constant;
+import com.alibaba.cloud.ai.dataagent.constant.DocumentMetadataConstant;
+import com.alibaba.cloud.ai.dataagent.properties.DataAgentProperties;
+import com.alibaba.cloud.ai.dataagent.service.vectorstore.AgentVectorStoreService;
+import com.alibaba.cloud.ai.dataagent.service.vectorstore.AgentVectorStoreServiceImpl;
+import com.alibaba.cloud.ai.dataagent.service.vectorstore.DynamicFilterService;
+import com.alibaba.cloud.ai.dataagent.service.vector.MetadataDocumentRetriever;
+import com.alibaba.cloud.ai.dataagent.support.KeywordEmbeddingModel;
+import io.milvus.client.MilvusServiceClient;
+import io.milvus.param.ConnectParam;
+import io.milvus.param.collection.DropCollectionParam;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.filter.FilterExpressionBuilder;
+import org.springframework.ai.vectorstore.milvus.MilvusVectorStore;
+import org.springframework.core.env.StandardEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnabledIfSystemProperty(named = "dataagent.milvus.integration", matches = "true")
+class MilvusVectorStoreIntegrationTest {
+
+	private MilvusServiceClient client;
+
+	private MilvusVectorStore vectorStore;
+
+	private String collectionName;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		String host = System.getProperty("dataagent.milvus.host", "127.0.0.1");
+		int port = Integer.getInteger("dataagent.milvus.port", 19530);
+		collectionName = "dataagent_it_" + UUID.randomUUID().toString().replace("-", "");
+		client = new MilvusServiceClient(ConnectParam.newBuilder().withHost(host).withPort(port).build());
+		vectorStore = MilvusVectorStore.builder(client, new KeywordEmbeddingModel())
+			.collectionName(collectionName)
+			.embeddingDimension(3)
+			.initializeSchema(true)
+			.build();
+		vectorStore.afterPropertiesSet();
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (client != null && collectionName != null) {
+			client.dropCollection(DropCollectionParam.newBuilder().withCollectionName(collectionName).build());
+			client.close();
+		}
+	}
+
+	@Test
+	void addSearchFilterAndDeleteUseTheRealMilvusServer() {
+		Document order = new Document("订单销售数据",
+				Map.of(Constant.AGENT_ID, "42", DocumentMetadataConstant.VECTOR_TYPE,
+						DocumentMetadataConstant.AGENT_KNOWLEDGE));
+		Document user = new Document("用户注册信息",
+				Map.of(Constant.AGENT_ID, "99", DocumentMetadataConstant.VECTOR_TYPE,
+						DocumentMetadataConstant.AGENT_KNOWLEDGE));
+		vectorStore.add(List.of(order, user));
+
+		FilterExpressionBuilder filters = new FilterExpressionBuilder();
+		SearchRequest request = SearchRequest.builder()
+			.query("查询订单")
+			.topK(5)
+			.similarityThreshold(0.8)
+			.filterExpression(filters.eq(Constant.AGENT_ID, "42").build())
+			.build();
+
+		assertThat(vectorStore.similaritySearch(request)).extracting(Document::getText)
+			.containsExactly("订单销售数据");
+		AgentVectorStoreService service = new AgentVectorStoreServiceImpl(vectorStore, Optional.empty(),
+				new DataAgentProperties(), new DynamicFilterService(null, null),
+				new MetadataDocumentRetriever(new StandardEnvironment()));
+		assertThat(service.getDocumentsOnlyByFilter(filters.eq(Constant.AGENT_ID, "42").build(), 5))
+			.extracting(Document::getText)
+			.containsExactly("订单销售数据");
+
+		vectorStore.delete("agentId == '42'");
+		assertThat(vectorStore.similaritySearch(request)).isEmpty();
+	}
+
+}

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/integration/MilvusVectorStoreIntegrationTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/integration/MilvusVectorStoreIntegrationTest.java
@@ -75,12 +75,10 @@ class MilvusVectorStoreIntegrationTest {
 
 	@Test
 	void addSearchFilterAndDeleteUseTheRealMilvusServer() {
-		Document order = new Document("订单销售数据",
-				Map.of(Constant.AGENT_ID, "42", DocumentMetadataConstant.VECTOR_TYPE,
-						DocumentMetadataConstant.AGENT_KNOWLEDGE));
-		Document user = new Document("用户注册信息",
-				Map.of(Constant.AGENT_ID, "99", DocumentMetadataConstant.VECTOR_TYPE,
-						DocumentMetadataConstant.AGENT_KNOWLEDGE));
+		Document order = new Document("订单销售数据", Map.of(Constant.AGENT_ID, "42", DocumentMetadataConstant.VECTOR_TYPE,
+				DocumentMetadataConstant.AGENT_KNOWLEDGE));
+		Document user = new Document("用户注册信息", Map.of(Constant.AGENT_ID, "99", DocumentMetadataConstant.VECTOR_TYPE,
+				DocumentMetadataConstant.AGENT_KNOWLEDGE));
 		vectorStore.add(List.of(order, user));
 
 		FilterExpressionBuilder filters = new FilterExpressionBuilder();
@@ -91,8 +89,7 @@ class MilvusVectorStoreIntegrationTest {
 			.filterExpression(filters.eq(Constant.AGENT_ID, "42").build())
 			.build();
 
-		assertThat(vectorStore.similaritySearch(request)).extracting(Document::getText)
-			.containsExactly("订单销售数据");
+		assertThat(vectorStore.similaritySearch(request)).extracting(Document::getText).containsExactly("订单销售数据");
 		AgentVectorStoreService service = new AgentVectorStoreServiceImpl(vectorStore, Optional.empty(),
 				new DataAgentProperties(), new DynamicFilterService(null, null),
 				new MetadataDocumentRetriever(new StandardEnvironment()));

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/integration/SimpleVectorStorePersistenceIntegrationTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/integration/SimpleVectorStorePersistenceIntegrationTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.service.integration;
+
+import com.alibaba.cloud.ai.dataagent.properties.DataAgentProperties;
+import com.alibaba.cloud.ai.dataagent.service.vectorstore.SimpleVectorStoreInitialization;
+import com.alibaba.cloud.ai.dataagent.support.KeywordEmbeddingModel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.SimpleVectorStore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SimpleVectorStorePersistenceIntegrationTest {
+
+	@TempDir
+	Path tempDirectory;
+
+	@Test
+	void saveAndLoadRoundTripUsesACompleteReplacementFile() throws Exception {
+		Path storeFile = tempDirectory.resolve("nested/vectorstore.json");
+		DataAgentProperties properties = new DataAgentProperties();
+		properties.getVectorStore().setFilePath(storeFile.toString());
+
+		SimpleVectorStore original = SimpleVectorStore.builder(new KeywordEmbeddingModel()).build();
+		original.add(List.of(new Document("订单销售数据")));
+		new SimpleVectorStoreInitialization(original, properties).save();
+
+		assertThat(storeFile).exists();
+		try (Stream<Path> paths = Files.list(storeFile.getParent())) {
+			assertThat(paths.map(path -> path.getFileName().toString())).noneMatch(name -> name.endsWith(".tmp"));
+		}
+
+		SimpleVectorStore restored = SimpleVectorStore.builder(new KeywordEmbeddingModel()).build();
+		new SimpleVectorStoreInitialization(restored, properties).load();
+
+		assertThat(restored.similaritySearch(SearchRequest.builder()
+			.query("订单")
+			.topK(1)
+			.similarityThreshold(0.8)
+			.build())).extracting(Document::getText).containsExactly("订单销售数据");
+	}
+
+}

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/integration/SimpleVectorStorePersistenceIntegrationTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/integration/SimpleVectorStorePersistenceIntegrationTest.java
@@ -29,6 +29,7 @@ import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.SimpleVectorStore;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 class SimpleVectorStorePersistenceIntegrationTest {
 
@@ -57,6 +58,57 @@ class SimpleVectorStorePersistenceIntegrationTest {
 				restored.similaritySearch(SearchRequest.builder().query("订单").topK(1).similarityThreshold(0.8).build()))
 			.extracting(Document::getText)
 			.containsExactly("订单销售数据");
+	}
+
+	@Test
+	void applicationRunnerSkipsAMissingPersistenceFile() {
+		Path storeFile = tempDirectory.resolve("missing/vectorstore.json");
+		DataAgentProperties properties = propertiesFor(storeFile);
+		SimpleVectorStore store = SimpleVectorStore.builder(new KeywordEmbeddingModel()).build();
+
+		assertThatCode(() -> new SimpleVectorStoreInitialization(store, properties).run(null))
+			.doesNotThrowAnyException();
+		assertThat(storeFile).doesNotExist();
+	}
+
+	@Test
+	void corruptPersistenceFileDoesNotPreventStartup() throws Exception {
+		Path storeFile = tempDirectory.resolve("corrupt.json");
+		Files.writeString(storeFile, "{not-json");
+		DataAgentProperties properties = propertiesFor(storeFile);
+		SimpleVectorStore store = SimpleVectorStore.builder(new KeywordEmbeddingModel()).build();
+
+		assertThatCode(() -> new SimpleVectorStoreInitialization(store, properties).load()).doesNotThrowAnyException();
+	}
+
+	@Test
+	void disposableBeanPersistsTheStore() {
+		Path storeFile = tempDirectory.resolve("destroy/vectorstore.json");
+		DataAgentProperties properties = propertiesFor(storeFile);
+		SimpleVectorStore store = SimpleVectorStore.builder(new KeywordEmbeddingModel()).build();
+		store.add(List.of(new Document("订单销售数据")));
+
+		new SimpleVectorStoreInitialization(store, properties).destroy();
+
+		assertThat(storeFile).exists();
+	}
+
+	@Test
+	void persistenceFailureIsContained() throws Exception {
+		Path regularFile = tempDirectory.resolve("not-a-directory");
+		Files.writeString(regularFile, "blocker");
+		Path storeFile = regularFile.resolve("vectorstore.json");
+		DataAgentProperties properties = propertiesFor(storeFile);
+		SimpleVectorStore store = SimpleVectorStore.builder(new KeywordEmbeddingModel()).build();
+
+		assertThatCode(() -> new SimpleVectorStoreInitialization(store, properties).save()).doesNotThrowAnyException();
+		assertThat(Files.readString(regularFile)).isEqualTo("blocker");
+	}
+
+	private DataAgentProperties propertiesFor(Path storeFile) {
+		DataAgentProperties properties = new DataAgentProperties();
+		properties.getVectorStore().setFilePath(storeFile.toString());
+		return properties;
 	}
 
 }

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/integration/SimpleVectorStorePersistenceIntegrationTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/integration/SimpleVectorStorePersistenceIntegrationTest.java
@@ -53,11 +53,10 @@ class SimpleVectorStorePersistenceIntegrationTest {
 		SimpleVectorStore restored = SimpleVectorStore.builder(new KeywordEmbeddingModel()).build();
 		new SimpleVectorStoreInitialization(restored, properties).load();
 
-		assertThat(restored.similaritySearch(SearchRequest.builder()
-			.query("订单")
-			.topK(1)
-			.similarityThreshold(0.8)
-			.build())).extracting(Document::getText).containsExactly("订单销售数据");
+		assertThat(
+				restored.similaritySearch(SearchRequest.builder().query("订单").topK(1).similarityThreshold(0.8).build()))
+			.extracting(Document::getText)
+			.containsExactly("订单销售数据");
 	}
 
 }

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/integration/VectorReplacementIntegrationTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/integration/VectorReplacementIntegrationTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.service.integration;
+
+import com.alibaba.cloud.ai.dataagent.constant.Constant;
+import com.alibaba.cloud.ai.dataagent.constant.DocumentMetadataConstant;
+import com.alibaba.cloud.ai.dataagent.properties.DataAgentProperties;
+import com.alibaba.cloud.ai.dataagent.service.vectorstore.AgentVectorStoreService;
+import com.alibaba.cloud.ai.dataagent.service.vectorstore.AgentVectorStoreServiceImpl;
+import com.alibaba.cloud.ai.dataagent.service.vectorstore.MetadataAwareSimpleVectorStore;
+import com.alibaba.cloud.ai.dataagent.service.vectorstore.DynamicFilterService;
+import com.alibaba.cloud.ai.dataagent.service.vector.MetadataDocumentRetriever;
+import com.alibaba.cloud.ai.dataagent.support.KeywordEmbeddingModel;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.embedding.EmbeddingRequest;
+import org.springframework.ai.embedding.EmbeddingResponse;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.SimpleVectorStore;
+import org.springframework.ai.vectorstore.filter.Filter;
+import org.springframework.ai.vectorstore.filter.FilterExpressionBuilder;
+import org.springframework.core.env.StandardEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class VectorReplacementIntegrationTest {
+
+	private FailAfterEmbeddingModel embeddingModel;
+
+	private SimpleVectorStore vectorStore;
+
+	private AgentVectorStoreService service;
+
+	private Map<String, Object> identityMetadata;
+
+	@BeforeEach
+	void setUp() {
+		embeddingModel = new FailAfterEmbeddingModel();
+		vectorStore = new MetadataAwareSimpleVectorStore(embeddingModel);
+		DataAgentProperties properties = new DataAgentProperties();
+		service = new AgentVectorStoreServiceImpl(vectorStore, Optional.empty(), properties,
+				new DynamicFilterService(null, null), new MetadataDocumentRetriever(new StandardEnvironment()));
+		identityMetadata = Map.of(Constant.AGENT_ID, "1", DocumentMetadataConstant.VECTOR_TYPE,
+				DocumentMetadataConstant.BUSINESS_TERM, DocumentMetadataConstant.DB_BUSINESS_TERM_ID, 10L);
+		service.addDocuments("1", List.of(new Document("stable-old-id", "订单旧定义", identityMetadata)));
+	}
+
+	@Test
+	void failedReplacementKeepsTheOldVectorAvailable() {
+		embeddingModel.failAfterSuccessfulCalls(1);
+
+		assertThatThrownBy(() -> service.replaceDocumentsByMetadata(identityMetadata,
+				List.of(new Document("stable-old-id", "用户新定义", identityMetadata),
+						new Document("用户补充定义", identityMetadata))))
+			.isInstanceOf(IllegalStateException.class);
+
+		embeddingModel.disableFailure();
+		assertThat(search("订单查询")).extracting(Document::getText).containsExactly("订单旧定义");
+		assertThat(search("用户查询")).isEmpty();
+	}
+
+	@Test
+	void successfulReplacementPublishesNewVectorBeforeRemovingOldVector() {
+		service.replaceDocumentsByMetadata(identityMetadata, List.of(new Document("用户新定义", identityMetadata)));
+
+		assertThat(search("用户查询")).extracting(Document::getText).containsExactly("用户新定义");
+		assertThat(search("订单查询")).isEmpty();
+	}
+
+	private List<Document> search(String query) {
+		Filter.Expression filter = new FilterExpressionBuilder().eq(Constant.AGENT_ID, "1").build();
+		return vectorStore.similaritySearch(SearchRequest.builder()
+			.query(query)
+			.topK(5)
+			.similarityThreshold(0.8)
+			.filterExpression(filter)
+			.build());
+	}
+
+	private static final class FailAfterEmbeddingModel implements EmbeddingModel {
+
+		private final KeywordEmbeddingModel delegate = new KeywordEmbeddingModel();
+
+		private int successfulCallsBeforeFailure = Integer.MAX_VALUE;
+
+		@Override
+		public EmbeddingResponse call(EmbeddingRequest request) {
+			beforeEmbedding();
+			return delegate.call(request);
+		}
+
+		@Override
+		public float[] embed(Document document) {
+			beforeEmbedding();
+			return delegate.embed(document);
+		}
+
+		@Override
+		public float[] embed(String text) {
+			beforeEmbedding();
+			return delegate.embed(text);
+		}
+
+		@Override
+		public int dimensions() {
+			return delegate.dimensions();
+		}
+
+		void failAfterSuccessfulCalls(int successfulCalls) {
+			this.successfulCallsBeforeFailure = successfulCalls;
+		}
+
+		void disableFailure() {
+			this.successfulCallsBeforeFailure = Integer.MAX_VALUE;
+		}
+
+		private void beforeEmbedding() {
+			if (successfulCallsBeforeFailure == 0) {
+				throw new IllegalStateException("simulated embedding outage");
+			}
+			successfulCallsBeforeFailure--;
+		}
+
+	}
+
+}

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/integration/VectorReplacementIntegrationTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/integration/VectorReplacementIntegrationTest.java
@@ -68,9 +68,11 @@ class VectorReplacementIntegrationTest {
 	void failedReplacementKeepsTheOldVectorAvailable() {
 		embeddingModel.failAfterSuccessfulCalls(1);
 
-		assertThatThrownBy(() -> service.replaceDocumentsByMetadata(identityMetadata,
-				List.of(new Document("stable-old-id", "用户新定义", identityMetadata),
-						new Document("用户补充定义", identityMetadata))))
+		assertThatThrownBy(
+				() -> service
+					.replaceDocumentsByMetadata(identityMetadata,
+							List.of(new Document("stable-old-id", "用户新定义", identityMetadata),
+									new Document("用户补充定义", identityMetadata))))
 			.isInstanceOf(IllegalStateException.class);
 
 		embeddingModel.disableFailure();
@@ -88,12 +90,8 @@ class VectorReplacementIntegrationTest {
 
 	private List<Document> search(String query) {
 		Filter.Expression filter = new FilterExpressionBuilder().eq(Constant.AGENT_ID, "1").build();
-		return vectorStore.similaritySearch(SearchRequest.builder()
-			.query(query)
-			.topK(5)
-			.similarityThreshold(0.8)
-			.filterExpression(filter)
-			.build());
+		return vectorStore.similaritySearch(
+				SearchRequest.builder().query(query).topK(5).similarityThreshold(0.8).filterExpression(filter).build());
 	}
 
 	private static final class FailAfterEmbeddingModel implements EmbeddingModel {

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/integration/VectorReplacementIntegrationTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/integration/VectorReplacementIntegrationTest.java
@@ -17,7 +17,10 @@ package com.alibaba.cloud.ai.dataagent.service.integration;
 
 import com.alibaba.cloud.ai.dataagent.constant.Constant;
 import com.alibaba.cloud.ai.dataagent.constant.DocumentMetadataConstant;
+import com.alibaba.cloud.ai.dataagent.entity.AgentKnowledge;
+import com.alibaba.cloud.ai.dataagent.enums.KnowledgeType;
 import com.alibaba.cloud.ai.dataagent.properties.DataAgentProperties;
+import com.alibaba.cloud.ai.dataagent.service.knowledge.AgentKnowledgeResourceManager;
 import com.alibaba.cloud.ai.dataagent.service.vectorstore.AgentVectorStoreService;
 import com.alibaba.cloud.ai.dataagent.service.vectorstore.AgentVectorStoreServiceImpl;
 import com.alibaba.cloud.ai.dataagent.service.vectorstore.MetadataAwareSimpleVectorStore;
@@ -86,6 +89,24 @@ class VectorReplacementIntegrationTest {
 
 		assertThat(search("用户查询")).extracting(Document::getText).containsExactly("用户新定义");
 		assertThat(search("订单查询")).isEmpty();
+	}
+
+	@Test
+	void qaKnowledgeReembeddingUsesTheRealAtomicReplacementPath() throws Exception {
+		AgentKnowledge knowledge = new AgentKnowledge();
+		knowledge.setId(11);
+		knowledge.setAgentId(1);
+		knowledge.setType(KnowledgeType.QA);
+		knowledge.setQuestion("用户旧问题");
+		AgentKnowledgeResourceManager resourceManager = new AgentKnowledgeResourceManager(null, null, service);
+
+		resourceManager.doEmbedingToVectorStore(knowledge);
+		knowledge.setQuestion("订单新问题");
+		resourceManager.doEmbedingToVectorStore(knowledge);
+
+		Filter.Expression filter = new FilterExpressionBuilder().eq(DocumentMetadataConstant.DB_AGENT_KNOWLEDGE_ID, 11)
+			.build();
+		assertThat(service.getDocumentsOnlyByFilter(filter, 5)).extracting(Document::getText).containsExactly("订单新问题");
 	}
 
 	private List<Document> search(String query) {

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/schema/SchemaServiceImplTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/schema/SchemaServiceImplTest.java
@@ -212,7 +212,7 @@ class SchemaServiceImplTest {
 
 	@Test
 	void getTableDocumentsByDatasource_delegates() {
-		when(agentVectorStoreService.getDocumentsOnlyByFilter(any(), anyInt())).thenReturn(List.of());
+		when(agentVectorStoreService.similaritySearch(anyString(), any(), anyInt(), anyDouble())).thenReturn(List.of());
 
 		List<Document> result = schemaService.getTableDocumentsByDatasource(1, "test query");
 		assertNotNull(result);

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/schema/SchemaVectorRecallIntegrationTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/schema/SchemaVectorRecallIntegrationTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.service.schema;
+
+import com.alibaba.cloud.ai.dataagent.constant.Constant;
+import com.alibaba.cloud.ai.dataagent.constant.DocumentMetadataConstant;
+import com.alibaba.cloud.ai.dataagent.properties.DataAgentProperties;
+import com.alibaba.cloud.ai.dataagent.service.vectorstore.AgentVectorStoreService;
+import com.alibaba.cloud.ai.dataagent.service.vectorstore.AgentVectorStoreServiceImpl;
+import com.alibaba.cloud.ai.dataagent.service.vectorstore.MetadataAwareSimpleVectorStore;
+import com.alibaba.cloud.ai.dataagent.service.vectorstore.DynamicFilterService;
+import com.alibaba.cloud.ai.dataagent.service.vector.MetadataDocumentRetriever;
+import com.alibaba.cloud.ai.dataagent.support.KeywordEmbeddingModel;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.SimpleVectorStore;
+import org.springframework.core.env.StandardEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SchemaVectorRecallIntegrationTest {
+
+	private ExecutorService executorService;
+
+	private AgentVectorStoreService vectorStoreService;
+
+	private SchemaServiceImpl schemaService;
+
+	@BeforeEach
+	void setUp() {
+		DataAgentProperties properties = new DataAgentProperties();
+		properties.getVectorStore().setTableTopkLimit(1);
+		properties.getVectorStore().setTableSimilarityThreshold(0.8);
+		SimpleVectorStore vectorStore = new MetadataAwareSimpleVectorStore(new KeywordEmbeddingModel());
+		vectorStoreService = new AgentVectorStoreServiceImpl(vectorStore, Optional.empty(), properties,
+				new DynamicFilterService(null, null), new MetadataDocumentRetriever(new StandardEnvironment()));
+		executorService = Executors.newSingleThreadExecutor();
+		schemaService = new SchemaServiceImpl(executorService, null, null, null, null, properties, vectorStoreService);
+
+		vectorStoreService.addDocuments("7",
+				List.of(tableDocument("orders", "订单销售数据"), tableDocument("users", "用户注册信息")));
+	}
+
+	@AfterEach
+	void tearDown() {
+		executorService.shutdownNow();
+	}
+
+	@Test
+	void schemaRecallUsesTheUserQueryInsteadOfAConstantProbe() {
+		List<Document> result = schemaService.getTableDocumentsByDatasource(7, "查询订单销售数据");
+
+		assertThat(result).extracting(document -> document.getMetadata().get(DocumentMetadataConstant.NAME))
+			.containsExactly("orders");
+	}
+
+	@Test
+	void initializationCheckUsesDatasourceAndSelectedTableScope() {
+		assertThat(vectorStoreService.hasTableDocuments(7, List.of("orders", "users"))).isTrue();
+		assertThat(vectorStoreService.hasTableDocuments(7, List.of("orders", "missing"))).isFalse();
+	}
+
+	private Document tableDocument(String name, String text) {
+		return new Document(text,
+				Map.of(Constant.DATASOURCE_ID, "7", DocumentMetadataConstant.VECTOR_TYPE,
+						DocumentMetadataConstant.TABLE, DocumentMetadataConstant.NAME, name));
+	}
+
+}

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/schema/SchemaVectorRecallIntegrationTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/schema/SchemaVectorRecallIntegrationTest.java
@@ -81,9 +81,8 @@ class SchemaVectorRecallIntegrationTest {
 	}
 
 	private Document tableDocument(String name, String text) {
-		return new Document(text,
-				Map.of(Constant.DATASOURCE_ID, "7", DocumentMetadataConstant.VECTOR_TYPE,
-						DocumentMetadataConstant.TABLE, DocumentMetadataConstant.NAME, name));
+		return new Document(text, Map.of(Constant.DATASOURCE_ID, "7", DocumentMetadataConstant.VECTOR_TYPE,
+				DocumentMetadataConstant.TABLE, DocumentMetadataConstant.NAME, name));
 	}
 
 }

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/AgentVectorStoreServiceImplTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/AgentVectorStoreServiceImplTest.java
@@ -202,30 +202,4 @@ class AgentVectorStoreServiceImplTest {
 	void getDocumentsOnlyByFilter_nullFilter_throws() {
 		assertThrows(IllegalArgumentException.class, () -> service.getDocumentsOnlyByFilter(null, 10));
 	}
-
-	@Test
-	void getDocumentsOnlyByFilter_nullTopK_usesDefault() {
-		FilterExpressionBuilder b = new FilterExpressionBuilder();
-		Filter.Expression filter = b.eq("agentId", "1").build();
-		when(vectorStore.similaritySearch(any(SearchRequest.class))).thenReturn(List.of());
-
-		List<Document> result = service.getDocumentsOnlyByFilter(filter, null);
-		assertNotNull(result);
-	}
-
-	@Test
-	void hasSchemaDocuments_withDocs_returnsTrue() {
-		Document doc = new Document("content", Map.of("agentId", "1"));
-		when(vectorStore.similaritySearch(any(SearchRequest.class))).thenReturn(List.of(doc));
-
-		assertTrue(service.hasSchemaDocuments("1"));
-	}
-
-	@Test
-	void hasSchemaDocuments_noDocs_returnsFalse() {
-		when(vectorStore.similaritySearch(any(SearchRequest.class))).thenReturn(Collections.emptyList());
-
-		assertFalse(service.hasSchemaDocuments("1"));
-	}
-
 }

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/AgentVectorStoreServiceImplTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/AgentVectorStoreServiceImplTest.java
@@ -202,4 +202,5 @@ class AgentVectorStoreServiceImplTest {
 	void getDocumentsOnlyByFilter_nullFilter_throws() {
 		assertThrows(IllegalArgumentException.class, () -> service.getDocumentsOnlyByFilter(null, 10));
 	}
+
 }

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/MetadataAwareSimpleVectorStoreTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/MetadataAwareSimpleVectorStoreTest.java
@@ -15,31 +15,21 @@
  */
 package com.alibaba.cloud.ai.dataagent.service.vectorstore;
 
+import com.alibaba.cloud.ai.dataagent.support.KeywordEmbeddingModel;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.document.Document;
-import org.springframework.ai.embedding.EmbeddingModel;
 
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.when;
 
 class MetadataAwareSimpleVectorStoreTest {
 
 	@Test
-	void deleteByMetadata_doesNotInvokeEmbeddingModel() {
-		EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
-		when(embeddingModel.dimensions()).thenReturn(2);
-		when(embeddingModel.embed(any(Document.class))).thenReturn(new float[] { 1.0f, 0.0f });
-		MetadataAwareSimpleVectorStore store = new MetadataAwareSimpleVectorStore(embeddingModel);
+	void deleteByMetadata_removesOnlyExactMetadataMatches() {
+		MetadataAwareSimpleVectorStore store = new MetadataAwareSimpleVectorStore(new KeywordEmbeddingModel());
 		store.add(List.of(new Document("one", Map.of("agentId", "1")), new Document("two", Map.of("agentId", "2"))));
-
-		reset(embeddingModel);
-		when(embeddingModel.dimensions()).thenThrow(new IllegalStateException("embedding unavailable"));
 
 		assertEquals(1, store.deleteByMetadata(Map.of("agentId", 1)));
 		assertEquals(0, store.deleteByMetadata(Map.of("agentId", "1")));

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/MetadataAwareSimpleVectorStoreTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/vectorstore/MetadataAwareSimpleVectorStoreTest.java
@@ -15,13 +15,19 @@
  */
 package com.alibaba.cloud.ai.dataagent.service.vectorstore;
 
+import com.alibaba.cloud.ai.dataagent.service.vector.MetadataDocumentRetriever;
 import com.alibaba.cloud.ai.dataagent.support.KeywordEmbeddingModel;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.SimpleVectorStore;
+import org.springframework.ai.vectorstore.filter.FilterExpressionBuilder;
+import org.springframework.core.env.StandardEnvironment;
 
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class MetadataAwareSimpleVectorStoreTest {
@@ -34,6 +40,29 @@ class MetadataAwareSimpleVectorStoreTest {
 		assertEquals(1, store.deleteByMetadata(Map.of("agentId", 1)));
 		assertEquals(0, store.deleteByMetadata(Map.of("agentId", "1")));
 		assertEquals(1, store.deleteByMetadata(Map.of("agentId", "2")));
+	}
+
+	@Test
+	void exactMetadataRetrievalDoesNotRequireAQueryEmbedding() {
+		MetadataAwareSimpleVectorStore store = new MetadataAwareSimpleVectorStore(new KeywordEmbeddingModel());
+		store.add(List.of(new Document("first order", Map.of("agentId", "1")),
+				new Document("second order", Map.of("agentId", "1")),
+				new Document("other order", Map.of("agentId", "2"))));
+		var filter = new FilterExpressionBuilder().eq("agentId", "1").build();
+		MetadataDocumentRetriever retriever = new MetadataDocumentRetriever(new StandardEnvironment());
+
+		assertThat(retriever.find(store, filter, 1)).hasSize(1)
+			.allSatisfy(document -> assertThat(document.getMetadata()).containsEntry("agentId", "1"));
+	}
+
+	@Test
+	void unsupportedStoresFailInsteadOfFallingBackToSyntheticSimilaritySearch() {
+		SimpleVectorStore store = SimpleVectorStore.builder(new KeywordEmbeddingModel()).build();
+		var filter = new FilterExpressionBuilder().eq("agentId", "1").build();
+		MetadataDocumentRetriever retriever = new MetadataDocumentRetriever(new StandardEnvironment());
+
+		assertThatThrownBy(() -> retriever.find(store, filter, 1)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Exact metadata retrieval is not supported");
 	}
 
 }

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/support/KeywordEmbeddingModel.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/support/KeywordEmbeddingModel.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dataagent.support;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import org.springframework.ai.embedding.Embedding;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.embedding.EmbeddingRequest;
+import org.springframework.ai.embedding.EmbeddingResponse;
+import org.springframework.ai.document.Document;
+
+/**
+ * Small deterministic embedding model for vector-store integration tests. It performs
+ * real vector calculations without a network dependency or mocking framework.
+ */
+public final class KeywordEmbeddingModel implements EmbeddingModel {
+
+	private static final int DIMENSIONS = 3;
+
+	@Override
+	public EmbeddingResponse call(EmbeddingRequest request) {
+		List<Embedding> embeddings = new ArrayList<>();
+		for (int i = 0; i < request.getInstructions().size(); i++) {
+			embeddings.add(new Embedding(embed(request.getInstructions().get(i)), i));
+		}
+		return new EmbeddingResponse(embeddings);
+	}
+
+	@Override
+	public float[] embed(String text) {
+		String normalized = text == null ? "" : text.toLowerCase(Locale.ROOT);
+		if (normalized.contains("订单") || normalized.contains("order")) {
+			return new float[] { 1.0f, 0.0f, 0.0f };
+		}
+		if (normalized.contains("用户") || normalized.contains("user")) {
+			return new float[] { 0.0f, 1.0f, 0.0f };
+		}
+		return new float[] { 0.0f, 0.0f, 1.0f };
+	}
+
+	@Override
+	public float[] embed(Document document) {
+		return embed(document.getText());
+	}
+
+	@Override
+	public int dimensions() {
+		return DIMENSIONS;
+	}
+
+}


### PR DESCRIPTION
## What changed

- Replace synthetic similarity queries used for metadata-only reads with provider-specific exact metadata retrieval for SimpleVectorStore, Milvus, and Elasticsearch.
- Check schema completeness by datasource and the complete requested table set instead of treating one recalled document as successful initialization.
- Make vector replacement write the new documents before deleting the old set, assign fresh IDs when required, and roll back newly written documents on failure.
- Validate embedding dimensions/model compatibility before activation and before vector operations can corrupt an existing collection.
- Recover pending and stale embedding work at startup, with mapper-level integration coverage.
- Persist SimpleVectorStore snapshots through a temporary file and atomic move.
- Add bounded timeouts to hybrid retrieval and expose the timeout through vector-store configuration.
- Reuse the upstream `MetadataAwareSimpleVectorStore` introduced by #562 rather than adding a parallel implementation.

## Why

The previous metadata path was implemented as `similaritySearch("default")`. That made existence checks and deletion depend on the active embedding model and similarity ranking, so exact metadata matches could be missed. Replacement also deleted old vectors before the new set was safely established. A model/dimension change, interrupted persistence, stuck embedding status, or an unbounded hybrid request could therefore cause missing recall, data loss, or permanently blocked work.

## Validation

- `./mvnw -pl data-agent-management -DskipTests test-compile`
- `./mvnw -pl data-agent-management -Dtest='SchemaVectorRecallIntegrationTest,VectorReplacementIntegrationTest,SimpleVectorStorePersistenceIntegrationTest,EmbeddingModelCompatibilityValidatorTest,VectorStoreConfigurationTest,EmbeddingRecoveryMapperIntegrationTest,MetadataAwareSimpleVectorStoreTest' test` — 14 passed
- `./mvnw -q -pl data-agent-management test` — 1819 passed, 0 failures, 0 errors, 1 skipped
- The new vector regression tests use a deterministic real `EmbeddingModel` and real `SimpleVectorStore`; they do not use Mockito.
- `MilvusVectorStoreIntegrationTest` exercises add/search/exact-filter/delete against an actual Milvus server and is gated by `-Ddataagent.milvus.integration=true`. It was not rerun during the final rebase because the local Docker daemon was unavailable.

## Notes

- This branch is rebased directly onto the current upstream `main` (`ff49a5f`).
- Local datasource credentials in `application.yml` are intentionally excluded from the commit.
