### PR TITLE
fix(constant): correct typos in state key constants

### DIFF
--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/config/DataAgentConfiguration.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/config/DataAgentConfiguration.java
@@ -131,12 +131,12 @@ public class DataAgentConfiguration implements DisposableBean {
 			// QUERY_ENHANCE_NODE节点输出
 			keyStrategyHashMap.put(QUERY_ENHANCE_NODE_OUTPUT, KeyStrategy.REPLACE);
 			// Semantic model
-			keyStrategyHashMap.put(GENEGRATED_SEMANTIC_MODEL_PROMPT, KeyStrategy.REPLACE);
+			keyStrategyHashMap.put(GENERATED_SEMANTIC_MODEL_PROMPT, KeyStrategy.REPLACE);
 			// EVIDENCE节点输出
 			keyStrategyHashMap.put(EVIDENCE, KeyStrategy.REPLACE);
 			// schema recall节点输出
 			keyStrategyHashMap.put(TABLE_DOCUMENTS_FOR_SCHEMA_OUTPUT, KeyStrategy.REPLACE);
-			keyStrategyHashMap.put(COLUMN_DOCUMENTS__FOR_SCHEMA_OUTPUT, KeyStrategy.REPLACE);
+			keyStrategyHashMap.put(COLUMN_DOCUMENTS_FOR_SCHEMA_OUTPUT, KeyStrategy.REPLACE);
 			// table relation节点输出
 			keyStrategyHashMap.put(TABLE_RELATION_OUTPUT, KeyStrategy.REPLACE);
 			keyStrategyHashMap.put(TABLE_RELATION_EXCEPTION_OUTPUT, KeyStrategy.REPLACE);

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/constant/Constant.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/constant/Constant.java
@@ -50,7 +50,7 @@ public final class Constant {
 
 	public static final String SCHEMA_RECALL_NODE_OUTPUT = "SCHEMA_RECALL_NODE_OUTPUT";
 
-	public static final String COLUMN_DOCUMENTS__FOR_SCHEMA_OUTPUT = "COLUMN_DOCUMENTS__FOR_SCHEMA_OUTPUT";
+	public static final String COLUMN_DOCUMENTS_FOR_SCHEMA_OUTPUT = "COLUMN_DOCUMENTS_FOR_SCHEMA_OUTPUT";
 
 	public static final String TABLE_RELATION_OUTPUT = "TABLE_RELATION_OUTPUT";
 
@@ -58,7 +58,7 @@ public final class Constant {
 
 	public static final String TABLE_RELATION_RETRY_COUNT = "TABLE_RELATION_RETRY_COUNT";
 
-	public static final String GENEGRATED_SEMANTIC_MODEL_PROMPT = "GENEGRATED_SEMANTIC_MODEL_PROMPT";
+	public static final String GENERATED_SEMANTIC_MODEL_PROMPT = "GENERATED_SEMANTIC_MODEL_PROMPT";
 
 	public static final String SQL_GENERATE_OUTPUT = "SQL_GENERATE_OUTPUT";
 

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/PlannerNode.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/PlannerNode.java
@@ -82,7 +82,7 @@ public class PlannerNode implements NodeAction {
 		}
 
 		// 构建提示参数
-		String semanticModel = (String) state.value(GENEGRATED_SEMANTIC_MODEL_PROMPT).orElse("");
+		String semanticModel = (String) state.value(GENERATED_SEMANTIC_MODEL_PROMPT).orElse("");
 		SchemaDTO schemaDTO = StateUtil.getObjectValue(state, TABLE_RELATION_OUTPUT, SchemaDTO.class);
 		String schemaStr = PromptHelper.buildMixMacSqlDbPrompt(schemaDTO, true);
 

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/SchemaRecallNode.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/SchemaRecallNode.java
@@ -91,7 +91,7 @@ public class SchemaRecallNode implements NodeAction {
 			Flux<GraphResponse<StreamingOutput>> generator = FluxUtil
 				.createStreamingGeneratorWithMessages(this.getClass(), state, currentState -> {
 					return Map.of(TABLE_DOCUMENTS_FOR_SCHEMA_OUTPUT, Collections.emptyList(),
-							COLUMN_DOCUMENTS__FOR_SCHEMA_OUTPUT, Collections.emptyList());
+							COLUMN_DOCUMENTS_FOR_SCHEMA_OUTPUT, Collections.emptyList());
 				}, displayFlux);
 
 			return Map.of(SCHEMA_RECALL_NODE_OUTPUT, generator);
@@ -128,8 +128,8 @@ public class SchemaRecallNode implements NodeAction {
 
 		Flux<GraphResponse<StreamingOutput>> generator = FluxUtil.createStreamingGeneratorWithMessages(this.getClass(),
 				state, currentState -> {
-					return Map.of(TABLE_DOCUMENTS_FOR_SCHEMA_OUTPUT, tableDocuments,
-							COLUMN_DOCUMENTS__FOR_SCHEMA_OUTPUT, columnDocuments);
+					return Map.of(TABLE_DOCUMENTS_FOR_SCHEMA_OUTPUT, tableDocuments, COLUMN_DOCUMENTS_FOR_SCHEMA_OUTPUT,
+							columnDocuments);
 				}, displayFlux);
 
 		// Return the processing result

--- a/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/TableRelationNode.java
+++ b/data-agent-management/src/main/java/com/alibaba/cloud/ai/dataagent/workflow/node/TableRelationNode.java
@@ -16,10 +16,10 @@
 package com.alibaba.cloud.ai.dataagent.workflow.node;
 
 import static com.alibaba.cloud.ai.dataagent.constant.Constant.AGENT_ID;
-import static com.alibaba.cloud.ai.dataagent.constant.Constant.COLUMN_DOCUMENTS__FOR_SCHEMA_OUTPUT;
+import static com.alibaba.cloud.ai.dataagent.constant.Constant.COLUMN_DOCUMENTS_FOR_SCHEMA_OUTPUT;
 import static com.alibaba.cloud.ai.dataagent.constant.Constant.DB_DIALECT_TYPE;
 import static com.alibaba.cloud.ai.dataagent.constant.Constant.EVIDENCE;
-import static com.alibaba.cloud.ai.dataagent.constant.Constant.GENEGRATED_SEMANTIC_MODEL_PROMPT;
+import static com.alibaba.cloud.ai.dataagent.constant.Constant.GENERATED_SEMANTIC_MODEL_PROMPT;
 import static com.alibaba.cloud.ai.dataagent.constant.Constant.SQL_GENERATE_SCHEMA_MISSING_ADVICE;
 import static com.alibaba.cloud.ai.dataagent.constant.Constant.TABLE_DOCUMENTS_FOR_SCHEMA_OUTPUT;
 import static com.alibaba.cloud.ai.dataagent.constant.Constant.TABLE_RELATION_EXCEPTION_OUTPUT;
@@ -98,7 +98,7 @@ public class TableRelationNode implements NodeAction {
 
 		String evidence = StateUtil.getStringValue(state, EVIDENCE);
 		List<Document> tableDocuments = StateUtil.getDocumentList(state, TABLE_DOCUMENTS_FOR_SCHEMA_OUTPUT);
-		List<Document> columnDocuments = StateUtil.getDocumentList(state, COLUMN_DOCUMENTS__FOR_SCHEMA_OUTPUT);
+		List<Document> columnDocuments = StateUtil.getDocumentList(state, COLUMN_DOCUMENTS_FOR_SCHEMA_OUTPUT);
 		String agentIdStr = StateUtil.getStringValue(state, AGENT_ID);
 
 		// Execute business logic first - get final result immediately
@@ -130,7 +130,7 @@ public class TableRelationNode implements NodeAction {
 
 					// 构建语义模型提示并存储到resultMap中
 					String semanticModelPrompt = buildSemanticModelPrompt(semanticModels);
-					resultMap.put(GENEGRATED_SEMANTIC_MODEL_PROMPT, semanticModelPrompt);
+					resultMap.put(GENERATED_SEMANTIC_MODEL_PROMPT, semanticModelPrompt);
 				});
 
 		// Create display stream for user experience only

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/workflow/node/SchemaRecallNodeTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/workflow/node/SchemaRecallNodeTest.java
@@ -63,7 +63,7 @@ class SchemaRecallNodeTest {
 		state.registerKeyAndStrategy(AGENT_ID, new ReplaceStrategy());
 		state.registerKeyAndStrategy(SCHEMA_RECALL_NODE_OUTPUT, new ReplaceStrategy());
 		state.registerKeyAndStrategy(TABLE_DOCUMENTS_FOR_SCHEMA_OUTPUT, new ReplaceStrategy());
-		state.registerKeyAndStrategy(COLUMN_DOCUMENTS__FOR_SCHEMA_OUTPUT, new ReplaceStrategy());
+		state.registerKeyAndStrategy(COLUMN_DOCUMENTS_FOR_SCHEMA_OUTPUT, new ReplaceStrategy());
 		return state;
 	}
 

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/workflow/node/TableRelationNodeTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/workflow/node/TableRelationNodeTest.java
@@ -84,14 +84,14 @@ class TableRelationNodeTest {
 		state.registerKeyAndStrategy(QUERY_ENHANCE_NODE_OUTPUT, new ReplaceStrategy());
 		state.registerKeyAndStrategy(EVIDENCE, new ReplaceStrategy());
 		state.registerKeyAndStrategy(TABLE_DOCUMENTS_FOR_SCHEMA_OUTPUT, new ReplaceStrategy());
-		state.registerKeyAndStrategy(COLUMN_DOCUMENTS__FOR_SCHEMA_OUTPUT, new ReplaceStrategy());
+		state.registerKeyAndStrategy(COLUMN_DOCUMENTS_FOR_SCHEMA_OUTPUT, new ReplaceStrategy());
 		state.registerKeyAndStrategy(AGENT_ID, new ReplaceStrategy());
 		state.registerKeyAndStrategy(TABLE_RELATION_OUTPUT, new ReplaceStrategy());
 		state.registerKeyAndStrategy(DB_DIALECT_TYPE, new ReplaceStrategy());
 		state.registerKeyAndStrategy(TABLE_RELATION_RETRY_COUNT, new ReplaceStrategy());
 		state.registerKeyAndStrategy(TABLE_RELATION_EXCEPTION_OUTPUT, new ReplaceStrategy());
 		state.registerKeyAndStrategy(SQL_GENERATE_SCHEMA_MISSING_ADVICE, new ReplaceStrategy());
-		state.registerKeyAndStrategy(GENEGRATED_SEMANTIC_MODEL_PROMPT, new ReplaceStrategy());
+		state.registerKeyAndStrategy(GENERATED_SEMANTIC_MODEL_PROMPT, new ReplaceStrategy());
 		return state;
 	}
 
@@ -132,7 +132,7 @@ class TableRelationNodeTest {
 		List<Document> colDocs = List.of(new Document("column doc"));
 
 		state.updateState(Map.of(QUERY_ENHANCE_NODE_OUTPUT, dto, EVIDENCE, "evidence", AGENT_ID, "1",
-				TABLE_DOCUMENTS_FOR_SCHEMA_OUTPUT, tableDocs, COLUMN_DOCUMENTS__FOR_SCHEMA_OUTPUT, colDocs));
+				TABLE_DOCUMENTS_FOR_SCHEMA_OUTPUT, tableDocs, COLUMN_DOCUMENTS_FOR_SCHEMA_OUTPUT, colDocs));
 
 		setupCommonMocks("1", tableDocs);
 
@@ -154,7 +154,7 @@ class TableRelationNodeTest {
 		List<Document> emptyColDocs = Collections.emptyList();
 
 		state.updateState(Map.of(QUERY_ENHANCE_NODE_OUTPUT, dto, EVIDENCE, "evidence", AGENT_ID, "2",
-				TABLE_DOCUMENTS_FOR_SCHEMA_OUTPUT, emptyTableDocs, COLUMN_DOCUMENTS__FOR_SCHEMA_OUTPUT, emptyColDocs));
+				TABLE_DOCUMENTS_FOR_SCHEMA_OUTPUT, emptyTableDocs, COLUMN_DOCUMENTS_FOR_SCHEMA_OUTPUT, emptyColDocs));
 
 		setupCommonMocks("2", emptyTableDocs);
 
@@ -172,7 +172,7 @@ class TableRelationNodeTest {
 		List<Document> tableDocs = List.of(createTableDocument("users"));
 
 		state.updateState(Map.of(QUERY_ENHANCE_NODE_OUTPUT, dto, EVIDENCE, "evidence", AGENT_ID, "3",
-				TABLE_DOCUMENTS_FOR_SCHEMA_OUTPUT, tableDocs, COLUMN_DOCUMENTS__FOR_SCHEMA_OUTPUT,
+				TABLE_DOCUMENTS_FOR_SCHEMA_OUTPUT, tableDocs, COLUMN_DOCUMENTS_FOR_SCHEMA_OUTPUT,
 				Collections.emptyList()));
 
 		setupCommonMocks("3", tableDocs);
@@ -190,7 +190,7 @@ class TableRelationNodeTest {
 		List<Document> tableDocs = List.of(createTableDocument("users"));
 
 		state.updateState(Map.of(QUERY_ENHANCE_NODE_OUTPUT, dto, EVIDENCE, "evidence", AGENT_ID, "4",
-				TABLE_DOCUMENTS_FOR_SCHEMA_OUTPUT, tableDocs, COLUMN_DOCUMENTS__FOR_SCHEMA_OUTPUT,
+				TABLE_DOCUMENTS_FOR_SCHEMA_OUTPUT, tableDocs, COLUMN_DOCUMENTS_FOR_SCHEMA_OUTPUT,
 				Collections.emptyList()));
 
 		when(databaseUtil.getAgentDbConfig(4L)).thenThrow(new RuntimeException("DB config not found"));
@@ -205,7 +205,7 @@ class TableRelationNodeTest {
 		List<Document> tableDocs = List.of(createTableDocument("users"));
 
 		state.updateState(Map.of(QUERY_ENHANCE_NODE_OUTPUT, dto, EVIDENCE, "evidence", AGENT_ID, "5",
-				TABLE_DOCUMENTS_FOR_SCHEMA_OUTPUT, tableDocs, COLUMN_DOCUMENTS__FOR_SCHEMA_OUTPUT,
+				TABLE_DOCUMENTS_FOR_SCHEMA_OUTPUT, tableDocs, COLUMN_DOCUMENTS_FOR_SCHEMA_OUTPUT,
 				Collections.emptyList()));
 
 		DbConfigBO dbConfig = DbConfigBO.builder().dialectType("mysql").schema("test_db").build();
@@ -239,7 +239,7 @@ class TableRelationNodeTest {
 		List<Document> tableDocs = List.of(createTableDocument("users"));
 
 		state.updateState(Map.of(QUERY_ENHANCE_NODE_OUTPUT, dto, EVIDENCE, "evidence", AGENT_ID, "6",
-				TABLE_DOCUMENTS_FOR_SCHEMA_OUTPUT, tableDocs, COLUMN_DOCUMENTS__FOR_SCHEMA_OUTPUT,
+				TABLE_DOCUMENTS_FOR_SCHEMA_OUTPUT, tableDocs, COLUMN_DOCUMENTS_FOR_SCHEMA_OUTPUT,
 				Collections.emptyList(), SQL_GENERATE_SCHEMA_MISSING_ADVICE, "add orders table"));
 
 		DbConfigBO dbConfig = DbConfigBO.builder().dialectType("mysql").schema("test_db").build();

--- a/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/workflow/node/orchestration/PlannerNodeTest.java
+++ b/data-agent-management/src/test/java/com/alibaba/cloud/ai/dataagent/workflow/node/orchestration/PlannerNodeTest.java
@@ -124,7 +124,7 @@ class PlannerNodeTest {
 		state.registerKeyAndStrategy(QUERY_ENHANCE_NODE_OUTPUT, new ReplaceStrategy());
 		state.registerKeyAndStrategy(TABLE_RELATION_OUTPUT, new ReplaceStrategy());
 		state.registerKeyAndStrategy(EVIDENCE, new ReplaceStrategy());
-		state.registerKeyAndStrategy(GENEGRATED_SEMANTIC_MODEL_PROMPT, new ReplaceStrategy());
+		state.registerKeyAndStrategy(GENERATED_SEMANTIC_MODEL_PROMPT, new ReplaceStrategy());
 		state.registerKeyAndStrategy(IS_ONLY_NL2SQL, new ReplaceStrategy());
 		state.registerKeyAndStrategy(PLAN_VALIDATION_ERROR, new ReplaceStrategy());
 		return state;
@@ -132,7 +132,7 @@ class PlannerNodeTest {
 
 	private void setupBasicState(OverAllState state) {
 		state.updateState(Map.of(QUERY_ENHANCE_NODE_OUTPUT, TEST_QUERY_ENHANCE, TABLE_RELATION_OUTPUT, TEST_SCHEMA,
-				EVIDENCE, "业务知识：用户表包含所有注册用户", GENEGRATED_SEMANTIC_MODEL_PROMPT, ""));
+				EVIDENCE, "业务知识：用户表包含所有注册用户", GENERATED_SEMANTIC_MODEL_PROMPT, ""));
 	}
 
 	@Test
@@ -218,7 +218,7 @@ class PlannerNodeTest {
 	void apply_withSemanticModel_includesInPrompt() throws Exception {
 		OverAllState state = createTestState();
 		setupBasicState(state);
-		state.updateState(Map.of(GENEGRATED_SEMANTIC_MODEL_PROMPT, "语义模型定义：PV表示页面浏览量"));
+		state.updateState(Map.of(GENERATED_SEMANTIC_MODEL_PROMPT, "语义模型定义：PV表示页面浏览量"));
 
 		when(llmService.callUser(anyString()))
 			.thenReturn(Flux.just(ChatResponseUtil.createPureResponse(VALID_PLAN_JSON)));
@@ -233,7 +233,7 @@ class PlannerNodeTest {
 	void apply_emptyEvidence_generatesWithoutEvidence() throws Exception {
 		OverAllState state = createTestState();
 		state.updateState(Map.of(QUERY_ENHANCE_NODE_OUTPUT, TEST_QUERY_ENHANCE, TABLE_RELATION_OUTPUT, TEST_SCHEMA,
-				EVIDENCE, "", GENEGRATED_SEMANTIC_MODEL_PROMPT, ""));
+				EVIDENCE, "", GENERATED_SEMANTIC_MODEL_PROMPT, ""));
 
 		when(llmService.callUser(anyString()))
 			.thenReturn(Flux.just(ChatResponseUtil.createPureResponse(VALID_PLAN_JSON)));


### PR DESCRIPTION
### Describe what this PR does / why we need it

Correct two misspelled state-key constants:

- `GENEGRATED_SEMANTIC_MODEL_PROMPT` → `GENERATED_SEMANTIC_MODEL_PROMPT`
- `COLUMN_DOCUMENTS__FOR_SCHEMA_OUTPUT` → `COLUMN_DOCUMENTS_FOR_SCHEMA_OUTPUT`

The names are used as both Java identifiers and in-memory `OverAllState` keys. The update keeps their definitions and all references consistent across production code and tests.

This is a replacement for #543 after the source fork was recreated. The original commit is preserved unchanged.

### Does this pull request fix one issue?

Fixes #542

### Describe how you did it

Renamed both constant identifiers and their string values, then updated all references across 8 files. The change is rename-only and does not affect database persistence, API serialization, or frontend mappings.

### Describe how to verify it

- Search for `GENEGRATED_SEMANTIC_MODEL_PROMPT` and confirm there are no remaining references.
- Search for `COLUMN_DOCUMENTS__FOR_SCHEMA_OUTPUT` and confirm there are no remaining references.
- Run `SchemaRecallNodeTest` (6 tests).
- Run `TableRelationNodeTest` (7 tests).
- Run `PlannerNodeTest` (9 tests).
- Run `spring-javaformat:apply` and `checkstyle:check`.

The patch also applies cleanly to the current upstream `main` commit.

### Special notes for reviews

No new files or logic changes are included. The diff contains 25 additions and 25 deletions, all from the two renames.
