### PR TITLE
infra: bootstrap live model validation workflow

### DIFF
--- a/.github/workflows/live-model-test.yml
+++ b/.github/workflows/live-model-test.yml
@@ -1,0 +1,102 @@
+#
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Alibaba Cloud Live Model Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Open pull request number to validate
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: live-model-pr-${{ inputs.pr_number }}
+  cancel-in-progress: false
+
+jobs:
+  resolve_pr:
+    name: Resolve immutable PR head
+    if: github.repository == 'spring-ai-alibaba/DataAgent'
+    runs-on: ubuntu-22.04
+    outputs:
+      repository: ${{ steps.resolve.outputs.repository }}
+      sha: ${{ steps.resolve.outputs.sha }}
+      short_sha: ${{ steps.resolve.outputs.short_sha }}
+      url: ${{ steps.resolve.outputs.url }}
+    steps:
+      - name: Resolve and validate PR
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          pr_json=$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}")
+          state=$(jq -r '.state' <<<"${pr_json}")
+          base_ref=$(jq -r '.base.ref' <<<"${pr_json}")
+          head_repository=$(jq -r '.head.repo.full_name' <<<"${pr_json}")
+          head_sha=$(jq -r '.head.sha' <<<"${pr_json}")
+          pr_url=$(jq -r '.html_url' <<<"${pr_json}")
+
+          test "${state}" = "open"
+          test "${base_ref}" = "main"
+          [[ "${head_repository}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]
+          [[ "${head_sha}" =~ ^[0-9a-f]{40}$ ]]
+          [[ "${pr_url}" =~ ^https://github.com/[^/]+/[^/]+/pull/[0-9]+$ ]]
+
+          {
+            echo "repository=${head_repository}"
+            echo "sha=${head_sha}"
+            echo "short_sha=${head_sha:0:12}"
+            echo "url=${pr_url}"
+          } >>"${GITHUB_OUTPUT}"
+
+          printf 'Resolved %s to %s@%s\n' "${pr_url}" "${head_repository}" "${head_sha}"
+
+  live-model:
+    name: "PR #${{ inputs.pr_number }} @ ${{ needs.resolve_pr.outputs.short_sha }}"
+    needs: resolve_pr
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    environment:
+      name: live-model
+      url: ${{ needs.resolve_pr.outputs.url }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: ${{ needs.resolve_pr.outputs.repository }}
+          ref: ${{ needs.resolve_pr.outputs.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Verify immutable checkout
+        env:
+          EXPECTED_SHA: ${{ needs.resolve_pr.outputs.sha }}
+        run: test "$(git rev-parse HEAD)" = "${EXPECTED_SHA}"
+      - uses: ./CI/github-actions/setup-deps
+      - run: make tools
+      - name: Run Alibaba Cloud live model contract
+        env:
+          DATAAGENT_LIVE_DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
+        run: |
+          test -n "${DATAAGENT_LIVE_DASHSCOPE_API_KEY}"
+          make live-model-test


### PR DESCRIPTION
## What changed

- add a manual-only `Alibaba Cloud Live Model Test` workflow to the default branch
- accept an open PR number and resolve its fork repository plus immutable head SHA before the secret-bearing job starts
- check out that exact revision without persisted Git credentials
- expose `DASHSCOPE_API_KEY` only to the final live-provider test step

## Why

GitHub only enables `workflow_dispatch` after a workflow exists on the default branch. PR #598 contains both the real-provider tests and this workflow, so it cannot use the new workflow to validate itself before merge. Landing this small bootstrap PR first lets maintainers run the dispatcher against the still-open PR #598.

## Validation

- workflow is byte-for-byte identical to the version reviewed in PR #598
- YAML parse passed
- Actionlint passed
- yamllint passed
- resolver validated PR #598 as open, targeting `main`, and pinned its immutable fork head SHA
- staged secret scan found no credential pattern

## Follow-up

After this PR is merged, run **Alibaba Cloud Live Model Test** with PR number `598`. Merge PR #598 only after the live Chat and Embedding contracts succeed.

This workflow executes code from the selected PR with a repository secret. Review the displayed PR URL and immutable SHA before dispatching, and use a dedicated low-quota key.
