### PR TITLE
feat(datasource): add table selection search

### DIFF
--- a/data-agent-frontend-nuxt/app/pages/system/data-sources/ExpandedTableManager.vue
+++ b/data-agent-frontend-nuxt/app/pages/system/data-sources/ExpandedTableManager.vue
@@ -35,6 +35,25 @@
 			</div>
 			<v-divider class="mb-4" />
 
+			<v-text-field
+				v-if="!loadingTables && !fetchError && allTables.length > 0"
+				v-model="searchQuery"
+				label="搜索数据表"
+				placeholder="输入表名"
+				prepend-inner-icon="mdi-magnify"
+				variant="outlined"
+				density="compact"
+				clearable
+				hide-details
+				class="mb-4 table-search"
+			>
+				<template #append-inner>
+					<span class="text-caption text-medium-emphasis text-no-wrap">
+						{{ filteredTables.length }} / {{ allTables.length }}
+					</span>
+				</template>
+			</v-text-field>
+
 			<div v-if="loadingTables" class="d-flex justify-center py-8">
 				<v-progress-circular indeterminate color="primary" size="32" />
 			</div>
@@ -46,9 +65,9 @@
 				<v-btn color="primary" variant="outlined" size="small" @click="$emit('retry')">重试</v-btn>
 			</div>
 
-			<div v-else class="table-grid">
+			<div v-else-if="filteredTables.length > 0" class="table-grid">
 				<v-checkbox
-					v-for="tbl in allTables"
+					v-for="tbl in filteredTables"
 					:key="tbl"
 					v-model="selectedTables"
 					:label="tbl"
@@ -57,6 +76,11 @@
 					density="compact"
 					color="primary"
 				/>
+			</div>
+
+			<div v-if="!loadingTables && !fetchError && allTables.length > 0 && filteredTables.length === 0" class="empty-state">
+				<v-icon size="40" color="grey" class="mb-2">mdi-table-search</v-icon>
+				<p class="text-body-2 text-medium-emphasis">没有匹配“{{ searchQuery.trim() }}”的数据表</p>
 			</div>
 
 			<div v-if="!loadingTables && !fetchError && allTables.length === 0" class="empty-state">
@@ -68,7 +92,10 @@
 </template>
 
 <script setup lang="ts">
+import { filterTableNames } from '../../../utils/tableSearch';
+
 const selectedTables = defineModel<string[]>('selectedTables', { default: () => [] });
+const searchQuery = ref('');
 
 const props = defineProps<{
 	allTables: string[];
@@ -82,8 +109,14 @@ defineEmits<{
 	retry: [];
 }>();
 
+const filteredTables = computed(() =>
+	filterTableNames(props.allTables, searchQuery.value),
+);
+
 function selectAll() {
-	selectedTables.value = [...props.allTables];
+	selectedTables.value = [
+		...new Set([...selectedTables.value, ...filteredTables.value]),
+	];
 }
 
 function clearAll() {

--- a/data-agent-frontend-nuxt/app/utils/tableSearch.test.ts
+++ b/data-agent-frontend-nuxt/app/utils/tableSearch.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { filterTableNames } from './tableSearch';
+
+describe('filterTableNames', () => {
+	const tableNames = ['orders', 'Order_Items', 'customers'];
+
+	it('matches table names case-insensitively', () => {
+		expect(filterTableNames(tableNames, 'ORDER')).toEqual([
+			'orders',
+			'Order_Items',
+		]);
+	});
+
+	it('trims the query before matching', () => {
+		expect(filterTableNames(tableNames, '  items ')).toEqual(['Order_Items']);
+	});
+
+	it('keeps all tables for an empty query', () => {
+		expect(filterTableNames(tableNames, '   ')).toBe(tableNames);
+	});
+});

--- a/data-agent-frontend-nuxt/app/utils/tableSearch.ts
+++ b/data-agent-frontend-nuxt/app/utils/tableSearch.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function filterTableNames(
+	tableNames: string[],
+	searchQuery: string,
+): string[] {
+	const normalizedQuery = searchQuery.trim().toLocaleLowerCase();
+	if (!normalizedQuery) return tableNames;
+
+	return tableNames.filter((tableName) =>
+		tableName.toLocaleLowerCase().includes(normalizedQuery),
+	);
+}


### PR DESCRIPTION
## Problem and root cause

The rebuilt datasource table manager renders every available table without a search control. Large schemas therefore require scanning the entire checkbox grid to find tables for initialization.

## Changes

- add a clearable, case-insensitive table-name search field
- show visible and total table counts plus a dedicated no-match state
- make Select all merge only the currently filtered tables while preserving selections made under other filters
- extract and test the table-name filtering behavior

## User impact

Users can quickly locate and select tables in large datasources without losing selections made before changing the search query.

## Validation

- `pnpm exec vitest run app/utils/tableSearch.test.ts` (3 tests)
- `pnpm exec eslint app/pages/system/data-sources/ExpandedTableManager.vue app/utils/tableSearch.ts app/utils/tableSearch.test.ts`
- `pnpm build`

## Compatibility and risk

The component props, events, and selected-table model remain unchanged. With an empty query the full table list and existing Select all behavior are preserved.

Fixes #347