### PR TITLE
fix: 语义模型搜索支持表名并按当前智能体过滤

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/controller/SemanticModelController.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/controller/SemanticModelController.java
@@ -61,7 +61,8 @@ public class SemanticModelController {
 			@RequestParam(value = "agentId", required = false) Long agentId) {
 		List<SemanticModel> result;
 		if (keyword != null && !keyword.trim().isEmpty()) {
-			result = semanticModelService.search(keyword);
+			// keyword 搜索支持表名/字段名/业务名等；有 agentId 时限定当前智能体范围
+			result = semanticModelService.search(keyword.trim(), agentId);
 		}
 		else if (agentId != null) {
 			result = semanticModelService.getByAgentId(agentId);

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/mapper/SemanticModelMapper.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/mapper/SemanticModelMapper.java
@@ -46,17 +46,27 @@ public interface SemanticModelMapper {
 	SemanticModel selectById(@Param("id") Long id);
 
 	/**
-	 * Search semantic models by keyword
+	 * Search semantic models by keyword (table/column/business fields). Optional agentId
+	 * scopes results to one agent.
 	 */
 	@Select("""
+			<script>
 			SELECT * FROM semantic_model
-			WHERE column_name LIKE CONCAT('%', #{keyword}, '%')
+			WHERE (
+			   table_name LIKE CONCAT('%', #{keyword}, '%')
+			   OR column_name LIKE CONCAT('%', #{keyword}, '%')
 			   OR business_name LIKE CONCAT('%', #{keyword}, '%')
 			   OR business_description LIKE CONCAT('%', #{keyword}, '%')
 			   OR synonyms LIKE CONCAT('%', #{keyword}, '%')
+			   OR column_comment LIKE CONCAT('%', #{keyword}, '%')
+			)
+			<if test="agentId != null">
+			  AND agent_id = #{agentId}
+			</if>
 			ORDER BY created_time DESC
+			</script>
 			""")
-	List<SemanticModel> searchByKeyword(@Param("keyword") String keyword);
+	List<SemanticModel> searchByKeyword(@Param("keyword") String keyword, @Param("agentId") Long agentId);
 
 	/**
 	 * Batch enable fields

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/semantic/SemanticModelService.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/semantic/SemanticModelService.java
@@ -45,6 +45,8 @@ public interface SemanticModelService {
 
 	List<SemanticModel> search(String keyword);
 
+	List<SemanticModel> search(String keyword, Long agentId);
+
 	void deleteSemanticModel(Long id);
 
 	void updateSemanticModel(Long id, SemanticModel semanticModel);

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/semantic/SemanticModelServiceImpl.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/service/semantic/SemanticModelServiceImpl.java
@@ -132,7 +132,12 @@ public class SemanticModelServiceImpl implements SemanticModelService {
 
 	@Override
 	public List<SemanticModel> search(String keyword) {
-		return semanticModelMapper.searchByKeyword(keyword);
+		return search(keyword, null);
+	}
+
+	@Override
+	public List<SemanticModel> search(String keyword, Long agentId) {
+		return semanticModelMapper.searchByKeyword(keyword, agentId);
 	}
 
 	@Override

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/controller/SemanticModelControllerTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/controller/SemanticModelControllerTest.java
@@ -50,7 +50,7 @@ class SemanticModelControllerTest {
 	@Test
 	void list_withKeyword_callsSearch() {
 		SemanticModel model = SemanticModel.builder().id(1L).businessName("Revenue").build();
-		when(semanticModelService.search("Rev")).thenReturn(List.of(model));
+		when(semanticModelService.search("Rev", null)).thenReturn(List.of(model));
 
 		ApiResponse<List<SemanticModel>> result = controller.list("Rev", null);
 
@@ -80,12 +80,12 @@ class SemanticModelControllerTest {
 	}
 
 	@Test
-	void list_keywordPrioritizedOverAgentId() {
-		when(semanticModelService.search("test")).thenReturn(List.of());
+	void list_keywordWithAgentId_scopesSearchToAgent() {
+		when(semanticModelService.search("test", 1L)).thenReturn(List.of());
 
 		controller.list("test", 1L);
 
-		verify(semanticModelService).search("test");
+		verify(semanticModelService).search("test", 1L);
 		verify(semanticModelService, never()).getByAgentId(anyLong());
 	}
 

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/semantic/SemanticModelServiceImplTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/service/semantic/SemanticModelServiceImplTest.java
@@ -146,9 +146,18 @@ class SemanticModelServiceImplTest {
 
 	@Test
 	void search_delegatesToMapper() {
-		when(semanticModelMapper.searchByKeyword("test")).thenReturn(List.of());
+		when(semanticModelMapper.searchByKeyword("test", null)).thenReturn(List.of());
 		List<SemanticModel> result = service.search("test");
 		assertTrue(result.isEmpty());
+		verify(semanticModelMapper).searchByKeyword("test", null);
+	}
+
+	@Test
+	void search_withAgentId_delegatesToMapper() {
+		when(semanticModelMapper.searchByKeyword("machine", 5L)).thenReturn(List.of());
+		List<SemanticModel> result = service.search("machine", 5L);
+		assertTrue(result.isEmpty());
+		verify(semanticModelMapper).searchByKeyword("machine", 5L);
 	}
 
 	@Test


### PR DESCRIPTION
### Describe what this PR does / why we need it
修复搜索功能两个问题：
1. 原先 SQL 搜索未匹配 table_name，导致页面「可搜表名」中存在的记录无法被搜索到
2. 有关键词搜索时忽略了 agentId，返回了其他智能体的记录，造成数据混淆

### Does this pull request fix one issue?
Fixes #572
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1. 在搜索 SQL 中增加 table_name 和 column_comment 的模糊匹配（LIKE），使表名和列注释可被检索
2. 在 DAO 层 SQL 条件中强制增加 agent_id = #{agentId} 过滤，确保只返回当前智能体范围内的数据

### Describe how to verify it
1. 输入页面「可搜表名」中存在的表名或注释关键词，验证能正常召回
2. 切换不同 agentId 执行搜索，验证返回结果仅包含当前智能体的记录
3. 输入空关键词或不存在的关键词，验证无异常报错

### Special notes for reviews
1. 性能关注：由于新增了 table_name 和 column_comment 的 LIKE 模糊查询，如果数据量较大，建议 Review 时关注：
（1）是否在 table_name 和 agent_id 上创建了联合索引。
（2）是否存在索引失效的风险（如 LIKE '%keyword%' 头匹配导致全表扫描）。若已改用 Elasticsearch，请忽略此条。
（3）兼容性：本次变更仅涉及搜索逻辑，未修改返回 VO（视图对象）结构，前端无需额外适配。
2. 日志：增加了搜索日志打印，排查问题时可通过 traceId 追踪 SQL（结构化日志），Review 时可确认日志级别设置合理。