### PR TITLE
fix(planner): handle concatenated plan responses

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/util/PlanProcessUtil.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/util/PlanProcessUtil.java
@@ -18,9 +18,11 @@ package com.alibaba.cloud.ai.dataagent.util;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.dataagent.dto.planner.ExecutionStep;
 import com.alibaba.cloud.ai.dataagent.dto.planner.Plan;
+import com.fasterxml.jackson.databind.MappingIterator;
 import org.springframework.ai.converter.BeanOutputConverter;
 import org.springframework.core.ParameterizedTypeReference;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -101,11 +103,31 @@ public final class PlanProcessUtil {
 	public static Plan getPlan(OverAllState state) {
 		String plannerNodeOutput = (String) state.value(PLANNER_NODE_OUTPUT)
 			.orElseThrow(() -> new IllegalStateException("计划节点输出为空"));
-		Plan plan = converter.convert(plannerNodeOutput);
+		Plan plan = convertPlan(plannerNodeOutput);
 		if (plan == null) {
 			throw new IllegalStateException("计划解析失败");
 		}
 		return plan;
+	}
+
+	private static Plan convertPlan(String plannerNodeOutput) {
+		try (MappingIterator<Plan> plans = JsonUtil.getObjectMapper()
+			.readerFor(Plan.class)
+			.readValues(plannerNodeOutput)) {
+			Plan lastPlan = null;
+			int planCount = 0;
+			while (plans.hasNextValue()) {
+				lastPlan = plans.nextValue();
+				planCount++;
+			}
+			if (planCount > 1) {
+				return lastPlan;
+			}
+		}
+		catch (IOException ignored) {
+			// Let the existing converter handle its supported wrappers and report errors.
+		}
+		return converter.convert(plannerNodeOutput);
 	}
 
 	/**

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/util/PlanProcessUtilTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/util/PlanProcessUtilTest.java
@@ -43,6 +43,18 @@ class PlanProcessUtilTest {
 	}
 
 	@Test
+	void getPlan_withConcatenatedPlans_returnsLastCompletePlan() {
+		String plannerOutput = TestFixtures.createSingleSqlPlanJson() + TestFixtures.createMultiStepPlanJson();
+		OverAllState state = TestFixtures.createStateWith(Map.of(PLANNER_NODE_OUTPUT, plannerOutput));
+
+		Plan plan = PlanProcessUtil.getPlan(state);
+
+		assertEquals("Multi-step analysis", plan.getThoughtProcess());
+		assertEquals(3, plan.getExecutionPlan().size());
+		assertEquals(REPORT_GENERATOR_NODE, plan.getExecutionPlan().get(2).getToolToUse());
+	}
+
+	@Test
 	void getPlan_withEmptyState_throwsException() {
 		OverAllState state = TestFixtures.createStateWith(PLANNER_NODE_OUTPUT);
 


### PR DESCRIPTION
## Summary
- detect when the planner model emits multiple complete JSON root objects in one response
- use the final complete plan so model self-corrections are not silently ignored
- preserve the existing converter path for normal single-plan responses and wrapped output

## Validation
- `./mvnw -pl data-agent-management -Dtest=PlanProcessUtilTest test` (13 tests)
- `./mvnw -pl data-agent-management test` (1630 tests)

Fixes #275