### PR TITLE
fix(ui): wrap long workflow code blocks

### DIFF
--- a/data-agent-frontend-nuxt/app/components/chat/ChatWorkflowTimeline.vue
+++ b/data-agent-frontend-nuxt/app/components/chat/ChatWorkflowTimeline.vue
@@ -551,8 +551,16 @@ watch(
 	padding: 10px 12px;
 	font-size: 12.5px;
 	overflow-x: auto;
-	white-space: pre;
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+	word-break: break-word;
 	margin: 4px 0 0;
+}
+
+:deep(.tl-code code) {
+	white-space: inherit;
+	overflow-wrap: inherit;
+	word-break: inherit;
 }
 
 /* ── Markdown inside step content ────────────────────────────────────────────── */


### PR DESCRIPTION
## 问题

工作流时间线中的 SQL 代码块使用 `white-space: pre`，长 SQL 会保持单行。macOS 默认隐藏横向滚动条，因此页面看起来像是内容没有展示完整。

## 修复

- 仅调整工作流时间线的代码块样式
- 使用 `pre-wrap` 保留代码格式并允许自动换行
- 使用 `overflow-wrap: anywhere` / `word-break: break-word` 处理无自然断点的长内容
- 同步约束内部 `code` 元素，避免 Markdown 样式覆盖
- 不改变最终报告中 Markdown 代码块的展示行为

## 验证

- `pnpm test:unit`：5 个测试文件、16 个测试全部通过
- `pnpm build`：Nuxt 客户端与服务端构建通过（Node.js 22）
- ESLint：目标组件通过
- `git diff --check`：通过
- 本地真实页面：180 字符 SQL 自动换行，`scrollWidth === clientWidth`，没有横向裁切
