### PR TITLE
docs: fix broken Star History chart

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -109,7 +109,7 @@ This project is licensed under the Apache License 2.0.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=spring-ai-alibaba/DataAgent&type=Date)](https://star-history.com/#spring-ai-alibaba/DataAgent&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=spring-ai-alibaba/DataAgent&type=Date)](https://star-history.dera.page/#spring-ai-alibaba/DataAgent&Date)
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ pnpm install && pnpm dev
 本项目采用 Apache License 2.0 许可证。
 ## Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=spring-ai-alibaba/DataAgent&type=Date)](https://star-history.com/#spring-ai-alibaba/DataAgent&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=spring-ai-alibaba/DataAgent&type=Date)](https://star-history.dera.page/#spring-ai-alibaba/DataAgent&Date)
 
 ## 贡献者名单
 


### PR DESCRIPTION
The Star History chart shown in the README and README-en is broken and cannot be displayed anymore. This PR restores it by pointing the chart to a working endpoint so contributors can keep tracking the project's star growth.