### PR TITLE
fix(planner): validate structured plan output

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/PlannerNode.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/PlannerNode.java
@@ -100,7 +100,7 @@ public class PlannerNode implements NodeAction {
 		log.debug("Planner prompt: as follows \n{}\n", plannerPrompt);
 
 		// 调用LLM生成计划
-		return llmService.callUser(plannerPrompt);
+		return llmService.callUser(plannerPrompt, Plan.class);
 	}
 
 	private Flux<ChatResponse> handleNl2SqlOnly(OverAllState state) {

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/workflow/node/orchestration/PlannerNodeTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/workflow/node/orchestration/PlannerNodeTest.java
@@ -18,6 +18,7 @@ package com.alibaba.cloud.ai.dataagent.workflow.node.orchestration;
 import static com.alibaba.cloud.ai.dataagent.constant.Constant.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -144,7 +145,7 @@ class PlannerNodeTest {
 		OverAllState state = createTestState();
 		setupBasicState(state);
 
-		when(llmService.callUser(anyString()))
+		when(llmService.callUser(anyString(), eq(Plan.class)))
 			.thenReturn(Flux.just(ChatResponseUtil.createPureResponse(VALID_PLAN_JSON)));
 
 		Map<String, Object> result = plannerNode.apply(state);
@@ -158,7 +159,7 @@ class PlannerNodeTest {
 		OverAllState state = createTestState();
 		setupBasicState(state);
 
-		when(llmService.callUser(anyString()))
+		when(llmService.callUser(anyString(), eq(Plan.class)))
 			.thenReturn(Flux.just(ChatResponseUtil.createPureResponse(MULTI_STEP_PLAN_JSON)));
 
 		Map<String, Object> result = plannerNode.apply(state);
@@ -198,7 +199,8 @@ class PlannerNodeTest {
 		OverAllState state = createTestState();
 		setupBasicState(state);
 
-		when(llmService.callUser(anyString())).thenThrow(new RuntimeException("LLM service unavailable"));
+		when(llmService.callUser(anyString(), eq(Plan.class)))
+			.thenThrow(new RuntimeException("LLM service unavailable"));
 
 		assertThrows(RuntimeException.class, () -> plannerNode.apply(state));
 	}
@@ -208,7 +210,7 @@ class PlannerNodeTest {
 		OverAllState state = createTestState();
 		setupBasicState(state);
 
-		when(llmService.callUser(anyString()))
+		when(llmService.callUser(anyString(), eq(Plan.class)))
 			.thenReturn(Flux.just(ChatResponseUtil.createPureResponse("this is not valid json at all")));
 
 		Map<String, Object> result = plannerNode.apply(state);
@@ -223,7 +225,7 @@ class PlannerNodeTest {
 		setupBasicState(state);
 		state.updateState(Map.of(PLAN_VALIDATION_ERROR, "请不要使用Python分析，直接用SQL", PLANNER_NODE_OUTPUT, VALID_PLAN_JSON));
 
-		when(llmService.callUser(anyString()))
+		when(llmService.callUser(anyString(), eq(Plan.class)))
 			.thenReturn(Flux.just(ChatResponseUtil.createPureResponse(VALID_PLAN_JSON)));
 
 		Map<String, Object> result = plannerNode.apply(state);
@@ -238,7 +240,7 @@ class PlannerNodeTest {
 		setupBasicState(state);
 		state.updateState(Map.of(GENEGRATED_SEMANTIC_MODEL_PROMPT, "语义模型定义：PV表示页面浏览量"));
 
-		when(llmService.callUser(anyString()))
+		when(llmService.callUser(anyString(), eq(Plan.class)))
 			.thenReturn(Flux.just(ChatResponseUtil.createPureResponse(VALID_PLAN_JSON)));
 
 		Map<String, Object> result = plannerNode.apply(state);
@@ -253,7 +255,7 @@ class PlannerNodeTest {
 		state.updateState(Map.of(QUERY_ENHANCE_NODE_OUTPUT, TEST_QUERY_ENHANCE, TABLE_RELATION_OUTPUT, TEST_SCHEMA,
 				EVIDENCE, "", GENEGRATED_SEMANTIC_MODEL_PROMPT, ""));
 
-		when(llmService.callUser(anyString()))
+		when(llmService.callUser(anyString(), eq(Plan.class)))
 			.thenReturn(Flux.just(ChatResponseUtil.createPureResponse(VALID_PLAN_JSON)));
 
 		Map<String, Object> result = plannerNode.apply(state);


### PR DESCRIPTION
## Problem and root cause

Planner responses were requested through the raw streaming LLM method even though the repository already provides structured-output validation. A truncated or malformed plan therefore reached `PlanExecutorNode`, where repeated full-plan regeneration could exhaust the workflow repair limit.

## Changes

- request planner responses with `Plan.class` through `StructuredOutputValidationAdvisor`
- let the existing framework validate and repair malformed structured output before it enters workflow state
- update planner tests to require the typed LLM call

## User impact

Planner JSON that is initially truncated or malformed gets the framework-level repair attempts instead of immediately failing plan parsing and terminating the workflow.

## Validation

- `./mvnw -pl data-agent-management -Dtest=PlannerNodeTest test` (9 tests)
- `./mvnw -pl data-agent-management test` (1629 tests)

## Compatibility and risk

The plan schema and downstream state format are unchanged. The planner now returns a validated response as one framework-managed result instead of exposing unvalidated partial JSON chunks.

Fixes #516