### PR TITLE
fix(report): prevent chart title and legend overlap

### DIFF
--- a/data-agent-frontend-nuxt/app/utils/report-html-template.test.ts
+++ b/data-agent-frontend-nuxt/app/utils/report-html-template.test.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildReportHtml } from './report-html-template';
+
+describe('buildReportHtml', () => {
+	it('reserves separate space for chart titles and legends', () => {
+		const html = buildReportHtml('```echarts\n{"title":{"text":"趋势"},"legend":{},"series":[]}\n```');
+
+		expect(html).toContain('normalizeChartLayout');
+		expect(html).toContain('legend.top = titles.length > 0 ? 50 : 10');
+		expect(html).toContain('grid.containLabel = true');
+	});
+});

--- a/data-agent-frontend-nuxt/app/utils/report-html-template.ts
+++ b/data-agent-frontend-nuxt/app/utils/report-html-template.ts
@@ -63,6 +63,27 @@ pre code { background: transparent; color: inherit; padding: 0; }
 <div id="render-target" class="markdown-body"></div>
 </div>
 <script>
+function normalizeChartLayout(option) {
+  var titles = option.title ? (Array.isArray(option.title) ? option.title : [option.title]) : [];
+  var legends = option.legend ? (Array.isArray(option.legend) ? option.legend : [option.legend]) : [];
+  titles.forEach(function(title) {
+    if (title && title.top == null) title.top = 10;
+  });
+  legends.forEach(function(legend) {
+    if (legend && legend.top == null) legend.top = titles.length > 0 ? 50 : 10;
+  });
+
+  var reservedTop = titles.length > 0 && legends.length > 0 ? 90
+    : (titles.length > 0 || legends.length > 0 ? 60 : 40);
+  var grids = option.grid ? (Array.isArray(option.grid) ? option.grid : [option.grid]) : [{}];
+  grids.forEach(function(grid) {
+    if (grid.top == null) grid.top = reservedTop;
+    if (grid.containLabel == null) grid.containLabel = true;
+  });
+  option.grid = Array.isArray(option.grid) ? grids : grids[0];
+  return option;
+}
+
 window.onload = function() {
   if (typeof marked === 'undefined') {
     document.getElementById('render-target').innerHTML = '<p style="color:red;">Marked库加载失败，请检查网络</p>';
@@ -84,7 +105,7 @@ window.onload = function() {
     document.querySelectorAll('.chart-box').forEach(function(box) {
       try {
         var code = decodeURIComponent(box.getAttribute('data-option'));
-        var option = new Function('return ' + code)();
+        var option = normalizeChartLayout(new Function('return ' + code)());
         var myChart = echarts.init(box);
         myChart.setOption(option);
         window.addEventListener('resize', function() { myChart.resize(); });

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/util/ReportTemplateUtil.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/util/ReportTemplateUtil.java
@@ -168,6 +168,27 @@ public class ReportTemplateUtil {
 			</div> <!-- container 结束 -->
 
 			<script>
+			  function normalizeChartLayout(option) {
+			      const titles = option.title ? (Array.isArray(option.title) ? option.title : [option.title]) : [];
+			      const legends = option.legend ? (Array.isArray(option.legend) ? option.legend : [option.legend]) : [];
+			      titles.forEach(title => {
+			          if (title && title.top == null) title.top = 10;
+			      });
+			      legends.forEach(legend => {
+			          if (legend && legend.top == null) legend.top = titles.length > 0 ? 50 : 10;
+			      });
+
+			      const reservedTop = titles.length > 0 && legends.length > 0 ? 90
+			          : (titles.length > 0 || legends.length > 0 ? 60 : 40);
+			      const grids = option.grid ? (Array.isArray(option.grid) ? option.grid : [option.grid]) : [{}];
+			      grids.forEach(grid => {
+			          if (grid.top == null) grid.top = reservedTop;
+			          if (grid.containLabel == null) grid.containLabel = true;
+			      });
+			      option.grid = Array.isArray(option.grid) ? grids : grids[0];
+			      return option;
+			  }
+
 			  window.onload = function() {
 			      // 0. 安全检查
 			      if (typeof marked === 'undefined') {
@@ -205,7 +226,7 @@ public class ReportTemplateUtil {
 			                  // 🌟 核心修改：使用 new Function 替代 JSON.parse
 			                  // 这样可以兼容 LLM 生成的 JS 函数 (formatter: function()...)
 			                  // 注意：这就要求 LLM 生成的是 JS 对象字面量，而不仅仅是 JSON (通常 LLM 都会这么做)
-			                  const option = new Function('return ' + code)();
+			                  const option = normalizeChartLayout(new Function('return ' + code)());
 
 			                  const myChart = echarts.init(box);
 			                  myChart.setOption(option);

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/util/ReportTemplateUtilTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/util/ReportTemplateUtilTest.java
@@ -69,6 +69,15 @@ class ReportTemplateUtilTest {
 	}
 
 	@Test
+	void testGetFooter_preventsDefaultTitleLegendOverlap() {
+		ReportTemplateUtil footerUtil = new ReportTemplateUtil(dataAgentProperties);
+		String footer = footerUtil.getFooter();
+		assertTrue(footer.contains("normalizeChartLayout"));
+		assertTrue(footer.contains("legend.top = titles.length > 0 ? 50 : 10"));
+		assertTrue(footer.contains("grid.containLabel = true"));
+	}
+
+	@Test
 	void testCleanJsonExample_notNull() {
 		assertNotNull(ReportTemplateUtil.cleanJsonExample);
 		assertTrue(ReportTemplateUtil.cleanJsonExample.contains("title"));


### PR DESCRIPTION
## Summary
- normalize missing ECharts title, legend, and grid offsets before rendering reports
- preserve explicitly generated layout values while reserving separate default space for titles and legends
- apply the same layout normalization to backend exports and frontend HTML preview/download

## Validation
- `./mvnw -pl data-agent-management -Dtest=ReportTemplateUtilTest test` (5 tests)
- `./mvnw -pl data-agent-management test` (1630 tests)
- `pnpm exec vitest run app/utils/report-html-template.test.ts` (1 test)
- `pnpm build`

Fixes #354